### PR TITLE
Path traversal protection relies on incomplete str

### DIFF
--- a/src/features/composer/components/ChatInputBox/utils/pathValidation.ts
+++ b/src/features/composer/components/ChatInputBox/utils/pathValidation.ts
@@ -7,22 +7,43 @@ export function validateFilePath(filePath: string): string | null {
   if (!trimmed) return null;
   if (trimmed.length > 4096) return null;
 
-  const normalized = trimmed.replace(/\\/g, '/');
-
-  // Reject paths with directory traversal
-  if (normalized.includes('/../') || normalized.startsWith('../') || normalized.endsWith('/..')) {
+  let decoded = trimmed;
+  try {
+    decoded = decodeURIComponent(trimmed);
+  } catch {
     return null;
   }
 
-  // Reject paths targeting sensitive system directories
+  const normalized = decoded.replace(/\\/g, '/');
+
+  if (
+    normalized.includes('\0') ||
+    normalized.startsWith('/') ||
+    normalized.startsWith('//') ||
+    /^[a-zA-Z]:/.test(normalized)
+  ) {
+    return null;
+  }
+
+  const parts = normalized.split('/');
+  const sanitizedParts: string[] = [];
+  for (const part of parts) {
+    if (!part || part === '.') continue;
+    if (part === '..') return null;
+    sanitizedParts.push(part);
+  }
+
+  const sanitized = sanitizedParts.join('/');
+  if (!sanitized) return null;
+
   const sensitivePatterns = [
     '/etc/passwd', '/etc/shadow', '/proc/', '/sys/',
     '/.ssh/', '/.env', '/.aws/', '/.gnupg/',
   ];
-  const lower = normalized.toLowerCase();
+  const lower = `/${sanitized.toLowerCase()}`;
   if (sensitivePatterns.some(p => lower.includes(p))) {
     return null;
   }
 
-  return trimmed;
+  return sanitized;
 }


### PR DESCRIPTION
The file path validator attempts to block traversal and sensitive paths using substring matching, but it does not canonicalize paths or enforce an allowlisted root. Attackers can often bypass this style of validation with encoded separators, unusual path forms, absolute paths outside the workspace, Windows device/UNC paths, or normalization differences handled later by other layers. If this function is used as a security boundary before file access, it is insufficient.

Affected files: pathValidation.ts