### PR TITLE
fix(skills): 发现 Claude 插件缓存技能

### DIFF
--- a/.trellis/tasks/04-30-add-claude-plugin-skill-discovery/prd.md
+++ b/.trellis/tasks/04-30-add-claude-plugin-skill-discovery/prd.md
@@ -1,0 +1,25 @@
+# Add Claude plugin skill discovery
+
+## Goal
+
+修复 GitHub issue #394：Settings → Skills 面板必须能发现 Claude Code `/plugin` 安装到 `~/.claude/plugins/cache/*/*/skills` 下的 skill。
+
+## Requirements
+
+- OpenSpec change: `add-claude-plugin-skill-discovery`。
+- 后端返回新增 source `global_claude_plugin`，用于区分 plugin cache skill。
+- 缺少或不可读 plugin cache 时不得影响现有 skill discovery。
+- 不在本任务处理 symlink skill 目录；issue #303 可作为后续独立 PR。
+- 不新增依赖，不新增 Tauri command。
+
+## Acceptance Criteria
+
+- [x] `skills_list` 可以返回 Claude plugin cache skill。
+- [x] Settings Skills Claude 分组可以展示 plugin skill。
+- [x] targeted Rust tests 通过。
+- [x] `npm run typecheck` 通过。
+
+## Verification
+
+- `cargo test --manifest-path src-tauri/Cargo.toml skills::`
+- `npm run typecheck`

--- a/.trellis/tasks/04-30-add-claude-plugin-skill-discovery/task.json
+++ b/.trellis/tasks/04-30-add-claude-plugin-skill-discovery/task.json
@@ -1,0 +1,53 @@
+{
+  "id": "add-claude-plugin-skill-discovery",
+  "name": "add-claude-plugin-skill-discovery",
+  "title": "Add Claude plugin skill discovery",
+  "description": "Discover Claude Code plugin cache skills in Settings Skills.",
+  "status": "completed",
+  "dev_type": "fullstack",
+  "scope": "skills",
+  "package": null,
+  "priority": "P1",
+  "creator": "watsonk1998",
+  "assignee": "watsonk1998",
+  "createdAt": "2026-04-30",
+  "completedAt": "2026-04-30",
+  "branch": "fix/claude-plugin-skill-discovery",
+  "base_branch": "main",
+  "worktree_path": null,
+  "current_phase": 6,
+  "next_action": [
+    {
+      "phase": 3,
+      "action": "implement"
+    },
+    {
+      "phase": 4,
+      "action": "check"
+    },
+    {
+      "phase": 5,
+      "action": "update-spec"
+    },
+    {
+      "phase": 6,
+      "action": "record-session"
+    }
+  ],
+  "commit": null,
+  "pr_url": null,
+  "subtasks": [],
+  "children": [],
+  "parent": null,
+  "relatedFiles": [
+    "src-tauri/src/skills.rs",
+    "src/features/settings/components/SkillsSection.tsx",
+    "src/features/composer/components/ChatInputBox/ChatInputBoxAdapter.tsx",
+    "openspec/changes/add-claude-plugin-skill-discovery"
+  ],
+  "notes": "Linked GitHub issue: #394. Verification: npm run typecheck; npm exec eslint -- src/features/settings/components/SkillsSection.tsx src/features/composer/components/ChatInputBox/ChatInputBoxAdapter.tsx; npm run build; cargo test --manifest-path src-tauri/Cargo.toml skills::.",
+  "meta": {
+    "openspecChange": "add-claude-plugin-skill-discovery",
+    "githubIssue": 394
+  }
+}

