### PR TITLE
fix: 修复更新检查异常误报失败

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ dist-ssr
 release-local
 CLAUDE.md
 .claude.github/workflows/release.yml
+.spec-workflow
 
 # AI workflow local-only state
 .claude/settings.local.json

--- a/.trellis/workspace/xuvian/index.md
+++ b/.trellis/workspace/xuvian/index.md
@@ -1,0 +1,41 @@
+# Workspace Index - xuvian
+
+> Journal tracking for AI development sessions.
+
+---
+
+## Current Status
+
+<!-- @@@auto:current-status -->
+- **Active File**: `journal-1.md`
+- **Total Sessions**: 1
+- **Last Active**: 2026-04-24
+<!-- @@@/auto:current-status -->
+
+---
+
+## Active Documents
+
+<!-- @@@auto:active-documents -->
+| File | Lines | Status |
+|------|-------|--------|
+| `journal-1.md` | ~64 | Active |
+<!-- @@@/auto:active-documents -->
+
+---
+
+## Session History
+
+<!-- @@@auto:session-history -->
+| # | Date | Title | Commits | Branch |
+|---|------|-------|---------|--------|
+| 1 | 2026-04-24 | 修复更新检查误报失败 | `be7718b2a45dd5b7a2d48b20e7d0cec251cc01b6` | `fix/updater-check-fallback` |
+<!-- @@@/auto:session-history -->
+
+---
+
+## Notes
+
+- Sessions are appended to journal files
+- New journal file created when current exceeds 2000 lines
+- Use `add_session.py` to record sessions

--- a/.trellis/workspace/xuvian/journal-1.md
+++ b/.trellis/workspace/xuvian/journal-1.md
@@ -1,0 +1,64 @@
+# Journal - xuvian (Part 1)
+
+> AI development session journal
+> Started: 2026-04-24
+
+---
+
+
+
+## Session 1: 修复更新检查误报失败
+
+**Date**: 2026-04-24
+**Task**: 修复更新检查误报失败
+**Branch**: `fix/updater-check-fallback`
+
+### Summary
+
+(Add summary)
+
+### Main Changes
+
+任务目标
+- 修复客户端更新完成后再次检查更新，随后误报“更新失败，请重试”的问题。
+
+主要改动
+- 调整 updater hook 的状态机，区分后台自动检查与用户手动检查。
+- 为更新检查增加 request id 防串线，避免旧请求结果覆盖新状态。
+- 手动检查无更新时显示 latest 提示并自动消失，后台检查失败仅记录 debug 并回到 idle。
+- 补充 updater hook 测试，覆盖静默失败与 stale request 场景。
+- 在 .gitignore 中加入 .spec-workflow，避免本地工作流目录误入提交。
+
+涉及模块
+- src/features/update/hooks/useUpdater.ts
+- src/features/update/hooks/useUpdater.test.ts
+- src/features/app/hooks/useUpdaterController.ts
+- .gitignore
+
+验证结果
+- npm exec vitest run "src/features/update/hooks/useUpdater.test.ts" "src/features/update/components/UpdateToast.test.tsx"
+- ./node_modules/.bin/eslint "src/features/update/hooks/useUpdater.ts" "src/features/update/hooks/useUpdater.test.ts" "src/features/app/hooks/useUpdaterController.ts"
+- ./node_modules/.bin/tsc --noEmit
+
+后续事项
+- GitHub release feed 的 latest.json 仍停留在 0.4.8，需要发布侧及时更新到 0.4.9 及后续版本。
+- PR 说明中提醒维护者同步修复 release 产物，避免客户端继续被过期 manifest 误导。
+
+
+### Git Commits
+
+| Hash | Message |
+|------|---------|
+| `be7718b2a45dd5b7a2d48b20e7d0cec251cc01b6` | (see git log) |
+
+### Testing
+
+- [OK] (Add test results)
+
+### Status
+
+[OK] **Completed**
+
+### Next Steps
+
+- None - task complete

