### PR TITLE
fix(styles): 兼容 Windows 换行符布局守卫测试

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ CLAUDE.md
 .trellis/*.tmp
 .trellis/*.new
 .trellis/.backup-*/
+
+.specstory/
+.superpowers/

--- a/src/styles/layout-swapped-platform-guard.test.ts
+++ b/src/styles/layout-swapped-platform-guard.test.ts
@@ -3,8 +3,12 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
+function readText(filePath: string): string {
+  return readFileSync(filePath, "utf8").replace(/\r\n/g, "\n");
+}
+
 function readCssWithImports(filePath: string): string {
-  const css = readFileSync(filePath, "utf8");
+  const css = readText(filePath);
   const importPattern = /^@import\s+"(.+?)";$/gm;
 
   return css.replace(importPattern, (_, relativeImportPath: string) =>
@@ -12,24 +16,20 @@ function readCssWithImports(filePath: string): string {
   );
 }
 
-const baseCss = readFileSync(
+const baseCss = readText(
   fileURLToPath(new URL("./base.css", import.meta.url)),
-  "utf8",
 );
-const mainCss = readFileSync(
+const mainCss = readText(
   fileURLToPath(new URL("./main.css", import.meta.url)),
-  "utf8",
 );
-const sidebarCss = readFileSync(
+const sidebarCss = readText(
   fileURLToPath(new URL("./sidebar.css", import.meta.url)),
-  "utf8",
 );
 const messagesCss = readCssWithImports(
   fileURLToPath(new URL("./messages.css", import.meta.url)),
 );
-const diffViewerCss = readFileSync(
+const diffViewerCss = readText(
   fileURLToPath(new URL("./diff-viewer.css", import.meta.url)),
-  "utf8",
 );
 
 function getCssRuleBlock(css: string, selector: string): string {


### PR DESCRIPTION
## 背景
- `src/styles/layout-swapped-platform-guard.test.ts` 在 Windows `core.autocrlf=true` 场景下会把 CSS 读成 `CRLF`
- 用 `indexOf("...\n...")` 做 selector 顺序断言时会误报失败
- 这是测试脆弱性问题，不是业务样式逻辑回归

## 修改
- 在测试文件内统一把读取到的 CSS 文本规范化为 `LF`
- 保持断言语义不变，只消除换行符差异带来的平台误差

## 验证
- `npm exec vitest run src/styles/layout-swapped-platform-guard.test.ts`
- `npm run lint`
- `npm run typecheck`
