### PR TITLE
docs: update repo references from ccgui to desktop-cc-gui

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ npm run test          # Run frontend tests
 
 ### Download
 
-Download link: https://github.com/zhukunpenglinyutong/ccgui/releases
+Download link: https://github.com/zhukunpenglinyutong/desktop-cc-gui/releases
 
 ---
 
@@ -147,7 +147,13 @@ Your Stars and recommendations help more people discover this project. Thank you
 
 ### License
 
-[MIT](https://github.com/zhukunpenglinyutong/ccgui?tab=MIT-1-ov-file)
+[MIT](https://github.com/zhukunpenglinyutong/desktop-cc-gui?tab=MIT-1-ov-file)
+
+---
+
+## Friendship Link
+
+Thanks for the support and feedback from the friends at [LINUX DO](https://linux.do/). 
 
 ---
 
@@ -181,13 +187,13 @@ Thanks to all the contributors who help make ccgui better!
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=zhukunpenglinyutong/ccgui&type=date&legend=top-left)](https://www.star-history.com/#zhukunpenglinyutong/ccgui&type=date&legend=top-left)
+[![Star History Chart](https://api.star-history.com/svg?repos=zhukunpenglinyutong/desktop-cc-gui&type=date&legend=top-left)](https://www.star-history.com/#zhukunpenglinyutong/desktop-cc-gui&type=date&legend=top-left)
 
 <!-- LINK GROUP -->
 
-[github-contributors-shield]: https://img.shields.io/github/contributors/zhukunpenglinyutong/ccgui?color=c4f042&labelColor=black&style=flat-square
-[github-forks-shield]: https://img.shields.io/github/forks/zhukunpenglinyutong/ccgui?color=8ae8ff&labelColor=black&style=flat-square
-[github-issues-link]: https://github.com/zhukunpenglinyutong/ccgui/issues
-[github-issues-shield]: https://img.shields.io/github/issues/zhukunpenglinyutong/ccgui?color=ff80eb&labelColor=black&style=flat-square
-[github-license-link]: https://github.com/zhukunpenglinyutong/ccgui/blob/main/LICENSE
-[github-stars-shield]: https://img.shields.io/github/stars/zhukunpenglinyutong/ccgui?color=ffcb47&labelColor=black&style=flat-square
+[github-contributors-shield]: https://img.shields.io/github/contributors/zhukunpenglinyutong/desktop-cc-gui?color=c4f042&labelColor=black&style=flat-square
+[github-forks-shield]: https://img.shields.io/github/forks/zhukunpenglinyutong/desktop-cc-gui?color=8ae8ff&labelColor=black&style=flat-square
+[github-issues-link]: https://github.com/zhukunpenglinyutong/desktop-cc-gui/issues
+[github-issues-shield]: https://img.shields.io/github/issues/zhukunpenglinyutong/desktop-cc-gui?color=ff80eb&labelColor=black&style=flat-square
+[github-license-link]: https://github.com/zhukunpenglinyutong/desktop-cc-gui/blob/main/LICENSE
+[github-stars-shield]: https://img.shields.io/github/stars/zhukunpenglinyutong/desktop-cc-gui?color=ffcb47&labelColor=black&style=flat-square

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -132,7 +132,7 @@ npm run test          # 运行前端测试
 ---
 ### 客户端下载
 
-下载地址：https://github.com/zhukunpenglinyutong/ccgui/releases
+下载地址：https://github.com/zhukunpenglinyutong/desktop-cc-gui/releases
 
 ---
 
@@ -146,7 +146,7 @@ npm run test          # 运行前端测试
 
 ### License
 
-[MIT](https://github.com/zhukunpenglinyutong/ccgui?tab=MIT-1-ov-file)
+[MIT](https://github.com/zhukunpenglinyutong/desktop-cc-gui?tab=MIT-1-ov-file)
 
 ---
 
@@ -178,15 +178,21 @@ npm run test          # 运行前端测试
 
 ---
 
+## 友链
+
+感谢 [LINUX DO](https://linux.do/) 用户的支持与反馈
+
+---
+
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=zhukunpenglinyutong/ccgui&type=date&legend=top-left)](https://www.star-history.com/#zhukunpenglinyutong/ccgui&type=date&legend=top-left)
+[![Star History Chart](https://api.star-history.com/svg?repos=zhukunpenglinyutong/desktop-cc-gui&type=date&legend=top-left)](https://www.star-history.com/#zhukunpenglinyutong/desktop-cc-gui&type=date&legend=top-left)
 
 <!-- LINK GROUP -->
 
-[github-contributors-shield]: https://img.shields.io/github/contributors/zhukunpenglinyutong/ccgui?color=c4f042&labelColor=black&style=flat-square
-[github-forks-shield]: https://img.shields.io/github/forks/zhukunpenglinyutong/ccgui?color=8ae8ff&labelColor=black&style=flat-square
-[github-issues-link]: https://github.com/zhukunpenglinyutong/ccgui/issues
-[github-issues-shield]: https://img.shields.io/github/issues/zhukunpenglinyutong/ccgui?color=ff80eb&labelColor=black&style=flat-square
-[github-license-link]: https://github.com/zhukunpenglinyutong/ccgui/blob/main/LICENSE
-[github-stars-shield]: https://img.shields.io/github/stars/zhukunpenglinyutong/ccgui?color=ffcb47&labelColor=black&style=flat-square
+[github-contributors-shield]: https://img.shields.io/github/contributors/zhukunpenglinyutong/desktop-cc-gui?color=c4f042&labelColor=black&style=flat-square
+[github-forks-shield]: https://img.shields.io/github/forks/zhukunpenglinyutong/desktop-cc-gui?color=8ae8ff&labelColor=black&style=flat-square
+[github-issues-link]: https://github.com/zhukunpenglinyutong/desktop-cc-gui/issues
+[github-issues-shield]: https://img.shields.io/github/issues/zhukunpenglinyutong/desktop-cc-gui?color=ff80eb&labelColor=black&style=flat-square
+[github-license-link]: https://github.com/zhukunpenglinyutong/desktop-cc-gui/blob/main/LICENSE
+[github-stars-shield]: https://img.shields.io/github/stars/zhukunpenglinyutong/desktop-cc-gui?color=ffcb47&labelColor=black&style=flat-square

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -50,8 +50,8 @@
           <a href="index.html#cta">Get started</a>
         </nav>
         <div class="nav-actions">
-          <a class="btn ghost" href="https://github.com/zhukunpenglinyutong/ccgui" target="_blank" rel="noreferrer">GitHub</a>
-          <a class="btn primary" href="https://github.com/zhukunpenglinyutong/ccgui/releases" target="_blank" rel="noreferrer">Download</a>
+          <a class="btn ghost" href="https://github.com/zhukunpenglinyutong/desktop-cc-gui" target="_blank" rel="noreferrer">GitHub</a>
+          <a class="btn primary" href="https://github.com/zhukunpenglinyutong/desktop-cc-gui/releases" target="_blank" rel="noreferrer">Download</a>
         </div>
       </div>
     </header>
@@ -88,7 +88,7 @@
           <a href="index.html#screens">Screenshots</a>
           <a href="index.html#workflow">Workflow</a>
           <a href="changelog.html">Changelog</a>
-          <a href="https://github.com/zhukunpenglinyutong/ccgui" target="_blank" rel="noreferrer">GitHub</a>
+          <a href="https://github.com/zhukunpenglinyutong/desktop-cc-gui" target="_blank" rel="noreferrer">GitHub</a>
         </div>
       </div>
       <div class="container footer-meta">
@@ -99,7 +99,7 @@
     <script>
       const releaseStatus = document.getElementById("release-status");
       const releaseList = document.getElementById("release-list");
-      const apiUrl = "https://api.github.com/repos/zhukunpenglinyutong/ccgui/releases?per_page=50";
+      const apiUrl = "https://api.github.com/repos/zhukunpenglinyutong/desktop-cc-gui/releases?per_page=50";
 
       const formatDate = (dateString) => {
         if (!dateString) return "Draft";

--- a/docs/index.html
+++ b/docs/index.html
@@ -50,8 +50,8 @@
           <a href="#cta">Get started</a>
         </nav>
         <div class="nav-actions">
-          <a class="btn ghost" href="https://github.com/zhukunpenglinyutong/ccgui" target="_blank" rel="noreferrer">GitHub</a>
-          <a class="btn primary" href="https://github.com/zhukunpenglinyutong/ccgui/releases" target="_blank" rel="noreferrer">Download</a>
+          <a class="btn ghost" href="https://github.com/zhukunpenglinyutong/desktop-cc-gui" target="_blank" rel="noreferrer">GitHub</a>
+          <a class="btn primary" href="https://github.com/zhukunpenglinyutong/desktop-cc-gui/releases" target="_blank" rel="noreferrer">Download</a>
         </div>
       </div>
     </header>
@@ -67,7 +67,7 @@
               command center for threads, reviews, and worktrees.
             </p>
             <div class="hero-actions">
-              <a class="btn primary" href="https://github.com/zhukunpenglinyutong/ccgui/releases" target="_blank" rel="noreferrer">Get the app</a>
+              <a class="btn primary" href="https://github.com/zhukunpenglinyutong/desktop-cc-gui/releases" target="_blank" rel="noreferrer">Get the app</a>
               <a class="btn ghost" href="#features">Explore features</a>
             </div>
             <div class="hero-meta">
@@ -297,7 +297,7 @@
               <p>ccgui keeps your Codex workflows visible, organized, and fast.</p>
             </div>
             <div class="cta-actions">
-              <a class="btn primary" href="https://github.com/zhukunpenglinyutong/ccgui" target="_blank" rel="noreferrer">View repo</a>
+              <a class="btn primary" href="https://github.com/zhukunpenglinyutong/desktop-cc-gui" target="_blank" rel="noreferrer">View repo</a>
             </div>
           </div>
         </div>
@@ -319,7 +319,7 @@
           <a href="#workflow">Workflow</a>
           <a href="#testimonies">Testimonials</a>
           <a href="changelog.html">Changelog</a>
-          <a href="https://github.com/zhukunpenglinyutong/ccgui" target="_blank" rel="noreferrer">GitHub</a>
+          <a href="https://github.com/zhukunpenglinyutong/desktop-cc-gui" target="_blank" rel="noreferrer">GitHub</a>
         </div>
       </div>
       <div class="container footer-meta">

--- a/src/features/about/components/AboutView.tsx
+++ b/src/features/about/components/AboutView.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import { getVersion } from "@tauri-apps/api/app";
 import { openUrl } from "@tauri-apps/plugin-opener";
 
-const GITHUB_URL = "https://github.com/zhukunpenglinyutong/ccgui";
+const GITHUB_URL = "https://github.com/zhukunpenglinyutong/desktop-cc-gui";
 
 export function AboutView() {
   const { t } = useTranslation();

--- a/src/features/settings/components/SettingsView.tsx
+++ b/src/features/settings/components/SettingsView.tsx
@@ -2325,7 +2325,7 @@ export function SettingsView({
                   <button
                     type="button"
                     className="ghost"
-                    onClick={() => void openUrl("https://github.com/zhukunpenglinyutong/ccgui")}
+                    onClick={() => void openUrl("https://github.com/zhukunpenglinyutong/desktop-cc-gui")}
                   >
                     {t("about.github")}
                   </button>

--- a/src/features/update/updateReleaseConfig.test.ts
+++ b/src/features/update/updateReleaseConfig.test.ts
@@ -21,6 +21,6 @@ describe("update release configuration", () => {
     const workflow = readWorkspaceFile(".github/workflows/release.yml");
 
     expect(workflow).toContain("zhukunpenglinyutong/desktop-cc-gui/releases/download");
-    expect(workflow).not.toContain("zhukunpenglinyutong/ccgui/releases/download");
+    expect(workflow).not.toContain("zhukunpenglinyutong/desktop-cc-gui/releases/download");
   });
 });


### PR DESCRIPTION
- Replace all ccgui GitHub URLs with desktop-cc-gui across docs and source
- Add friendship link section (LINUX DO) to README.md and README.zh-CN.md
- Update updateReleaseConfig test expectation to match new repo name