--- a/.trellis/workspace/watsonk1998/index.md
+++ b/.trellis/workspace/watsonk1998/index.md
@@ -1,0 +1,41 @@
+# Workspace Index - watsonk1998
+
+> Journal tracking for AI development sessions.
+
+---
+
+## Current Status
+
+<!-- @@@auto:current-status -->
+- **Active File**: `journal-1.md`
+- **Total Sessions**: 1
+- **Last Active**: 2026-05-01
+<!-- @@@/auto:current-status -->
+
+---
+
+## Active Documents
+
+<!-- @@@auto:active-documents -->
+| File | Lines | Status |
+|------|-------|--------|
+| `journal-1.md` | ~45 | Active |
+<!-- @@@/auto:active-documents -->
+
+---
+
+## Session History
+
+<!-- @@@auto:session-history -->
+| # | Date | Title | Commits | Branch |
+|---|------|-------|---------|--------|
+| 1 | 2026-05-01 | 迁移 Claude 插件技能发现 PR 到 0.4.12 分支 | `9b1b63c623b6f2e10d234298ee81aa17506a4146` | `fix/claude-plugin-skill-discovery` |
+<!-- @@@/auto:session-history -->
+
+---
+
+## Notes
+
+- Sessions are appended to journal files
+- New journal file created when current exceeds 2000 lines
+- Use `add_session.py` to record sessions

--- a/.trellis/workspace/watsonk1998/journal-1.md
+++ b/.trellis/workspace/watsonk1998/journal-1.md
@@ -1,0 +1,45 @@
+# Journal - watsonk1998 (Part 1)
+
+> AI development session journal
+> Started: 2026-05-01
+
+---
+
+
+
+## Session 1: 迁移 Claude 插件技能发现 PR 到 0.4.12 分支
+
+**Date**: 2026-05-01
+**Task**: 迁移 Claude 插件技能发现 PR 到 0.4.12 分支
+**Branch**: `fix/claude-plugin-skill-discovery`
+
+### Summary
+
+(Add summary)
+
+### Main Changes
+
+任务目标：按维护者反馈，将 PR #476 从 main 目标迁移到 chore/bump-version-0.4.12 目标分支，同时保持 diff 干净。
+主要改动：基于 origin/chore/bump-version-0.4.12 重建 fix/claude-plugin-skill-discovery 分支，并 cherry-pick 原业务提交 1e01ed7 的 Claude plugin cache skill discovery 修复。
+涉及模块：src-tauri skills discovery；Settings Skills section；ChatInputBoxAdapter skill hints；openspec/changes/add-claude-plugin-skill-discovery；.trellis/tasks/04-30-add-claude-plugin-skill-discovery。
+验证结果：npm exec eslint -- src/features/settings/components/SkillsSection.tsx src/features/composer/components/ChatInputBox/ChatInputBoxAdapter.tsx 通过；cargo test --manifest-path src-tauri/Cargo.toml skills:: 通过；npm run typecheck 通过；git diff --check origin/chore/bump-version-0.4.12..HEAD 通过。
+后续事项：推送 fork/fix/claude-plugin-skill-discovery 后，将 PR #476 base 改为 chore/bump-version-0.4.12。
+
+
+### Git Commits
+
+| Hash | Message |
+|------|---------|
+| `9b1b63c623b6f2e10d234298ee81aa17506a4146` | (see git log) |
+
+### Testing
+
+- [OK] (Add test results)
+
+### Status
+
+[OK] **Completed**
+
+### Next Steps
+
+- None - task complete

--- a/openspec/changes/add-claude-plugin-skill-discovery/.openspec.yaml
+++ b/openspec/changes/add-claude-plugin-skill-discovery/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/add-claude-plugin-skill-discovery/design.md
+++ b/openspec/changes/add-claude-plugin-skill-discovery/design.md
@@ -1,0 +1,36 @@
+## Context
+
+当前 `skills_list_local_for_workspace` 已经集中扫描 workspace-managed、project `.claude/.codex/.agents/.gemini` 与 global `.claude/.codex/.agents/.gemini`。Issue #394 的缺口是 Claude plugin cache 位于同一 Claude home 下，但目录形态是二级 cache：`plugins/cache/<owner>/<plugin>/skills`。
+
+## Decisions
+
+### Decision 1: 增加独立 source `global_claude_plugin`
+
+不把 plugin skill 混入 `global_claude`，而是返回独立 source。
+
+- 便于 UI 与 debug payload 区分真实来源。
+- 不改变现有 `global_claude` 目录语义。
+- Composer 可以继续用 source priority 控制同名候选的默认顺序。
+
+### Decision 2: 仅扫描二级 plugin cache skills root
+
+扫描范围固定为 `~/.claude/plugins/cache/*/*/skills`。
+
+- 与 Claude Code plugin cache 的已知安装形态对齐。
+- 避免对 cache 下任意深度做递归扫描，降低意外 IO 与安全边界风险。
+- 缺失目录、不可读目录或非目录条目均跳过，不阻塞其他 skill source。
+
+### Decision 3: 不在本 PR 处理 symlink skill
+
+Issue #303 属于相邻但独立的问题。该 PR 只解决 plugin cache discovery，保持 `discover_skills_in` 现有 symlink 策略，避免把安全/循环链接边界混入首 PR。
+
+## Risks / Mitigations
+
+- Risk: plugin cache 下有多个 plugin 提供同名 skill。Mitigation: 返回 source metadata；Composer slash 候选继续用 scope/name 去重和 source priority 收敛。
+- Risk: 只有 plugin skill 时 Settings tree 无法定位根目录。Mitigation: Claude engine 增加 `/.claude/plugins/cache` path marker，用于推导浏览根。
+
+## Verification
+
+- Rust unit test: plugin cache roots discovery。
+- Rust unit test: merge priority includes `global_claude_plugin` as a global source。
+- TypeScript typecheck: Settings/Composer source priority changes保持类型稳定。

