### PR TITLE
feat(sidebar): 优化 worktrees 与当前会话折叠视觉

### DIFF
--- a/docs/plans/2026-02-08-worktree-style-optimization-plan.md
+++ b/docs/plans/2026-02-08-worktree-style-optimization-plan.md
@@ -1,0 +1,65 @@
+# Worktree Sidebar 样式优化与折叠交互计划（2026-02-08）
+
+## 目标
+优化左侧工作区内 `worktrees` 与 `当前会话` 的视觉层次与交互一致性：
+- icon + 字体更精致、单行紧凑。
+- `worktrees`、worktree 子项、`当前会话` 支持折叠。
+- 全局折叠/展开按钮覆盖工作区主折叠 + worktrees + 当前会话 + 分组折叠。
+- 去掉明显“包裹块感”的竖向视觉，保留横向分隔，提升融合感。
+
+## 边界（严格）
+仅处理本次新增/修改相关代码，不扩展到无关模块：
+- 允许：`Sidebar`、`WorktreeSection`、`WorktreeCard`、`WorkspaceCard`、`useCollapsedGroups`、对应 i18n、`sidebar.css`、相关测试。
+- 禁止：改动业务逻辑链路、数据模型、后端接口、无关页面。
+
+## 实施项
+1. `worktrees` 折叠头与子项交互
+- [x] worktrees 区块增加可折叠 header。
+- [x] 每个 worktree 子项支持点击切换其消息折叠。
+- [x] 子项保留小 icon 与紧凑排版。
+
+2. `当前会话` 区块折叠
+- [x] 在 workspace 下增加 `当前会话` 折叠头。
+- [x] 标题前增加会话 icon。
+- [x] 与 worktrees 使用统一折叠动效与视觉语义。
+
+3. 全局折叠/展开
+- [x] 工作区标题区增加“全部折叠/展开”按钮（在创建项目按钮左侧）。
+- [x] 全局动作覆盖：workspace 折叠、worktrees section 折叠、当前会话折叠、workspace group 折叠。
+- [x] `useCollapsedGroups` 支持批量替换（用于全局切换）。
+
+4. 视觉融合（去竖线，保横线）
+- [x] worktrees 与当前会话改为 top border 分层，减少卡片包裹感。
+- [x] 调整字体、间距、圆角、hover/active 对比度，避免“浮肿”。
+
+5. 本轮无效代码清理（仅限本次改动新增内容）
+- [x] 清理 Sidebar 中已失效的 addMenu 状态/副作用。
+- [x] 清理 WorkspaceCard 中无效 props（`addMenuOpen`、`addMenuWidth`、`onConnectWorkspace`）。
+- [x] 清理 useCollapsedGroups 无效入参 `_storageKey`。
+- [x] 清理本次引入的临时注释噪音。
+
+## 改动文件（Refers to）
+- `src/features/app/components/Sidebar.tsx`
+- `src/features/app/components/WorktreeSection.tsx`
+- `src/features/app/components/WorktreeCard.tsx`
+- `src/features/app/components/WorkspaceCard.tsx`
+- `src/features/app/hooks/useCollapsedGroups.ts`
+- `src/styles/sidebar.css`
+- `src/i18n/locales/zh.ts`
+- `src/i18n/locales/en.ts`
+- `src/features/app/components/WorktreeSection.test.tsx`
+
+## 验证
+- [x] `npm run build` 通过。
+- [x] `npm run lint` 通过（仅历史 warning，无新增 error）。
+- [ ] `npm run test -- WorktreeSection` 受现有环境依赖问题阻塞：`@lobehub/fluent-emoji` ESM 目录导入报错（非本次改动引入）。
+
+## 回滚策略
+- 若 UI 反馈不满意，可仅回滚以下文件到优化前版本：
+  - `src/styles/sidebar.css`
+  - `src/features/app/components/WorktreeSection.tsx`
+  - `src/features/app/components/WorktreeCard.tsx`
+  - `src/features/app/components/Sidebar.tsx`
+
+## PR 说明建议
+本次为侧栏样式与折叠交互优化，功能边界限定于工作区展示层；构建通过，测试受既有依赖问题影响。

