### PR TITLE
refactor: improve file autocomplete with lazy directory loading and c…

### DIFF
--- a/src/features/composer/components/ChatInputBox/ChatInputBoxAdapter.tsx
+++ b/src/features/composer/components/ChatInputBox/ChatInputBoxAdapter.tsx
@@ -39,6 +39,7 @@ import {
   setClaudeAlwaysThinkingEnabled,
   switchClaudeProvider,
   updateClaudeProvider,
+  getWorkspaceDirectoryChildren,
 } from '../../../../services/tauri';
 
 // Re-export the handle type for Composer to use
@@ -531,13 +532,10 @@ export const ChatInputBoxAdapter = forwardRef<ChatInputBoxHandle, ChatInputBoxAd
         if (signal.aborted) {
           throw new DOMException('Aborted', 'AbortError');
         }
-        const sourceDirectories = directories ?? [];
-        const sourceFiles = files ?? [];
-        const normalizedQuery = query.trim().toLowerCase();
-        const maxSuggestions = 500;
+        const maxSuggestions = 200;
         const results: FileItem[] = [];
 
-        const pushDirectory = (path: string) => {
+        const pushDirectoryFromPath = (path: string) => {
           const normalizedPath = `${normalizePath(path)}/`;
           const name = fileNameFromPath(path);
           results.push({
@@ -548,7 +546,7 @@ export const ChatInputBoxAdapter = forwardRef<ChatInputBoxHandle, ChatInputBoxAd
             extension: '',
           });
         };
-        const pushFile = (path: string) => {
+        const pushFileFromPath = (path: string) => {
           const normalizedPath = normalizePath(path);
           const name = fileNameFromPath(path);
           results.push({
@@ -559,52 +557,101 @@ export const ChatInputBoxAdapter = forwardRef<ChatInputBoxHandle, ChatInputBoxAd
             extension: extensionFromFileName(name),
           });
         };
+        const pushFromResponse = (response: { files: string[]; directories: string[] }) => {
+          for (const dir of response.directories) {
+            pushDirectoryFromPath(dir);
+            if (results.length >= maxSuggestions) return;
+          }
+          for (const file of response.files) {
+            pushFileFromPath(file);
+            if (results.length >= maxSuggestions) return;
+          }
+        };
+
+        const normalizedQuery = query.trim();
+
+        // Parse query: separate directory path from search fragment
+        // e.g. "src/com" -> { dirPath: "src", fragment: "com" }
+        // e.g. "src/"   -> { dirPath: "src", fragment: "" }
+        // e.g. "but"    -> { dirPath: "", fragment: "but" }
+        const lastSlashIndex = normalizedQuery.lastIndexOf('/');
+        const dirPath = lastSlashIndex >= 0 ? normalizedQuery.slice(0, lastSlashIndex) : '';
+        const fragment = lastSlashIndex >= 0 ? normalizedQuery.slice(lastSlashIndex + 1) : normalizedQuery;
+        const lowerFragment = fragment.toLowerCase();
+
+        // If we have a workspace ID and a directory path, use lazy loading
+        if (workspaceId && dirPath) {
+          try {
+            const response = await getWorkspaceDirectoryChildren(workspaceId, dirPath);
+            if (signal.aborted) {
+              throw new DOMException('Aborted', 'AbortError');
+            }
+            if (!lowerFragment) {
+              // No search term - show all direct children of the directory
+              pushFromResponse(response);
+            } else {
+              // Filter by fragment
+              for (const dir of response.directories) {
+                const name = fileNameFromPath(dir);
+                if (name.toLowerCase().includes(lowerFragment)) {
+                  pushDirectoryFromPath(dir);
+                  if (results.length >= maxSuggestions) break;
+                }
+              }
+              for (const file of response.files) {
+                const name = fileNameFromPath(file);
+                if (name.toLowerCase().includes(lowerFragment)) {
+                  pushFileFromPath(file);
+                  if (results.length >= maxSuggestions) break;
+                }
+              }
+            }
+            return results;
+          } catch (error) {
+            if ((error as Error).name === 'AbortError') throw error;
+            // Fallback to local filtering on error
+          }
+        }
+
+        // For root-level browsing or search, use the pre-loaded file/directory arrays
+        const sourceDirectories = directories ?? [];
+        const sourceFiles = files ?? [];
 
         if (!normalizedQuery) {
+          // No query: show only root-level entries (direct children of workspace root)
           for (const path of sourceDirectories) {
-            pushDirectory(path);
-            if (results.length >= maxSuggestions) {
-              return results;
+            if (!path.includes('/')) {
+              pushDirectoryFromPath(path);
+              if (results.length >= maxSuggestions) return results;
             }
           }
           for (const path of sourceFiles) {
-            pushFile(path);
-            if (results.length >= maxSuggestions) {
-              return results;
+            if (!path.includes('/')) {
+              pushFileFromPath(path);
+              if (results.length >= maxSuggestions) return results;
             }
           }
           return results;
         }
 
+        // Search query without directory path: search by name across all entries
         for (const path of sourceDirectories) {
-          const normalizedPath = normalizePath(path);
           const name = fileNameFromPath(path);
-          if (
-            name.toLowerCase().includes(normalizedQuery) ||
-            normalizedPath.toLowerCase().includes(normalizedQuery)
-          ) {
-            pushDirectory(path);
-            if (results.length >= maxSuggestions) {
-              return results;
-            }
+          if (name.toLowerCase().includes(lowerFragment) || normalizePath(path).toLowerCase().includes(lowerFragment)) {
+            pushDirectoryFromPath(path);
+            if (results.length >= maxSuggestions) return results;
           }
         }
         for (const path of sourceFiles) {
-          const normalizedPath = normalizePath(path);
           const name = fileNameFromPath(path);
-          if (
-            name.toLowerCase().includes(normalizedQuery) ||
-            normalizedPath.toLowerCase().includes(normalizedQuery)
-          ) {
-            pushFile(path);
-            if (results.length >= maxSuggestions) {
-              return results;
-            }
+          if (name.toLowerCase().includes(lowerFragment) || normalizePath(path).toLowerCase().includes(lowerFragment)) {
+            pushFileFromPath(path);
+            if (results.length >= maxSuggestions) return results;
           }
         }
         return results;
       },
-      [directories, files],
+      [directories, files, workspaceId],
     );
 
     const manualMemoryCompletionProvider = useCallback(

--- a/src/features/composer/components/ChatInputBox/Dropdown/DropdownItem.tsx
+++ b/src/features/composer/components/ChatInputBox/Dropdown/DropdownItem.tsx
@@ -1,5 +1,3 @@
-import { useRef, useState } from 'react';
-import { createPortal } from 'react-dom';
 import type { DropdownItemProps } from '../types';
 import { sanitizeSvg } from '../utils/sanitize';
 
@@ -12,42 +10,6 @@ export const DropdownItem = ({
   onClick,
   onMouseEnter,
 }: DropdownItemProps) => {
-  const itemRef = useRef<HTMLDivElement>(null);
-  const [showTooltip, setShowTooltip] = useState(false);
-  const [tooltipPosition, setTooltipPosition] = useState<{ top: number; left: number; placement: 'top' | 'bottom' }>({
-    top: 0,
-    left: 0,
-    placement: 'bottom'
-  });
-
-  /**
-   * Handle mouse enter to show tooltip
-   */
-  const handleMouseEnterItem = () => {
-    if (!itemRef.current || !item.description) return;
-
-    const rect = itemRef.current.getBoundingClientRect();
-    const viewportHeight = window.innerHeight;
-    const spaceBelow = viewportHeight - rect.bottom;
-    const tooltipEstimatedHeight = 100;
-
-    // Determine tooltip placement
-    const placement = spaceBelow < tooltipEstimatedHeight ? 'top' : 'bottom';
-
-    setTooltipPosition({
-      top: placement === 'bottom' ? rect.bottom + 8 : rect.top - 8,
-      left: rect.left + rect.width / 2,
-      placement
-    });
-    setShowTooltip(true);
-  };
-
-  /**
-   * Handle mouse leave to hide tooltip
-   */
-  const handleMouseLeaveItem = () => {
-    setShowTooltip(false);
-  };
 
   /**
    * Render icon
@@ -91,75 +53,6 @@ export const DropdownItem = ({
     }
   };
 
-  /**
-   * Render portal tooltip
-   */
-  const renderTooltip = () => {
-    if (!showTooltip || !item.description) return null;
-
-    const viewportHeight = window.innerHeight;
-
-    const tooltipStyle: React.CSSProperties = {
-      position: 'fixed',
-      left: tooltipPosition.left,
-      transform: 'translateX(-50%)',
-      ...(tooltipPosition.placement === 'bottom'
-        ? { top: tooltipPosition.top }
-        : { bottom: viewportHeight - tooltipPosition.top, transform: 'translateX(-50%)' }
-      ),
-      zIndex: 9999,
-      maxWidth: '400px',
-      minWidth: '200px',
-      width: 'max-content',
-      background: 'var(--dropdown-bg)',
-      color: 'var(--text-primary)',
-      border: '1px solid var(--dropdown-border)',
-      borderRadius: '6px',
-      padding: '8px 12px',
-      fontSize: '12px',
-      lineHeight: '1.4',
-      whiteSpace: 'pre-wrap',
-      wordBreak: 'break-word',
-      boxShadow: '0 4px 12px rgba(0, 0, 0, 0.25)',
-      pointerEvents: 'none',
-      animation: 'tooltip-fade-in 0.2s forwards'
-    };
-
-    const arrowStyle: React.CSSProperties = {
-      position: 'fixed',
-      left: tooltipPosition.left,
-      transform: 'translateX(-50%)',
-      ...(tooltipPosition.placement === 'bottom'
-        ? {
-            top: tooltipPosition.top - 6,
-            borderLeft: '6px solid transparent',
-            borderRight: '6px solid transparent',
-            borderBottom: '6px solid var(--dropdown-border)'
-          }
-        : {
-            bottom: viewportHeight - tooltipPosition.top - 6,
-            borderLeft: '6px solid transparent',
-            borderRight: '6px solid transparent',
-            borderTop: '6px solid var(--dropdown-border)'
-          }
-      ),
-      width: 0,
-      height: 0,
-      zIndex: 9999,
-      pointerEvents: 'none'
-    };
-
-    return createPortal(
-      <>
-        <div style={arrowStyle} />
-        <div style={tooltipStyle}>
-          {item.description}
-        </div>
-      </>,
-      document.body
-    );
-  };
-
   // Separator
   if (item.type === 'separator') {
     return <div className="dropdown-separator" />;
@@ -178,30 +71,23 @@ export const DropdownItem = ({
   const isDisabled = item.id === '__loading__';
 
   return (
-    <>
-      <div
-        ref={itemRef}
-        className={`dropdown-item ${isActive ? 'active' : ''} ${isDisabled ? 'disabled' : ''}`}
-        onClick={isDisabled ? undefined : onClick}
-        onMouseEnter={() => {
-          // Call the original onMouseEnter (for keyboard navigation highlighting)
-          onMouseEnter?.();
-          // Show tooltip
-          handleMouseEnterItem();
-        }}
-        onMouseLeave={handleMouseLeaveItem}
-        style={isDisabled ? { cursor: 'default' } : undefined}
-      >
-        {renderIcon()}
-        <div className="dropdown-item-content">
-          <div className="dropdown-item-label">{item.label}</div>
-          {item.description && (
-            <div className="dropdown-item-description">{item.description}</div>
-          )}
-        </div>
+    <div
+      className={`dropdown-item ${isActive ? 'active' : ''} ${isDisabled ? 'disabled' : ''}`}
+      onClick={isDisabled ? undefined : onClick}
+      onMouseEnter={() => {
+        // Call the original onMouseEnter (for keyboard navigation highlighting)
+        onMouseEnter?.();
+      }}
+      style={isDisabled ? { cursor: 'default' } : undefined}
+    >
+      {renderIcon()}
+      <div className="dropdown-item-content">
+        <div className="dropdown-item-label">{item.label}</div>
+        {item.description && (
+          <div className="dropdown-item-description">{item.description}</div>
+        )}
       </div>
-      {renderTooltip()}
-    </>
+    </div>
   );
 };
 

--- a/src/features/composer/components/ChatInputBox/styles/dropdown.css
+++ b/src/features/composer/components/ChatInputBox/styles/dropdown.css
@@ -3,7 +3,7 @@
    ============================================================ */
 .completion-dropdown {
   position: fixed;
-  background: var(--dropdown-bg);
+  background: var(--dropdown-bg, #252526);
   border: 1px solid var(--dropdown-border);
   border-radius: 6px;
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);

--- a/src/features/composer/components/ChatInputBox/styles/variables-bridge.css
+++ b/src/features/composer/components/ChatInputBox/styles/variables-bridge.css
@@ -25,7 +25,7 @@
   --text-primary: var(--text-primary, #e6e7ea);
   --text-secondary: var(--text-muted, #b3b3b3);
   --text-muted: var(--text-faint, #666666);
-  --dropdown-bg: var(--surface-popover, #0a0e14);
+  --dropdown-bg: #1f2028;
   --tooltip-bg: #1a1c24;
   --dropdown-border: var(--border-strong, #353540);
   --dropdown-hover: var(--surface-hover, #2a2d2e);
@@ -49,8 +49,8 @@
   --text-primary: var(--text-quiet, #333333);
   --text-secondary: var(--text-subtle, #666666);
   --text-muted: var(--text-faint, #999999);
-  --dropdown-bg: var(--surface-popover, #ffffff);
-  --tooltip-bg: var(--surface-popover, #ffffff);
+  --dropdown-bg: #ffffff;
+  --tooltip-bg: #ffffff;
   --dropdown-border: color-mix(in srgb, var(--border-strong, rgba(15, 23, 36, 0.14)) 88%, transparent);
   --dropdown-hover: color-mix(in srgb, var(--surface-hover, rgba(15, 23, 36, 0.06)) 90%, transparent);
   --dropdown-selected: #4d8ff0;
@@ -76,8 +76,8 @@
     --text-primary: var(--text-quiet, #333333);
     --text-secondary: var(--text-subtle, #666666);
     --text-muted: var(--text-faint, #999999);
-    --dropdown-bg: var(--surface-popover, #ffffff);
-    --tooltip-bg: var(--surface-popover, #ffffff);
+    --dropdown-bg: #ffffff;
+    --tooltip-bg: #ffffff;
     --dropdown-border: color-mix(in srgb, var(--border-strong, rgba(15, 23, 36, 0.14)) 88%, transparent);
     --dropdown-hover: color-mix(in srgb, var(--surface-hover, rgba(15, 23, 36, 0.06)) 90%, transparent);
     --dropdown-selected: #4d8ff0;

--- a/src/features/composer/hooks/useComposerAutocompleteState.ts
+++ b/src/features/composer/hooks/useComposerAutocompleteState.ts
@@ -42,7 +42,7 @@ type UseComposerAutocompleteStateArgs = {
   setSelectionStart: (next: number | null) => void;
 };
 
-const MAX_FILE_SUGGESTIONS = 500;
+const MAX_FILE_SUGGESTIONS = 200;
 const MAX_MEMORY_SUGGESTIONS = 50;
 const FILE_TRIGGER_PREFIX = new RegExp("^(?:\\s|[\"'`]|\\(|\\[|\\{)$");
 
@@ -262,26 +262,33 @@ export function useComposerAutocompleteState({
       isFileTriggerActive(text, selectionStart)
         ? (() => {
             const query = getFileTriggerQuery(text, selectionStart) ?? "";
-            const visibleDirectories = directories.filter((path) => !gitignoredDirectories?.has(path));
-            const visibleFiles = files.filter((path) => !gitignoredFiles?.has(path));
             const { parentPath, fragment } = splitFileQueryScope(query);
-            const directoryItems: AutocompleteItem[] = visibleDirectories
-              .filter((path) => isDirectChildPath(path, parentPath))
-              .filter((path) => matchesFileFragment(path, fragment))
-              .sort((a, b) => a.localeCompare(b))
-              .slice(0, MAX_FILE_SUGGESTIONS)
-              .map((path) => ({
-                id: `dir:${path}`,
-                label: `${path}/`,
-                insertText: `${path}/`,
-                isDirectory: true,
-              }));
-            const fileItemsList: AutocompleteItem[] = visibleFiles
-              .filter((path) => isDirectChildPath(path, parentPath))
-              .filter((path) => matchesFileFragment(path, fragment))
-              .sort((a, b) => a.localeCompare(b))
-              .slice(0, MAX_FILE_SUGGESTIONS)
-              .map((path) => ({
+            // Combine filter predicates to avoid multiple passes over large arrays
+            const matchedDirectories: string[] = [];
+            const matchedFiles: string[] = [];
+            for (const path of directories) {
+              if (matchedDirectories.length >= MAX_FILE_SUGGESTIONS) break;
+              if (gitignoredDirectories?.has(path)) continue;
+              if (!isDirectChildPath(path, parentPath)) continue;
+              if (!matchesFileFragment(path, fragment)) continue;
+              matchedDirectories.push(path);
+            }
+            for (const path of files) {
+              if (matchedFiles.length >= MAX_FILE_SUGGESTIONS) break;
+              if (gitignoredFiles?.has(path)) continue;
+              if (!isDirectChildPath(path, parentPath)) continue;
+              if (!matchesFileFragment(path, fragment)) continue;
+              matchedFiles.push(path);
+            }
+            matchedDirectories.sort((a, b) => a.localeCompare(b));
+            matchedFiles.sort((a, b) => a.localeCompare(b));
+            const directoryItems: AutocompleteItem[] = matchedDirectories.map((path) => ({
+              id: `dir:${path}`,
+              label: `${path}/`,
+              insertText: `${path}/`,
+              isDirectory: true,
+            }));
+            const fileItemsList: AutocompleteItem[] = matchedFiles.map((path) => ({
               id: path,
               label: path,
               insertText: path,

--- a/src/features/status-panel/components/StatusPanel.test.tsx
+++ b/src/features/status-panel/components/StatusPanel.test.tsx
@@ -17,26 +17,6 @@ const editToolItem: Extract<ConversationItem, { kind: "tool" }> = {
   ],
 };
 
-const commandToolItem: Extract<ConversationItem, { kind: "tool" }> = {
-  id: "tool-command-1",
-  kind: "tool",
-  toolType: "commandExecution",
-  title: "Tool: bash",
-  detail: '{"command":"npm run typecheck"}',
-  status: "completed",
-  output: "ok",
-};
-
-const commandToolWithCwdDetail: Extract<ConversationItem, { kind: "tool" }> = {
-  id: "tool-command-cwd-1",
-  kind: "tool",
-  toolType: "commandExecution",
-  title: "Command: git diff -- CLAUDE.md README.md",
-  detail: "/Users/chenxiangning/code/AI/reach/ai-reach",
-  status: "completed",
-  output: "ok",
-};
-
 const taskToolItem: Extract<ConversationItem, { kind: "tool" }> = {
   id: "tool-task-1",
   kind: "tool",
@@ -155,7 +135,7 @@ describe("StatusPanel", () => {
   it("shows codex activity tabs without inline plan tab", () => {
     render(
       <StatusPanel
-        items={[editToolItem, commandToolItem, taskToolItem]}
+        items={[editToolItem, taskToolItem]}
         isProcessing={false}
         plan={planSample}
         isPlanMode
@@ -168,7 +148,6 @@ describe("StatusPanel", () => {
     expect(screen.getByText("statusPanel.tabAgents")).toBeTruthy();
     expect(screen.getByText("statusPanel.tabEdits")).toBeTruthy();
     expect(screen.queryByText("Plan")).toBeNull();
-    expect(screen.getByText("statusPanel.tabCommands")).toBeTruthy();
     const allTabs = document.querySelectorAll(".sp-tab-half");
     expect(allTabs.length).toBe(0);
   });
@@ -219,52 +198,5 @@ describe("StatusPanel", () => {
     expect(screen.getAllByText("0/0").length).toBeGreaterThanOrEqual(2);
     expect(screen.getByText("statusPanel.tabAgents")).toBeTruthy();
     expect(screen.getByText("statusPanel.tabEdits")).toBeTruthy();
-  });
-
-  it("opens commands popover in codex mode", () => {
-    render(
-      <StatusPanel
-        items={[commandToolItem]}
-        isProcessing={false}
-        isCodexEngine
-      />,
-    );
-
-    fireEvent.click(screen.getByText("statusPanel.tabCommands"));
-    expect(screen.getByText("npm run typecheck")).toBeTruthy();
-  });
-
-  it("prefers command title over cwd detail for codex command summary", () => {
-    render(
-      <StatusPanel
-        items={[commandToolWithCwdDetail]}
-        isProcessing={false}
-        isCodexEngine
-      />,
-    );
-
-    fireEvent.click(screen.getByText("statusPanel.tabCommands"));
-    expect(screen.getByText("git diff -- CLAUDE.md README.md")).toBeTruthy();
-    expect(
-      screen.queryByText("/Users/chenxiangning/code/AI/reach/ai-reach"),
-    ).toBeNull();
-  });
-
-  it("toggles command expansion on click in codex mode", () => {
-    render(
-      <StatusPanel
-        items={[commandToolWithCwdDetail]}
-        isProcessing={false}
-        isCodexEngine
-      />,
-    );
-
-    fireEvent.click(screen.getByText("statusPanel.tabCommands"));
-    const commandNode = screen.getByText("git diff -- CLAUDE.md README.md");
-    expect(commandNode.className).not.toContain("is-expanded");
-    fireEvent.click(commandNode.closest(".sp-command-item") as HTMLElement);
-    expect(commandNode.className).toContain("is-expanded");
-    fireEvent.click(commandNode.closest(".sp-command-item") as HTMLElement);
-    expect(commandNode.className).not.toContain("is-expanded");
   });
 });

--- a/src/features/status-panel/components/StatusPanel.tsx
+++ b/src/features/status-panel/components/StatusPanel.tsx
@@ -4,7 +4,6 @@ import ListChecks from "lucide-react/dist/esm/icons/list-checks";
 import Bot from "lucide-react/dist/esm/icons/bot";
 import FileEdit from "lucide-react/dist/esm/icons/file-edit";
 import ListTodo from "lucide-react/dist/esm/icons/list-todo";
-import Terminal from "lucide-react/dist/esm/icons/terminal";
 import type { ConversationItem } from "../../../types";
 import type { TurnPlan } from "../../../types";
 import type { TabType } from "../types";
@@ -13,7 +12,6 @@ import { TodoList } from "./TodoList";
 import { SubagentList } from "./SubagentList";
 import { FileChangesList } from "./FileChangesList";
 import { PlanList } from "./PlanList";
-import { CommandList } from "./CommandList";
 
 interface StatusPanelProps {
   items: ConversationItem[];
@@ -45,10 +43,6 @@ export const StatusPanel = memo(function StatusPanel({
     subagentCompleted,
     subagentTotal,
     hasRunningSubagent,
-    commands,
-    commandCompleted,
-    commandTotal,
-    hasRunningCommand,
     totalAdditions,
     totalDeletions,
   } = useStatusPanelData(items, { isCodexEngine });
@@ -141,9 +135,6 @@ export const StatusPanel = memo(function StatusPanel({
                 isCodexEngine={isCodexEngine}
               />
             )}
-            {openTab === "command" && (
-              <CommandList commands={commands} enableExpand={isCodexEngine} />
-            )}
           </div>
         </div>
       )}
@@ -197,24 +188,6 @@ export const StatusPanel = memo(function StatusPanel({
               <span className="sp-stat-add">+{totalAdditions}</span>
               <span className="sp-stat-mod">-{totalDeletions}</span>
             </span>
-          </button>
-        )}
-
-        {isCodexEngine && commandTotal > 0 && (
-          <button
-            type="button"
-            className={`sp-tab${openTab === "command" ? " sp-tab-active" : ""}`}
-            onClick={() => handleTabClick("command")}
-            aria-expanded={openTab === "command"}
-          >
-            <Terminal size={14} className="sp-tab-icon" />
-            <span className="sp-tab-label">{t("statusPanel.tabCommands")}</span>
-            <span className="sp-tab-count">
-              {commandCompleted}/{commandTotal}
-            </span>
-            {isProcessing && hasRunningCommand && (
-              <span className="sp-tab-loading" />
-            )}
           </button>
         )}
 

--- a/src/styles/buttons.css
+++ b/src/styles/buttons.css
@@ -4,6 +4,9 @@
 }
 
 button {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
   border: none;
   border-radius: 10px;
   padding: 8px 14px;
@@ -50,5 +53,4 @@ button:disabled {
   width: 16px;
   height: 16px;
 }
-
 


### PR DESCRIPTION
…lean up status panel

- Add lazy directory loading via getWorkspaceDirectoryChildren for scoped file browsing (e.g. "src/com" only fetches children of "src/")
- Show only root-level entries when no query is provided
- Optimize autocomplete filtering with single-pass loops instead of chained .filter() calls and reduce max suggestions from 500 to 200
- Remove portal tooltip from DropdownItem in favor of inline description
- Remove command tab and CommandList from StatusPanel (codex mode)
- Fix dropdown background colors with hardcoded values for theme consistency
- Add cross-browser appearance reset for button elements