--- a/src/features/app/hooks/useUpdaterController.ts
+++ b/src/features/app/hooks/useUpdaterController.ts
@@ -41,7 +41,7 @@ export function useUpdaterController({
   );
 
   useTauriEvent(subscribeUpdaterCheckEvent, () => {
-    void checkForUpdates({ announceNoUpdate: true });
+    void checkForUpdates({ announceNoUpdate: true, interactive: true });
   });
 
   useAgentSoundNotifications({

--- a/src/features/update/hooks/useUpdater.test.ts
+++ b/src/features/update/hooks/useUpdater.test.ts
@@ -21,6 +21,16 @@ vi.mock("@tauri-apps/plugin-process", () => ({
 const checkMock = vi.mocked(check);
 const relaunchMock = vi.mocked(relaunch);
 
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 describe("useUpdater", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -52,12 +62,39 @@ describe("useUpdater", () => {
     );
   });
 
-  it("returns to idle when no update is available", async () => {
+  it("keeps background update check failures silent", async () => {
+    checkMock.mockRejectedValue(new Error("network down"));
+    const onDebug = vi.fn();
+    const { result } = renderHook(() => useUpdater({ onDebug }));
+
+    await act(async () => {
+      await result.current.checkForUpdates();
+    });
+
+    expect(checkMock).toHaveBeenCalledTimes(1);
+    expect(result.current.state.stage).toBe("idle");
+    expect(result.current.state.error).toBeUndefined();
+    expect(onDebug).toHaveBeenCalledWith(
+      expect.objectContaining({
+        label: "updater/error",
+        payload: "network down",
+      } satisfies Partial<DebugEntry>),
+    );
+  });
+
+  it("announces latest and auto-dismisses when a manual check finds no update", async () => {
+    vi.useFakeTimers();
     checkMock.mockResolvedValue(null);
     const { result } = renderHook(() => useUpdater({}));
 
     await act(async () => {
       await result.current.startUpdate();
+    });
+
+    expect(result.current.state.stage).toBe("latest");
+
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
     });
 
     expect(result.current.state.stage).toBe("idle");
@@ -171,5 +208,40 @@ describe("useUpdater", () => {
         payload: "download failed",
       } satisfies Partial<DebugEntry>),
     );
+  });
+
+  it("ignores stale check results from older requests", async () => {
+    vi.useFakeTimers();
+    const staleCheck = createDeferred<null>();
+    checkMock
+      .mockImplementationOnce(() => staleCheck.promise)
+      .mockResolvedValueOnce(null);
+
+    const { result } = renderHook(() => useUpdater({}));
+    let firstCheckPromise: Promise<void> | null = null;
+
+    await act(async () => {
+      firstCheckPromise = result.current.checkForUpdates();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      await result.current.checkForUpdates({ announceNoUpdate: true, interactive: true });
+    });
+
+    expect(result.current.state.stage).toBe("latest");
+
+    await act(async () => {
+      staleCheck.reject(new Error("stale failure"));
+      await firstCheckPromise;
+    });
+
+    expect(result.current.state.stage).toBe("latest");
+
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(result.current.state.stage).toBe("idle");
   });
 });

--- a/src/features/update/hooks/useUpdater.ts
+++ b/src/features/update/hooks/useUpdater.ts
@@ -32,6 +32,11 @@ type UseUpdaterOptions = {
   onDebug?: (entry: DebugEntry) => void;
 };
 
+type CheckForUpdatesOptions = {
+  announceNoUpdate?: boolean;
+  interactive?: boolean;
+};
+
 const AUTO_UPDATE_ENABLED = true;
 
 export function useUpdater({ enabled = true, onDebug }: UseUpdaterOptions) {
@@ -40,6 +45,7 @@ export function useUpdater({ enabled = true, onDebug }: UseUpdaterOptions) {
   const [state, setState] = useState<UpdateState>({ stage: "idle" });
   const updateRef = useRef<Update | null>(null);
   const latestTimeoutRef = useRef<number | null>(null);
+  const checkRequestIdRef = useRef(0);
   const latestToastDurationMs = 2000;
 
   const clearLatestTimeout = useCallback(() => {
@@ -49,24 +55,44 @@ export function useUpdater({ enabled = true, onDebug }: UseUpdaterOptions) {
     }
   }, []);
 
+  const invalidatePendingChecks = useCallback(() => {
+    checkRequestIdRef.current += 1;
+  }, []);
+
   const resetToIdle = useCallback(async () => {
+    invalidatePendingChecks();
     clearLatestTimeout();
     const update = updateRef.current;
     updateRef.current = null;
     setState({ stage: "idle" });
     await update?.close();
-  }, [clearLatestTimeout]);
+  }, [clearLatestTimeout, invalidatePendingChecks]);
 
-  const checkForUpdates = useCallback(async (options?: { announceNoUpdate?: boolean }) => {
+  const checkForUpdates = useCallback(async (options?: CheckForUpdatesOptions) => {
+    const requestId = checkRequestIdRef.current + 1;
+    checkRequestIdRef.current = requestId;
     let update: Awaited<ReturnType<typeof check>> | null = null;
+    const isStaleRequest = () => checkRequestIdRef.current !== requestId;
+
     try {
       clearLatestTimeout();
       setState({ stage: "checking" });
       update = await check();
+      if (isStaleRequest()) {
+        return;
+      }
+
       if (!update) {
+        const currentUpdate = updateRef.current;
+        updateRef.current = null;
+        await currentUpdate?.close();
+
         if (options?.announceNoUpdate) {
           setState({ stage: "latest" });
           latestTimeoutRef.current = window.setTimeout(() => {
+            if (checkRequestIdRef.current !== requestId) {
+              return;
+            }
             latestTimeoutRef.current = null;
             setState({ stage: "idle" });
           }, latestToastDurationMs);
@@ -76,12 +102,20 @@ export function useUpdater({ enabled = true, onDebug }: UseUpdaterOptions) {
         return;
       }
 
+      const currentUpdate = updateRef.current;
       updateRef.current = update;
+      if (currentUpdate && currentUpdate !== update) {
+        await currentUpdate.close();
+      }
       setState({
         stage: "available",
         version: update.version,
       });
     } catch (error) {
+      if (isStaleRequest()) {
+        return;
+      }
+
       const message =
         error instanceof Error ? error.message : JSON.stringify(error);
       onDebug?.({
@@ -91,9 +125,13 @@ export function useUpdater({ enabled = true, onDebug }: UseUpdaterOptions) {
         label: "updater/error",
         payload: message,
       });
-      setState({ stage: "error", error: message });
+      setState(
+        options?.interactive
+          ? { stage: "error", error: message }
+          : { stage: "idle" },
+      );
     } finally {
-      if (!updateRef.current) {
+      if (isStaleRequest() || !updateRef.current) {
         await update?.close();
       }
     }
@@ -102,7 +140,7 @@ export function useUpdater({ enabled = true, onDebug }: UseUpdaterOptions) {
   const startUpdate = useCallback(async () => {
     const update = updateRef.current;
     if (!update) {
-      await checkForUpdates();
+      await checkForUpdates({ announceNoUpdate: true, interactive: true });
       return;
     }
 
@@ -178,9 +216,13 @@ export function useUpdater({ enabled = true, onDebug }: UseUpdaterOptions) {
 
   useEffect(() => {
     return () => {
+      invalidatePendingChecks();
       clearLatestTimeout();
+      const update = updateRef.current;
+      updateRef.current = null;
+      void update?.close();
     };
-  }, [clearLatestTimeout]);
+  }, [clearLatestTimeout, invalidatePendingChecks]);
 
   return {
     state,


### PR DESCRIPTION
## Summary
- make updater background checks fail silently instead of surfacing a false error toast
- guard update checks with a request id so stale responses cannot overwrite newer updater state
- keep manual checks interactive, and add regression tests for silent failure / stale request behavior

## Validation
- `npm exec vitest run "src/features/update/hooks/useUpdater.test.ts" "src/features/update/components/UpdateToast.test.tsx"`
- `./node_modules/.bin/eslint "src/features/update/hooks/useUpdater.ts" "src/features/update/hooks/useUpdater.test.ts" "src/features/app/hooks/useUpdaterController.ts"`
- `./node_modules/.bin/tsc --noEmit`

## Notes for maintainers
- I verified the current release feed at `releases/latest/download/latest.json` still reports `0.4.8` while the repo/app version is already `0.4.9`.
- This PR hardens the client against that stale feed behavior, but please also update `latest.json` promptly for `0.4.9` and future releases so updater checks are not misled by an outdated manifest.