--- a/openspec/changes/add-claude-plugin-skill-discovery/proposal.md
+++ b/openspec/changes/add-claude-plugin-skill-discovery/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Claude Code 官方 plugin 会把 skill 安装到 `~/.claude/plugins/cache/<owner>/<plugin>/skills/`，但当前 Skills 面板只扫描 `~/.claude/skills` 等传统目录。用户通过 `/plugin` 安装的 skill 实际可被 Claude CLI 使用，却无法在 GUI 中查看、搜索或预览。
+
+## 目标与边界
+
+- 目标：将 Claude plugin cache 下的 `skills` 目录纳入本地 skill discovery。
+- 目标：保持现有优先级与去重语义，用户自建 `~/.claude/skills` 仍优先于 plugin cache。
+- 边界：不新增自定义 skill root 设置，不改变 Claude CLI 运行时加载逻辑，不处理 symlink skill 目录。
+
+## What Changes
+
+- 后端新增 `global_claude_plugin` source，扫描 `~/.claude/plugins/cache/*/*/skills`。
+- Settings → Skills 的 Claude 引擎分组识别该 source，并能从 plugin cache 路径推导浏览根。
+- Composer slash skill 候选保留 deterministic source priority。
+- 补充 Rust targeted tests 覆盖 plugin cache roots 发现与 source merge。
+
+## Capabilities
+
+### Modified Capabilities
+
+- `composer-context-project-resource-discovery`: local skill discovery MUST include Claude plugin cache skill roots.
+
+## 验收标准
+
+- 当 `~/.claude/plugins/cache/<owner>/<plugin>/skills/<name>/SKILL.md` 存在时，`skills_list` 返回对应 skill。
+- 返回项 source 为 `global_claude_plugin`。
+- Settings Skills 面板切换 Claude 时可以匹配并展示 plugin skill。
+- 缺少 plugin cache 目录时 discovery 不失败。

--- a/openspec/changes/add-claude-plugin-skill-discovery/specs/composer-context-project-resource-discovery/spec.md
+++ b/openspec/changes/add-claude-plugin-skill-discovery/specs/composer-context-project-resource-discovery/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Claude Plugin Cache Skill Discovery
+
+The system SHALL discover Claude Code plugin skills installed under the Claude home plugin cache in addition to existing managed, project, and global skill sources.
+
+#### Scenario: Discover skills from Claude plugin cache
+
+- **WHEN** Claude home contains `plugins/cache/<owner>/<plugin>/skills/<skill>/SKILL.md`
+- **THEN** `skills_list` result SHALL include skills discovered from that plugin `skills` directory
+- **AND** each discovered item SHALL carry `source = global_claude_plugin`
+
+#### Scenario: Missing Claude plugin cache does not fail discovery
+
+- **WHEN** Claude home does not contain `plugins/cache` or no plugin has a `skills` directory
+- **THEN** discovery SHALL continue using other sources
+- **AND** API call SHALL still return success with available items

