### PR TITLE
feat: improve kanban linking UX and routed send behavior

### DIFF
--- a/scripts/dev-local.sh
+++ b/scripts/dev-local.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export PATH="$HOME/.cargo/bin:$PATH"
+export RUSTUP_DIST_SERVER="https://mirrors.ustc.edu.cn/rust-static"
+export RUSTUP_UPDATE_ROOT="https://mirrors.ustc.edu.cn/rust-static/rustup"
+
+npm run tauri:dev

--- a/src/features/layout/hooks/useLayoutNodes.tsx
+++ b/src/features/layout/hooks/useLayoutNodes.tsx
@@ -419,6 +419,10 @@ type LayoutNodesOptions = {
   onDismissDictationHint: () => void;
   showComposer: boolean;
   composerSendLabel?: string;
+  composerLinkedKanbanPanels: { id: string; name: string; workspaceId: string }[];
+  selectedComposerKanbanPanelId: string | null;
+  onSelectComposerKanbanPanel: (panelId: string | null) => void;
+  onOpenComposerKanbanPanel: (panelId: string) => void;
   plan: TurnPlan | null;
   debugEntries: DebugEntry[];
   debugOpen: boolean;
@@ -612,6 +616,10 @@ export function useLayoutNodes(options: LayoutNodesOptions): LayoutNodesResult {
       onDismissDictationError={options.onDismissDictationError}
       dictationHint={options.dictationHint}
       onDismissDictationHint={options.onDismissDictationHint}
+      linkedKanbanPanels={options.composerLinkedKanbanPanels}
+      selectedLinkedKanbanPanelId={options.selectedComposerKanbanPanelId}
+      onSelectLinkedKanbanPanel={options.onSelectComposerKanbanPanel}
+      onOpenLinkedKanbanPanel={options.onOpenComposerKanbanPanel}
       reviewPrompt={options.reviewPrompt}
       onReviewPromptClose={options.onReviewPromptClose}
       onReviewPromptShowPreset={options.onReviewPromptShowPreset}

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1153,6 +1153,15 @@ const en = {
       searchWorkspaces: "Search workspaces...",
       noWorkspacesFound: "No workspaces found",
     },
+    composer: {
+      relatedPanels: "Linked Project Panels",
+      empty: "No linked panels",
+      count: "{{count}} panels",
+      clear: "Clear selection",
+      more: "More",
+      collapse: "Collapse",
+      link: "link",
+    },
   },
 
   // Usage labels

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -1153,6 +1153,15 @@ const zh = {
       searchWorkspaces: "搜索工作区...",
       noWorkspacesFound: "未找到工作区",
     },
+    composer: {
+      relatedPanels: "关联项目看板",
+      empty: "暂无关联看板",
+      count: "{{count}} 个看板",
+      clear: "取消选择",
+      more: "更多",
+      collapse: "收起",
+      link: "link",
+    },
   },
 
   // 使用量标签

--- a/src/styles/composer.css
+++ b/src/styles/composer.css
@@ -124,6 +124,105 @@
   gap: 8px;
 }
 
+.composer-kanban-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  padding-bottom: 2px;
+}
+
+.composer-kanban-toolbar--outside {
+  padding: 0 var(--main-panel-padding) 2px;
+}
+
+.composer-kanban-strip-title {
+  color: var(--text-muted);
+  font-size: 12px;
+  flex-shrink: 0;
+}
+
+.composer-kanban-strip {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.composer-kanban-strip::-webkit-scrollbar {
+  display: none;
+}
+
+.composer-kanban-strip-item {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  background: var(--surface-item);
+  overflow: hidden;
+}
+
+.composer-kanban-strip-item.is-active {
+  border-color: var(--accent-strong);
+  background: color-mix(in srgb, var(--surface-item) 55%, var(--accent-soft));
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent-strong) 40%, transparent);
+}
+
+.composer-kanban-strip-main {
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  padding: 4px 10px;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.composer-kanban-strip-link {
+  border: none;
+  border-left: 1px solid var(--border-subtle);
+  background: transparent;
+  color: var(--text-faint);
+  font-size: 12px;
+  padding: 4px 8px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.composer-kanban-strip-main:hover,
+.composer-kanban-strip-link:hover {
+  color: var(--text-strong);
+}
+
+.composer-kanban-strip-clear {
+  border: 1px dashed var(--border-muted);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-faint);
+  font-size: 12px;
+  padding: 4px 10px;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.composer-kanban-strip-clear:hover {
+  color: var(--text-muted);
+  border-color: var(--border-strong);
+}
+
+.composer-kanban-strip-empty {
+  color: var(--text-faint);
+  font-size: 12px;
+}
+
+
 .composer-textarea {
   width: 100%;
   border: none;


### PR DESCRIPTION
## Summary
- improve linked kanban selector UX in composer
- support deselecting selected kanban and cleaner one-line presentation
- decouple kanban selection from visible input text
- route `&@`-style linked sends to a new thread instead of current conversation
- fix workspace-to-kanban association issues during project initialization

## Validation
- npm run typecheck

## Notes
- added local helper script: `scripts/dev-local.sh`