--- a/src/features/app/components/WorkspaceCard.tsx
+++ b/src/features/app/components/WorkspaceCard.tsx
@@ -6,12 +6,9 @@ type WorkspaceCardProps = {
   workspaceName?: React.ReactNode;
   isActive: boolean;
   isCollapsed: boolean;
-  addMenuOpen: boolean;
-  addMenuWidth: number;
   onSelectWorkspace: (id: string) => void;
   onShowWorkspaceMenu: (event: MouseEvent, workspace: WorkspaceInfo) => void;
   onToggleWorkspaceCollapse: (workspaceId: string, collapsed: boolean) => void;
-  onConnectWorkspace: (workspace: WorkspaceInfo) => void;
   onAddAgent: (workspace: WorkspaceInfo) => void;
   children?: React.ReactNode;
 };
@@ -24,7 +21,6 @@ export function WorkspaceCard({
   onSelectWorkspace,
   onShowWorkspaceMenu,
   onToggleWorkspaceCollapse,
-  onConnectWorkspace: _onConnectWorkspace,
   onAddAgent,
   children,
 }: WorkspaceCardProps) {
@@ -54,9 +50,7 @@ export function WorkspaceCard({
         }}
       >
         <div className="workspace-header-content">
-          <button 
-            className="workspace-folder-btn"
-          >
+          <button className="workspace-folder-btn">
             {isActive ? (
               <span className="codicon codicon-folder-opened" style={{ fontSize: "16px" }} />
             ) : (
@@ -65,16 +59,16 @@ export function WorkspaceCard({
           </button>
 
           <span className="workspace-name-text">{workspaceName ?? workspace.name}</span>
-          
+
           <div className="workspace-actions">
-            <button 
+            <button
               className="workspace-action-btn"
               onClick={(e) => onShowWorkspaceMenu(e, workspace)}
               aria-label="More options"
             >
               <span className="codicon codicon-ellipsis" style={{ fontSize: "14px" }} />
             </button>
-            <button 
+            <button
               className="workspace-action-btn"
               onClick={handleNewSession}
               aria-label="New Session"

--- a/src/features/app/components/WorktreeCard.tsx
+++ b/src/features/app/components/WorktreeCard.tsx
@@ -1,3 +1,4 @@
+import GitBranch from "lucide-react/dist/esm/icons/git-branch";
 import type { MouseEvent } from "react";
 
 import type { WorkspaceInfo } from "../../../types";
@@ -36,6 +37,7 @@ export function WorktreeCard({
         onClick={() => {
           if (!isDeleting) {
             onSelectWorkspace(worktree.id);
+            onToggleWorkspaceCollapse(worktree.id, !worktreeCollapsed);
           }
         }}
         onContextMenu={(event) => {
@@ -50,9 +52,11 @@ export function WorktreeCard({
           if (event.key === "Enter" || event.key === " ") {
             event.preventDefault();
             onSelectWorkspace(worktree.id);
+            onToggleWorkspaceCollapse(worktree.id, !worktreeCollapsed);
           }
         }}
       >
+        <GitBranch className="worktree-node-icon" aria-hidden />
         <div className="worktree-label">{worktreeBranch || worktree.name}</div>
         <div className="worktree-actions">
           {isDeleting ? (

--- a/src/features/app/components/WorktreeSection.test.tsx
+++ b/src/features/app/components/WorktreeSection.test.tsx
@@ -18,7 +18,10 @@ describe("WorktreeSection", () => {
   it("does not render older thread controls for worktrees", () => {
     render(
       <WorktreeSection
+        parentWorkspaceId="workspace-1"
         worktrees={[worktree]}
+        isSectionCollapsed={false}
+        onToggleSectionCollapse={vi.fn()}
         deletingWorktreeIds={new Set()}
         threadsByWorkspace={{ [worktree.id]: [] }}
         threadStatusById={{}}

--- a/src/features/app/components/WorktreeSection.tsx
+++ b/src/features/app/components/WorktreeSection.tsx
@@ -19,7 +19,10 @@ type ThreadRowsResult = {
 };
 
 type WorktreeSectionProps = {
+  parentWorkspaceId: string;
   worktrees: WorkspaceInfo[];
+  isSectionCollapsed: boolean;
+  onToggleSectionCollapse: (workspaceId: string) => void;
   deletingWorktreeIds: Set<string>;
   threadsByWorkspace: Record<string, ThreadSummary[]>;
   threadStatusById: ThreadStatusMap;
@@ -55,7 +58,10 @@ type WorktreeSectionProps = {
 };
 
 export function WorktreeSection({
+  parentWorkspaceId,
   worktrees,
+  isSectionCollapsed,
+  onToggleSectionCollapse,
   deletingWorktreeIds,
   threadsByWorkspace,
   threadStatusById,
@@ -85,76 +91,88 @@ export function WorktreeSection({
 
   return (
     <div className="worktree-section">
-      <div className="worktree-header">
+      <button
+        type="button"
+        className={`worktree-header ${isSectionCollapsed ? "collapsed" : "expanded"}`}
+        onClick={() => {
+          onToggleSectionCollapse(parentWorkspaceId);
+        }}
+        aria-expanded={!isSectionCollapsed}
+        aria-label={isSectionCollapsed ? "Expand worktrees" : "Collapse worktrees"}
+      >
         <Layers className="worktree-header-icon" aria-hidden />
-        Worktrees
-      </div>
-      <div className="worktree-list">
-        {worktrees.map((worktree) => {
-          const worktreeThreads = threadsByWorkspace[worktree.id] ?? [];
-          const worktreeCollapsed = worktree.settings.sidebarCollapsed;
-          const isLoadingWorktreeThreads =
-            threadListLoadingByWorkspace[worktree.id] ?? false;
-          const showWorktreeLoader =
-            !worktreeCollapsed &&
-            isLoadingWorktreeThreads &&
-            worktreeThreads.length === 0;
-          const worktreeNextCursor =
-            threadListCursorByWorkspace[worktree.id] ?? null;
-          const showWorktreeThreadList =
-            !worktreeCollapsed &&
-            (worktreeThreads.length > 0 || Boolean(worktreeNextCursor));
-          const isWorktreePaging =
-            threadListPagingByWorkspace[worktree.id] ?? false;
-          const isWorktreeExpanded = expandedWorkspaces.has(worktree.id);
-          const {
-            unpinnedRows: worktreeThreadRows,
-            totalRoots: totalWorktreeRoots,
-          } = getThreadRows(
-            worktreeThreads,
-            isWorktreeExpanded,
-            worktree.id,
-            getPinTimestamp,
-          );
+        <span className="worktree-header-text">worktrees</span>
+        <span className="worktree-header-toggle" aria-hidden>
+          ›
+        </span>
+      </button>
+      <div className={`worktree-list ${isSectionCollapsed ? "collapsed" : "expanded"}`}>
+        {!isSectionCollapsed &&
+          worktrees.map((worktree) => {
+            const worktreeThreads = threadsByWorkspace[worktree.id] ?? [];
+            const worktreeCollapsed = worktree.settings.sidebarCollapsed;
+            const isLoadingWorktreeThreads =
+              threadListLoadingByWorkspace[worktree.id] ?? false;
+            const showWorktreeLoader =
+              !worktreeCollapsed &&
+              isLoadingWorktreeThreads &&
+              worktreeThreads.length === 0;
+            const worktreeNextCursor =
+              threadListCursorByWorkspace[worktree.id] ?? null;
+            const showWorktreeThreadList =
+              !worktreeCollapsed &&
+              (worktreeThreads.length > 0 || Boolean(worktreeNextCursor));
+            const isWorktreePaging =
+              threadListPagingByWorkspace[worktree.id] ?? false;
+            const isWorktreeExpanded = expandedWorkspaces.has(worktree.id);
+            const {
+              unpinnedRows: worktreeThreadRows,
+              totalRoots: totalWorktreeRoots,
+            } = getThreadRows(
+              worktreeThreads,
+              isWorktreeExpanded,
+              worktree.id,
+              getPinTimestamp,
+            );
 
-          return (
-            <WorktreeCard
-              key={worktree.id}
-              worktree={worktree}
-              isActive={worktree.id === activeWorkspaceId}
-              isDeleting={deletingWorktreeIds.has(worktree.id)}
-              onSelectWorkspace={onSelectWorkspace}
-              onShowWorktreeMenu={onShowWorktreeMenu}
-              onToggleWorkspaceCollapse={onToggleWorkspaceCollapse}
-              onConnectWorkspace={onConnectWorkspace}
-            >
-              {showWorktreeThreadList && (
-                <ThreadList
-                  workspaceId={worktree.id}
-                  pinnedRows={[]}
-                  unpinnedRows={worktreeThreadRows}
-                  totalThreadRoots={totalWorktreeRoots}
-                  isExpanded={isWorktreeExpanded}
-                  nextCursor={worktreeNextCursor}
-                  isPaging={isWorktreePaging}
-                  nested
-                  showLoadOlder={false}
-                  activeWorkspaceId={activeWorkspaceId}
-                  activeThreadId={activeThreadId}
-                  threadStatusById={threadStatusById}
-                  getThreadTime={getThreadTime}
-                  isThreadPinned={isThreadPinned}
-                  isThreadAutoNaming={isThreadAutoNaming}
-                  onToggleExpanded={onToggleExpanded}
-                  onLoadOlderThreads={onLoadOlderThreads}
-                  onSelectThread={onSelectThread}
-                  onShowThreadMenu={onShowThreadMenu}
-                />
-              )}
-              {showWorktreeLoader && <ThreadLoading nested />}
-            </WorktreeCard>
-          );
-        })}
+            return (
+              <WorktreeCard
+                key={worktree.id}
+                worktree={worktree}
+                isActive={worktree.id === activeWorkspaceId}
+                isDeleting={deletingWorktreeIds.has(worktree.id)}
+                onSelectWorkspace={onSelectWorkspace}
+                onShowWorktreeMenu={onShowWorktreeMenu}
+                onToggleWorkspaceCollapse={onToggleWorkspaceCollapse}
+                onConnectWorkspace={onConnectWorkspace}
+              >
+                {showWorktreeThreadList && (
+                  <ThreadList
+                    workspaceId={worktree.id}
+                    pinnedRows={[]}
+                    unpinnedRows={worktreeThreadRows}
+                    totalThreadRoots={totalWorktreeRoots}
+                    isExpanded={isWorktreeExpanded}
+                    nextCursor={worktreeNextCursor}
+                    isPaging={isWorktreePaging}
+                    nested
+                    showLoadOlder={false}
+                    activeWorkspaceId={activeWorkspaceId}
+                    activeThreadId={activeThreadId}
+                    threadStatusById={threadStatusById}
+                    getThreadTime={getThreadTime}
+                    isThreadPinned={isThreadPinned}
+                    isThreadAutoNaming={isThreadAutoNaming}
+                    onToggleExpanded={onToggleExpanded}
+                    onLoadOlderThreads={onLoadOlderThreads}
+                    onSelectThread={onSelectThread}
+                    onShowThreadMenu={onShowThreadMenu}
+                  />
+                )}
+                {showWorktreeLoader && <ThreadLoading nested />}
+              </WorktreeCard>
+            );
+          })}
       </div>
     </div>
   );

--- a/src/features/app/hooks/useCollapsedGroups.ts
+++ b/src/features/app/hooks/useCollapsedGroups.ts
@@ -1,7 +1,7 @@
 import { useCallback, useState } from "react";
 import { getClientStoreSync, writeClientStoreValue } from "../../../services/clientStorage";
 
-export function useCollapsedGroups(_storageKey: string) {
+export function useCollapsedGroups() {
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(() => {
     const stored = getClientStoreSync<string[]>("layout", "collapsedGroups");
     if (Array.isArray(stored)) {
@@ -33,5 +33,13 @@ export function useCollapsedGroups(_storageKey: string) {
     [persistCollapsedGroups],
   );
 
-  return { collapsedGroups, toggleGroupCollapse };
+  const replaceCollapsedGroups = useCallback(
+    (nextGroups: Set<string>) => {
+      setCollapsedGroups(new Set(nextGroups));
+      persistCollapsedGroups(nextGroups);
+    },
+    [persistCollapsedGroups],
+  );
+
+  return { collapsedGroups, toggleGroupCollapse, replaceCollapsedGroups };
 }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -78,6 +78,11 @@ const en = {
     signIn: "Sign in",
     account: "Account",
     session: "Session",
+    currentSession: "Current session",
+    expandCurrentSession: "Expand current session",
+    collapseCurrentSession: "Collapse current session",
+    expandAllSections: "Expand all sections",
+    collapseAllSections: "Collapse all sections",
     weekly: "Weekly",
   },
 

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -78,6 +78,11 @@ const zh = {
     signIn: "登录",
     account: "账户",
     session: "会话",
+    currentSession: "当前会话",
+    expandCurrentSession: "展开当前会话",
+    collapseCurrentSession: "折叠当前会话",
+    expandAllSections: "展开全部区块",
+    collapseAllSections: "折叠全部区块",
     weekly: "每周",
   },
 

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -139,6 +139,10 @@
   transform: none;
 }
 
+.sidebar-title-toggle-all {
+  margin-left: auto;
+}
+
 .workspace-icon {
   color: var(--text-muted);
   flex-shrink: 0;
@@ -667,6 +671,263 @@
   background: var(--surface-hover);
 }
 
+.worktree-section {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  margin: 6px 0 0;
+  padding: 6px 0 0;
+  border-top: 1px solid var(--border-subtle);
+  border-radius: 0;
+  background: transparent;
+}
+
+.worktree-header {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  min-height: 20px;
+  margin: 0;
+  padding: 0 4px 0 4px;
+  border-radius: 7px;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: pointer;
+  transition: background-color 0.16s ease, border-color 0.16s ease, color 0.16s ease;
+}
+
+.worktree-header:hover,
+.worktree-header:focus-visible {
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--text-quiet);
+}
+
+.worktree-header:focus-visible {
+  outline: 1px solid var(--border-subtle);
+  outline-offset: 1px;
+}
+
+.worktree-header-icon {
+  width: 11px;
+  height: 11px;
+  flex-shrink: 0;
+  opacity: 0.76;
+  stroke-width: 2px;
+}
+
+.worktree-header-text {
+  font-size: 10px;
+  font-weight: 500;
+  line-height: 1;
+  letter-spacing: 0.13em;
+  text-transform: lowercase;
+}
+
+.worktree-header-toggle {
+  margin-left: 2px;
+  font-size: 11px;
+  line-height: 1;
+  color: var(--text-faint);
+  transform: rotate(90deg);
+  transition: transform 0.16s ease;
+}
+
+.worktree-header.collapsed .worktree-header-toggle {
+  transform: rotate(0deg);
+}
+
+.worktree-list {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  margin: 0;
+  padding-top: 2px;
+}
+
+.worktree-list.collapsed {
+  display: none;
+}
+
+.worktree-card {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  border-radius: 7px;
+  border: none;
+  background: transparent;
+  overflow: hidden;
+}
+
+.worktree-card + .worktree-card {
+  border-top: 1px solid var(--border-subtle);
+  padding-top: 3px;
+}
+
+.worktree-row {
+  display: flex;
+  align-items: center;
+  position: relative;
+  min-width: 0;
+  gap: 6px;
+  padding: 5px 8px 5px 10px;
+  border-radius: 7px;
+  color: var(--text-quiet);
+  cursor: pointer;
+  transition: background-color 0.18s ease, color 0.18s ease, border-color 0.18s ease;
+  -webkit-app-region: no-drag;
+  border: 1px solid transparent;
+  background: transparent;
+}
+
+.worktree-node-icon {
+  width: 11px;
+  height: 11px;
+  color: var(--text-faint);
+  opacity: 0.85;
+  flex-shrink: 0;
+  margin-left: 2px;
+}
+
+.worktree-row:hover {
+  background: rgba(255, 255, 255, 0.045);
+  border-color: rgba(255, 255, 255, 0.08);
+  color: var(--text-strong);
+}
+
+.worktree-row:hover .worktree-node-icon,
+.worktree-row.active .worktree-node-icon {
+  color: var(--text-muted);
+  opacity: 1;
+}
+
+.worktree-row.active {
+  background: rgba(83, 130, 201, 0.09);
+  border-color: rgba(83, 130, 201, 0.26);
+  color: var(--text-strong);
+}
+
+.worktree-row.deleting {
+  opacity: 0.72;
+  cursor: default;
+}
+
+.worktree-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 12px;
+  font-weight: 620;
+  line-height: 1.25;
+  letter-spacing: 0.01em;
+}
+
+.worktree-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.worktree-toggle {
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-faint);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.worktree-toggle:hover,
+.worktree-toggle:focus-visible {
+  color: var(--text-strong);
+  background: rgba(255, 255, 255, 0.05);
+  border-color: var(--border-subtle);
+}
+
+.worktree-toggle-icon {
+  display: inline-block;
+  font-size: 12px;
+  line-height: 1;
+  transform: rotate(0deg);
+  transition: transform 0.15s ease;
+}
+
+.worktree-toggle.expanded .worktree-toggle-icon {
+  transform: rotate(90deg);
+}
+
+.worktree-row .connect {
+  color: var(--text-faint);
+  font-size: 9.5px;
+  line-height: 1;
+  letter-spacing: 0.05em;
+  text-transform: lowercase;
+}
+
+.worktree-row .connect:hover {
+  color: var(--text-strong);
+}
+
+.worktree-deleting {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--text-faint);
+  padding-right: 1px;
+}
+
+.worktree-deleting-spinner {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  border: 1.5px solid var(--border-subtle);
+  border-top-color: var(--text-muted);
+  animation: sidebar-worktree-spin 0.8s linear infinite;
+}
+
+.worktree-deleting-label {
+  font-size: 9.5px;
+  letter-spacing: 0.01em;
+}
+
+.worktree-card .thread-list {
+  margin-top: 0;
+  padding: 2px 8px 7px 10px;
+}
+
+.worktree-card .thread-row {
+  padding: 4px 8px;
+  border-radius: 6px;
+  font-size: 12px;
+}
+
+.worktree-card .thread-time {
+  font-size: 9.5px;
+  color: var(--text-faint);
+}
+
+.worktree-card .thread-name {
+  font-weight: 470;
+}
+
+@keyframes sidebar-worktree-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .thread-list {
   display: flex;
   flex-direction: column;
@@ -962,13 +1223,70 @@
   margin-bottom: 2px;
 }
 
+.workspace-session-section {
+  margin-top: 4px;
+  border-top: 1px solid var(--border-subtle);
+  border-radius: 0;
+  background: transparent;
+  overflow: hidden;
+}
+
+.sidebar-section-toggle {
+  width: 100%;
+  border: none;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  border-radius: 0;
+  margin-bottom: 0;
+  padding: 5px 8px;
+  transition: background-color 0.16s ease;
+}
+
+.sidebar-section-toggle:hover,
+.sidebar-section-toggle:focus-visible {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.sidebar-section-toggle:focus-visible {
+  outline: 1px solid var(--border-subtle);
+  outline-offset: -1px;
+}
+
 .sidebar-section-title {
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 500;
   color: var(--text-faint);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   transition: color 0.15s ease;
 }
 
 .sidebar-section-title:hover {
   color: var(--text-strong);
+}
+
+.sidebar-section-title-icon {
+  font-size: 12px;
+  opacity: 0.75;
+}
+
+.sidebar-section-chevron {
+  color: var(--text-faint);
+  font-size: 12px;
+  line-height: 1;
+  transform: rotate(90deg);
+  transition: transform 0.16s ease;
+}
+
+.sidebar-section-toggle.collapsed .sidebar-section-chevron {
+  transform: rotate(0deg);
+}
+
+.workspace-session-section .thread-list {
+  padding: 3px 6px 8px;
+  margin: 0;
 }


### PR DESCRIPTION
## 背景
侧栏 worktrees/当前会话区域存在层次割裂、折叠交互不统一与视觉不够精致的问题。

## 变更内容
- 优化 worktrees 标题与子项样式，统一为更紧凑的 icon+字体风格
- 支持 worktrees 区块折叠
- 支持每个 worktree 子项点击折叠/展开
- 新增 当前会话 区块折叠，标题前加入 icon
- 新增全局折叠/展开按钮，覆盖：
  - 工作区主折叠
  - worktrees section 折叠
  - 当前会话折叠
  - workspace group 折叠
- 清理本次改动引入的无效代码（失效 addMenu 状态/无效 props/无效 hook 入参）
- 同步补充中英文 i18n 文案
- 补充并更新计划文档：docs/plans/2026-02-08-worktree-style-optimization-plan.md

## 验证
- npm run build ✅
- npm run lint ✅（仅历史 warning，无新增 error）
- npm run test -- WorktreeSection ⚠️
  - 受现有依赖环境问题影响：@lobehub/fluent-emoji ESM 目录导入报错
  - 非本次改动逻辑引入

## 影响范围
- src/features/app/components/Sidebar.tsx
- src/features/app/components/WorkspaceCard.tsx
- src/features/app/components/WorktreeCard.tsx
- src/features/app/components/WorktreeSection.tsx
- src/features/app/components/WorktreeSection.test.tsx
- src/features/app/hooks/useCollapsedGroups.ts
- src/styles/sidebar.css
- src/i18n/locales/en.ts
- src/i18n/locales/zh.ts
- docs/plans/2026-02-08-worktree-style-optimization-plan.md