--- a/openspec/changes/add-claude-plugin-skill-discovery/tasks.md
+++ b/openspec/changes/add-claude-plugin-skill-discovery/tasks.md
@@ -1,0 +1,14 @@
+## 1. Backend Discovery
+
+- [x] 1.1 [P0][Input: `src-tauri/src/skills.rs`][Output: `global_claude_plugin` source constant and root discovery helper][Verify: Rust unit test] Add Claude plugin cache skill root discovery.
+- [x] 1.2 [P0][Depends: 1.1][Input: skill source merge order][Output: plugin cache skills merged after `global_claude` and before `global_codex`][Verify: Rust merge test] Preserve deterministic merge behavior.
+
+## 2. Frontend Presentation
+
+- [x] 2.1 [P1][Input: Settings Skills engine config][Output: Claude engine recognizes `global_claude_plugin` and plugin cache path marker][Verify: `npm run typecheck`] Wire plugin skill source into Settings Skills.
+- [x] 2.2 [P1][Input: Composer skill source priority][Output: plugin skill source sorted after user Claude global skills][Verify: `npm run typecheck`] Keep slash skill candidate ordering deterministic.
+
+## 3. Verification
+
+- [x] 3.1 [P0][Depends: 1.x][Input: Rust unit tests][Output: targeted `skills::` tests pass][Verify: `cargo test --manifest-path src-tauri/Cargo.toml skills::`]
+- [x] 3.2 [P1][Depends: 2.x][Input: TS changes][Output: clean typecheck][Verify: `npm run typecheck`]

--- a/src-tauri/src/skills.rs
+++ b/src-tauri/src/skills.rs
@@ -21,6 +21,7 @@ const SKILL_SOURCE_PROJECT_CODEX: &str = "project_codex";
 const SKILL_SOURCE_PROJECT_AGENTS: &str = "project_agents";
 const SKILL_SOURCE_PROJECT_GEMINI: &str = "project_gemini";
 const SKILL_SOURCE_GLOBAL_CLAUDE: &str = "global_claude";
+const SKILL_SOURCE_GLOBAL_CLAUDE_PLUGIN: &str = "global_claude_plugin";
 const SKILL_SOURCE_GLOBAL_CODEX: &str = "global_codex";
 const SKILL_SOURCE_GLOBAL_AGENTS: &str = "global_agents";
 const SKILL_SOURCE_GLOBAL_GEMINI: &str = "global_gemini";
@@ -115,6 +116,52 @@ fn default_claude_skills_dir() -> Option<PathBuf> {
     resolve_default_claude_home().map(|home| home.join("skills"))
 }
 
+fn claude_plugin_skills_roots_from_home(home: &Path) -> Vec<PathBuf> {
+    let cache = home.join("plugins").join("cache");
+    let Ok(owner_entries) = fs::read_dir(&cache) else {
+        return Vec::new();
+    };
+
+    let mut roots = Vec::new();
+    for owner_entry in owner_entries.flatten() {
+        let owner_path = owner_entry.path();
+        let Ok(owner_metadata) = fs::symlink_metadata(&owner_path) else {
+            continue;
+        };
+        if owner_metadata.file_type().is_symlink() || !owner_metadata.is_dir() {
+            continue;
+        }
+
+        let Ok(plugin_entries) = fs::read_dir(&owner_path) else {
+            continue;
+        };
+        for plugin_entry in plugin_entries.flatten() {
+            let plugin_path = plugin_entry.path();
+            let Ok(plugin_metadata) = fs::symlink_metadata(&plugin_path) else {
+                continue;
+            };
+            if plugin_metadata.file_type().is_symlink() || !plugin_metadata.is_dir() {
+                continue;
+            }
+
+            let skills_dir = plugin_path.join("skills");
+            if skills_dir.is_dir() {
+                roots.push(skills_dir);
+            }
+        }
+    }
+
+    roots.sort();
+    roots.dedup();
+    roots
+}
+
+fn default_claude_plugin_skills_roots() -> Vec<PathBuf> {
+    resolve_default_claude_home()
+        .map(|home| claude_plugin_skills_roots_from_home(&home))
+        .unwrap_or_default()
+}
+
 fn resolve_default_agents_home() -> Option<PathBuf> {
     if let Ok(value) = env::var("AGENTS_HOME") {
         if let Some(path) = normalize_home_path(&value) {
@@ -168,6 +215,7 @@ fn normalize_skill_name(name: &str) -> String {
 
 fn is_global_source(source: &str) -> bool {
     source == SKILL_SOURCE_GLOBAL_CLAUDE
+        || source == SKILL_SOURCE_GLOBAL_CLAUDE_PLUGIN
         || source == SKILL_SOURCE_GLOBAL_CODEX
         || source == SKILL_SOURCE_GLOBAL_AGENTS
         || source == SKILL_SOURCE_GLOBAL_GEMINI
@@ -379,7 +427,7 @@ fn merge_skills_by_priority(sources: Vec<Vec<SkillEntry>>) -> Vec<SkillEntry> {
 /// Scan local skills directories for a specific workspace.
 /// Priority order:
 /// workspace-managed > project .claude > project .codex > project .agents >
-/// global .claude > global .codex > global .agents.
+/// global .claude > global Claude plugins > global .codex > global .agents.
 pub(crate) async fn skills_list_local_for_workspace(
     state: &AppState,
     workspace_id: &str,
@@ -391,6 +439,7 @@ pub(crate) async fn skills_list_local_for_workspace(
         project_agents_dir,
         project_gemini_dir,
         claude_global_dir,
+        claude_plugin_global_dirs,
         codex_global_dir,
         agents_global_dir,
         gemini_global_dir,
@@ -406,6 +455,7 @@ pub(crate) async fn skills_list_local_for_workspace(
         let project_gemini_dir = PathBuf::from(&entry.path).join(".gemini").join("skills");
         let codex_dir = default_skills_dir_for_workspace(&workspaces, entry);
         let claude_dir = default_claude_skills_dir();
+        let claude_plugin_dirs = default_claude_plugin_skills_roots();
         let agents_dir = default_agents_skills_dir();
         let gemini_dir = default_gemini_skills_dir();
         (
@@ -415,6 +465,7 @@ pub(crate) async fn skills_list_local_for_workspace(
             Some(project_agents_dir),
             Some(project_gemini_dir),
             claude_dir,
+            claude_plugin_dirs,
             codex_dir,
             agents_dir,
             gemini_dir,
@@ -463,6 +514,11 @@ pub(crate) async fn skills_list_local_for_workspace(
             None => Vec::new(),
         };
 
+        let claude_plugin_skills = claude_plugin_global_dirs
+            .iter()
+            .flat_map(|dir| safe_discover(dir, SKILL_SOURCE_GLOBAL_CLAUDE_PLUGIN))
+            .collect::<Vec<_>>();
+
         let codex_skills = match &codex_global_dir {
             Some(dir) => safe_discover(dir, SKILL_SOURCE_GLOBAL_CODEX),
             None => Vec::new(),
@@ -484,6 +540,7 @@ pub(crate) async fn skills_list_local_for_workspace(
             project_agents_skills,
             project_gemini_skills,
             claude_skills,
+            claude_plugin_skills,
             codex_skills,
             agents_skills,
             gemini_skills,
@@ -557,6 +614,12 @@ mod tests {
             source: SKILL_SOURCE_GLOBAL_CLAUDE.to_string(),
             description: None,
         };
+        let claude_plugin_skill = SkillEntry {
+            name: "shared".to_string(),
+            path: "/home/.claude/plugins/cache/owner/plugin/skills/shared/SKILL.md".to_string(),
+            source: SKILL_SOURCE_GLOBAL_CLAUDE_PLUGIN.to_string(),
+            description: None,
+        };
         let codex_skill = SkillEntry {
             name: "shared".to_string(),
             path: "/home/.codex/skills/shared.md".to_string(),
@@ -574,11 +637,12 @@ mod tests {
             vec![workspace_skill.clone()],
             vec![project_claude_skill],
             vec![claude_skill],
+            vec![claude_plugin_skill],
             vec![codex_skill],
             vec![agents_skill],
         ]);
 
-        assert_eq!(merged.len(), 4);
+        assert_eq!(merged.len(), 5);
         assert!(merged.iter().any(|entry| {
             entry.name == "shared"
                 && entry.path == workspace_skill.path
@@ -588,6 +652,11 @@ mod tests {
             entry.name == "shared"
                 && entry.source == SKILL_SOURCE_GLOBAL_CLAUDE
                 && entry.path == "/home/.claude/skills/shared.md"
+        }));
+        assert!(merged.iter().any(|entry| {
+            entry.name == "shared"
+                && entry.source == SKILL_SOURCE_GLOBAL_CLAUDE_PLUGIN
+                && entry.path == "/home/.claude/plugins/cache/owner/plugin/skills/shared/SKILL.md"
         }));
         assert!(merged.iter().any(|entry| {
             entry.name == "shared"
@@ -623,5 +692,37 @@ mod tests {
         assert_eq!(entries[0].description.as_deref(), Some("project skill"));
 
         let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn claude_plugin_roots_discover_two_level_cache_skills_dirs() {
+        let home = new_temp_dir("claude-plugin-roots");
+        let first_skills = home
+            .join("plugins")
+            .join("cache")
+            .join("claude-plugins-official")
+            .join("superpowers")
+            .join("skills");
+        let second_skills = home
+            .join("plugins")
+            .join("cache")
+            .join("owner__repo")
+            .join("plugin-name")
+            .join("skills");
+        let non_skill_plugin = home
+            .join("plugins")
+            .join("cache")
+            .join("owner__repo")
+            .join("no-skills");
+
+        fs::create_dir_all(&first_skills).expect("create first plugin skills");
+        fs::create_dir_all(&second_skills).expect("create second plugin skills");
+        fs::create_dir_all(&non_skill_plugin).expect("create non-skill plugin");
+
+        let roots = claude_plugin_skills_roots_from_home(&home);
+
+        assert_eq!(roots, vec![first_skills, second_skills]);
+
+        let _ = fs::remove_dir_all(home);
     }
 }

--- a/src/features/composer/components/ChatInputBox/ChatInputBoxAdapter.tsx
+++ b/src/features/composer/components/ChatInputBox/ChatInputBoxAdapter.tsx
@@ -705,8 +705,9 @@ const SKILL_SOURCE_PRIORITY: Record<string, number> = {
   project_codex: 2,
   project_agents: 3,
   global_claude: 4,
-  global_codex: 5,
-  global_agents: 6,
+  global_claude_plugin: 5,
+  global_codex: 6,
+  global_agents: 7,
 };
 
 function normalizeSkillName(value: unknown) {

--- a/src/features/settings/components/SkillsSection.tsx
+++ b/src/features/settings/components/SkillsSection.tsx
@@ -77,8 +77,8 @@ const imageExtensions = new Set([
 const ENGINE_ORDER: GlobalEngine[] = ["claude", "code", "gemini", "agents"];
 const ENGINE_CONFIGS: Record<GlobalEngine, EngineConfig> = {
   claude: {
-    sourcePrefixes: ["global_claude"],
-    pathMarkers: ["/.claude/skills"],
+    sourcePrefixes: ["global_claude", "global_claude_plugin"],
+    pathMarkers: ["/.claude/skills", "/.claude/plugins/cache"],
     globalDir: ".claude/skills",
   },
   code: {


### PR DESCRIPTION
## Summary

Fixes #394.

- Discover Claude plugin cached skills from `~/.claude/plugins/cache/*/*/skills`.
- Surface those skills as `global_claude_plugin` in Settings Skills and composer skill suggestions.
- Preserve existing merge order, with `.claude/skills` taking precedence over plugin cache, then `.codex/skills`.

## Spec / Task

- OpenSpec change: `openspec/changes/add-claude-plugin-skill-discovery`
- Trellis task: `.trellis/tasks/04-30-add-claude-plugin-skill-discovery`

## Verification

- `npm run typecheck`
- `npm exec eslint -- src/features/settings/components/SkillsSection.tsx src/features/composer/components/ChatInputBox/ChatInputBoxAdapter.tsx`
- `npm run build`
- `cargo test --manifest-path src-tauri/Cargo.toml skills::`
- `git diff --check`

## Not Run

- `openspec validate add-claude-plugin-skill-discovery --strict`: `openspec` CLI is not available in this local PATH, and the repository-referenced `validate-consistency.py` script is not present in this checkout.