### PR TITLE
fix(git): 让提交信息生成遵守文件选择

### DIFF
--- a/.trellis/tasks/04-30-fix-selected-commit-message-scope/prd.md
+++ b/.trellis/tasks/04-30-fix-selected-commit-message-scope/prd.md
@@ -1,0 +1,25 @@
+# Fix Selected Commit Message Generation Scope
+
+## Problem
+
+GitHub issue #467 reports that AI-generated commit messages ignore the files selected for commit and instead describe all changed files. This makes the generated message unreliable for selective commits.
+
+## Goals
+
+- Use the same selected commit path list for commit message generation and commit execution.
+- Keep existing behavior when no selected path scope is supplied.
+- Support all commit message engines through the same selected-path prompt scope.
+
+## Non-Goals
+
+- Do not redesign commit selection UI.
+- Do not change staging or commit execution semantics.
+- Do not change Git history worktree panel whole-worktree generation.
+
+## Acceptance Criteria
+
+- [x] The diff panel forwards selected commit paths when generating AI commit messages.
+- [x] The Tauri service accepts optional selected paths for Codex and non-Codex engines.
+- [x] Backend diff collection filters staged and worktree fallback diffs by selected pathspecs.
+- [x] Empty or absent selected paths preserve existing full-diff behavior.
+- [x] Focused frontend and Rust tests cover the regression.

--- a/.trellis/tasks/04-30-fix-selected-commit-message-scope/task.json
+++ b/.trellis/tasks/04-30-fix-selected-commit-message-scope/task.json
@@ -1,0 +1,38 @@
+{
+  "id": "fix-selected-commit-message-scope",
+  "name": "fix-selected-commit-message-scope",
+  "title": "Fix selected commit message generation scope",
+  "description": "Ensure AI commit message generation only uses selected commit files when a selection exists.",
+  "status": "completed",
+  "dev_type": "feature",
+  "scope": "git",
+  "package": null,
+  "priority": "P1",
+  "creator": "watsonk1998",
+  "assignee": "watsonk1998",
+  "createdAt": "2026-04-30",
+  "completedAt": "2026-04-30",
+  "branch": "fix/git-commit-message-selected-files",
+  "base_branch": "main",
+  "worktree_path": null,
+  "current_phase": 6,
+  "next_action": [],
+  "commit": null,
+  "pr_url": null,
+  "subtasks": [],
+  "children": [],
+  "parent": null,
+  "relatedFiles": [
+    "src/features/git/components/GitDiffPanel.tsx",
+    "src/features/app/hooks/useGitCommitController.ts",
+    "src/services/tauri.ts",
+    "src-tauri/src/codex/mod.rs",
+    "src-tauri/src/git/mod.rs",
+    "src-tauri/src/git/commands.rs"
+  ],
+  "notes": "Implemented selected path propagation and backend pathspec filtering for GitHub issue #467.",
+  "meta": {
+    "githubIssue": 467,
+    "openspecChange": "fix-selected-commit-message-scope"
+  }
+}

--- a/.trellis/workspace/watsonk1998/index.md
+++ b/.trellis/workspace/watsonk1998/index.md
@@ -1,0 +1,33 @@
+# Workspace Index - watsonk1998
+
+> Journal tracking for AI development sessions.
+
+---
+
+## Current Status
+
+<!-- @@@auto:current-status -->
+- **Active File**: `journal-1.md`
+- **Total Sessions**: 1
+- **Last Active**: 2026-04-30
+<!-- @@@/auto:current-status -->
+
+---
+
+## Active Documents
+
+<!-- @@@auto:active-documents -->
+| File | Lines | Status |
+|------|-------|--------|
+| `journal-1.md` | ~46 | Active |
+<!-- @@@/auto:active-documents -->
+
+---
+
+## Session History
+
+<!-- @@@auto:session-history -->
+| # | Date | Title | Commits | Branch |
+|---|------|-------|---------|--------|
+| 1 | 2026-04-30 | 记录 selected commit message scope 修复 | `f106655f54be53a55be8d6da6f63e4f897f16580` | `fix/git-commit-message-selected-files` |
+<!-- @@@/auto:session-history -->

--- a/.trellis/workspace/watsonk1998/journal-1.md
+++ b/.trellis/workspace/watsonk1998/journal-1.md
@@ -1,0 +1,46 @@
+# Journal - watsonk1998 (Part 1)
+
+> AI development session journal
+> Started: 2026-04-30
+
+---
+
+
+
+## Session 1: 记录 selected commit message scope 修复
+
+**Date**: 2026-04-30
+**Task**: 记录 selected commit message scope 修复
+**Branch**: `fix/git-commit-message-selected-files`
+
+### Summary
+
+(Add summary)
+
+### Main Changes
+
+- Objective: 修复 GitHub issue #467，使 AI commit message generation 遵守 diff panel 里的 selected commit files。
+- Code changes: `GitDiffPanel` 将 `selectedCommitPaths` 传给 controller；Tauri service 和 Rust command 接收 `selectedPaths`；backend 使用 git2 pathspec 过滤 staged diff 和 worktree fallback diff。
+- Specification: 新增 OpenSpec change `fix-selected-commit-message-scope`，定义 selected commit scope 对 commit message prompt 的约束。
+- Task record: 新增 Trellis task `04-30-fix-selected-commit-message-scope`，acceptance criteria 已完成。
+- Verification: `npm exec vitest -- run src/features/git/components/GitDiffPanel.test.tsx src/features/app/hooks/useGitCommitController.test.tsx src/features/git-history/components/GitHistoryWorktreePanel.test.tsx`; `cargo test --manifest-path src-tauri/Cargo.toml collect_workspace_diff_for_paths`; `npm run typecheck`; `npm exec eslint -- src/services/tauri.ts src/features/git/components/GitDiffPanel.tsx src/features/app/hooks/useGitCommitController.ts src/features/layout/hooks/useLayoutNodes.tsx src/features/git/components/GitDiffPanel.test.tsx src/features/app/hooks/useGitCommitController.test.tsx src/features/git-history/components/GitHistoryWorktreePanel.test.tsx`; `git diff --check`。
+- Validation gap: `openspec validate fix-selected-commit-message-scope --strict` 未运行，因为本地 PATH 无 openspec CLI。
+
+
+### Git Commits
+
+| Hash | Message |
+|------|---------|
+| `f106655f54be53a55be8d6da6f63e4f897f16580` | (see git log) |
+
+### Testing
+
+- [OK] (Add test results)
+
+### Status
+
+[OK] **Completed**
+
+### Next Steps
+
+- None - task complete

--- a/openspec/changes/fix-selected-commit-message-scope/.openspec.yaml
+++ b/openspec/changes/fix-selected-commit-message-scope/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/fix-selected-commit-message-scope/design.md
+++ b/openspec/changes/fix-selected-commit-message-scope/design.md
@@ -1,0 +1,21 @@
+## Design
+
+The existing selective commit flow already computes `selectedCommitPaths` from staged files, unstaged files, and user selection overrides. The fix reuses that source of truth instead of introducing a second selection model.
+
+Frontend flow:
+
+- `GitDiffPanel` passes `selectedCommitPaths` as the third argument to `onGenerateCommitMessage` when the selection is non-empty.
+- `useGitCommitController` forwards those paths to `generateCommitMessageWithEngine`.
+- The Tauri service passes `selectedPaths` to both the direct Codex command and the prompt-building path used by non-Codex engines.
+
+Backend flow:
+
+- `generate_commit_message` and `get_commit_message_prompt` accept optional `selected_paths`.
+- `get_workspace_diff_with_selected_paths` resolves the repository once, then delegates to full diff collection or path-filtered diff collection.
+- `collect_workspace_diff_for_paths` applies git2 `DiffOptions::pathspec` to both staged and worktree fallback diffs, keeping the existing staged-first behavior.
+
+## Boundaries
+
+- Empty or absent `selectedPaths` keeps the previous full-diff behavior.
+- This change does not alter the commit button, temporary staging, or file selection UI.
+- The history worktree panel continues to generate from its whole worktree scope.

--- a/openspec/changes/fix-selected-commit-message-scope/proposal.md
+++ b/openspec/changes/fix-selected-commit-message-scope/proposal.md
@@ -1,0 +1,15 @@
+## Why
+
+Git commit message generation currently ignores the commit selection state added to the diff panel. When users include only a subset of files for commit, the AI prompt is still built from the full staged/worktree diff, so the generated message can describe files that will not be committed.
+
+## What Changes
+
+- Pass selected commit paths from `GitDiffPanel` into the commit message generation controller.
+- Thread selected paths through the Tauri service and commit message commands.
+- Filter Rust diff collection by selected pathspecs when a selection is provided, while preserving the existing full-diff fallback when no selection is provided.
+- Cover the UI propagation and Rust diff filtering behavior with focused tests.
+
+## Impact
+
+- Affects Git diff panel AI commit message generation for Codex, Claude, Gemini, and OpenCode engines.
+- Does not change commit execution semantics, staging behavior, or history worktree generation when no selected path scope is supplied.

--- a/openspec/changes/fix-selected-commit-message-scope/specs/git-commit-message-generation/spec.md
+++ b/openspec/changes/fix-selected-commit-message-scope/specs/git-commit-message-generation/spec.md
@@ -1,0 +1,25 @@
+# git-commit-message-generation Delta
+
+## Modified Requirements
+
+### Requirement: AI Commit Message Generation MUST Respect Selected Commit Scope
+
+When a commit selection is provided, the generated commit message prompt MUST be built only from the selected paths.
+
+#### Scenario: selected staged file excludes other staged files
+
+- **WHEN** the diff panel has multiple staged files
+- **AND** the user generates a commit message for a subset selection
+- **THEN** the backend diff used for prompt construction MUST include selected paths
+- **AND** MUST exclude unselected staged paths
+
+#### Scenario: selected worktree file excludes other worktree files
+
+- **WHEN** the commit message generation request includes selected worktree paths
+- **THEN** the backend worktree fallback diff MUST apply the same selected path filter
+- **AND** MUST not describe unselected worktree files
+
+#### Scenario: no selected paths preserves existing behavior
+
+- **WHEN** no selected path list is supplied
+- **THEN** commit message generation MUST keep the existing full staged-first diff behavior

--- a/openspec/changes/fix-selected-commit-message-scope/tasks.md
+++ b/openspec/changes/fix-selected-commit-message-scope/tasks.md
@@ -1,0 +1,8 @@
+## Tasks
+
+- [x] Route selected commit paths from `GitDiffPanel` to `useGitCommitController`.
+- [x] Extend Tauri service commit message helpers with optional `selectedPaths`.
+- [x] Extend Rust commit message commands with selected-path diff filtering.
+- [x] Add frontend regression tests for selected path propagation.
+- [x] Add Rust regression tests for staged and worktree path filtering.
+- [x] Run focused frontend and Rust verification.

--- a/src-tauri/src/codex/mod.rs
+++ b/src-tauri/src/codex/mod.rs
@@ -1239,10 +1239,13 @@ pub(crate) async fn respond_to_server_request(
 pub(crate) async fn get_commit_message_prompt(
     workspace_id: String,
     language: Option<String>,
+    selected_paths: Option<Vec<String>>,
     state: State<'_, AppState>,
 ) -> Result<String, String> {
     // Get the diff from git
-    let diff = crate::git::get_workspace_diff(&workspace_id, &state).await?;
+    let diff =
+        crate::git::get_workspace_diff_with_selected_paths(&workspace_id, &state, selected_paths)
+            .await?;
 
     if diff.trim().is_empty() {
         return Err("No changes to generate commit message for".to_string());
@@ -1284,11 +1287,14 @@ pub(crate) async fn get_config_model(
 pub(crate) async fn generate_commit_message(
     workspace_id: String,
     language: Option<String>,
+    selected_paths: Option<Vec<String>>,
     state: State<'_, AppState>,
     app: AppHandle,
 ) -> Result<String, String> {
     // Get the diff from git
-    let diff = crate::git::get_workspace_diff(&workspace_id, &state).await?;
+    let diff =
+        crate::git::get_workspace_diff_with_selected_paths(&workspace_id, &state, selected_paths)
+            .await?;
 
     if diff.trim().is_empty() {
         return Err("No changes to generate commit message for".to_string());

--- a/src-tauri/src/git/commands.rs
+++ b/src-tauri/src/git/commands.rs
@@ -589,10 +589,10 @@ pub(crate) async fn list_git_roots(
     Ok(scan_git_roots(&root, depth, 200))
 }
 
-/// Helper function to get the combined diff for a workspace (used by commit message generation)
-pub(crate) async fn get_workspace_diff(
+pub(crate) async fn get_workspace_diff_with_selected_paths(
     workspace_id: &str,
     state: &State<'_, AppState>,
+    selected_paths: Option<Vec<String>>,
 ) -> Result<String, String> {
     let workspaces = state.workspaces.lock().await;
     let entry = workspaces
@@ -602,7 +602,10 @@ pub(crate) async fn get_workspace_diff(
     drop(workspaces);
 
     let repo_root = resolve_git_root(&entry)?;
-    collect_workspace_diff(&repo_root)
+    match selected_paths {
+        Some(paths) if !paths.is_empty() => collect_workspace_diff_for_paths(&repo_root, &paths),
+        _ => collect_workspace_diff(&repo_root),
+    }
 }
 
 #[tauri::command]

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
@@ -724,11 +724,32 @@ fn build_combined_diff(diff: &git2::Diff) -> String {
     combined_diff
 }
 
-fn collect_workspace_diff(repo_root: &Path) -> Result<String, String> {
+fn normalize_diff_pathspecs(paths: &[String]) -> Vec<String> {
+    let mut seen_paths = HashSet::new();
+    paths
+        .iter()
+        .map(|path| normalize_git_path(path).trim().to_string())
+        .filter(|path| !path.is_empty())
+        .filter(|path| seen_paths.insert(path.clone()))
+        .collect()
+}
+
+fn apply_diff_pathspecs(options: &mut DiffOptions, pathspecs: &[String]) {
+    for pathspec in pathspecs {
+        options.pathspec(pathspec);
+    }
+}
+
+fn collect_workspace_diff_for_paths(
+    repo_root: &Path,
+    selected_paths: &[String],
+) -> Result<String, String> {
     let repo = open_repository_at_root(repo_root)?;
     let head_tree = repo.head().ok().and_then(|head| head.peel_to_tree().ok());
+    let pathspecs = normalize_diff_pathspecs(selected_paths);
 
     let mut options = DiffOptions::new();
+    apply_diff_pathspecs(&mut options, &pathspecs);
     let index = repo.index().map_err(|e| e.to_string())?;
     let diff = match head_tree.as_ref() {
         Some(tree) => repo
@@ -744,6 +765,7 @@ fn collect_workspace_diff(repo_root: &Path) -> Result<String, String> {
     }
 
     let mut options = DiffOptions::new();
+    apply_diff_pathspecs(&mut options, &pathspecs);
     options
         .include_untracked(true)
         .recurse_untracked_dirs(true)
@@ -757,6 +779,10 @@ fn collect_workspace_diff(repo_root: &Path) -> Result<String, String> {
             .map_err(|e| e.to_string())?,
     };
     Ok(build_combined_diff(&diff))
+}
+
+fn collect_workspace_diff(repo_root: &Path) -> Result<String, String> {
+    collect_workspace_diff_for_paths(repo_root, &[])
 }
 
 fn github_repo_from_path(path: &Path) -> Result<String, String> {
@@ -1424,6 +1450,42 @@ mod tests {
         let diff = collect_workspace_diff(&root).expect("collect diff");
         assert!(diff.contains("unstaged.txt"));
         assert!(diff.contains("unstaged"));
+    }
+
+    #[test]
+    fn collect_workspace_diff_for_paths_filters_staged_changes() {
+        let (root, repo) = create_temp_repo();
+        fs::write(root.join("selected.txt"), "selected\n").expect("write selected file");
+        fs::write(root.join("excluded.txt"), "excluded\n").expect("write excluded file");
+        let mut index = repo.index().expect("index");
+        index
+            .add_path(Path::new("selected.txt"))
+            .expect("add selected path");
+        index
+            .add_path(Path::new("excluded.txt"))
+            .expect("add excluded path");
+        index.write().expect("write index");
+
+        let diff = collect_workspace_diff_for_paths(&root, &["selected.txt".to_string()])
+            .expect("collect selected diff");
+        assert!(diff.contains("selected.txt"));
+        assert!(diff.contains("selected"));
+        assert!(!diff.contains("excluded.txt"));
+        assert!(!diff.contains("excluded"));
+    }
+
+    #[test]
+    fn collect_workspace_diff_for_paths_filters_workdir_changes() {
+        let (root, _repo) = create_temp_repo();
+        fs::write(root.join("selected.txt"), "selected\n").expect("write selected file");
+        fs::write(root.join("excluded.txt"), "excluded\n").expect("write excluded file");
+
+        let diff = collect_workspace_diff_for_paths(&root, &["selected.txt".to_string()])
+            .expect("collect selected diff");
+        assert!(diff.contains("selected.txt"));
+        assert!(diff.contains("selected"));
+        assert!(!diff.contains("excluded.txt"));
+        assert!(!diff.contains("excluded"));
     }
 
     #[test]

--- a/src/features/app/hooks/useGitCommitController.test.tsx
+++ b/src/features/app/hooks/useGitCommitController.test.tsx
@@ -6,7 +6,12 @@ import { useGitCommitController } from "./useGitCommitController";
 
 const mockCommitGit = vi.fn<(workspaceId: string, message: string) => Promise<void>>();
 const mockGenerateCommitMessageWithEngine = vi.fn<
-  (workspaceId: string, language?: "zh" | "en", engine?: "codex" | "claude" | "gemini" | "opencode") => Promise<string>
+  (
+    workspaceId: string,
+    language?: "zh" | "en",
+    engine?: "codex" | "claude" | "gemini" | "opencode",
+    selectedPaths?: string[],
+  ) => Promise<string>
 >();
 const mockPushGit = vi.fn<(workspaceId: string) => Promise<void>>();
 const mockSyncGit = vi.fn<(workspaceId: string) => Promise<void>>();
@@ -25,7 +30,8 @@ vi.mock("../../../services/tauri", () => ({
     workspaceId: string,
     language?: "zh" | "en",
     engine?: "codex" | "claude" | "gemini" | "opencode",
-  ) => mockGenerateCommitMessageWithEngine(workspaceId, language, engine),
+    selectedPaths?: string[],
+  ) => mockGenerateCommitMessageWithEngine(workspaceId, language, engine, selectedPaths),
   pushGit: (workspaceId: string) => mockPushGit(workspaceId),
   syncGit: (workspaceId: string) => mockSyncGit(workspaceId),
   stageGitFile: (workspaceId: string, path: string) => mockStageGitFile(workspaceId, path),
@@ -121,6 +127,25 @@ describe("useGitCommitController", () => {
     expect(refreshGitStatus).toHaveBeenCalledTimes(1);
     expect(refreshGitLog).toHaveBeenCalledTimes(1);
     expect(result.current.commitMessage).toBe("");
+  });
+
+  it("passes selected paths to AI commit message generation", async () => {
+    const { result } = createController({
+      stagedFiles: [{ path: "src/selected.ts", status: "M", additions: 1, deletions: 0 }],
+      unstagedFiles: [{ path: "src/excluded.ts", status: "M", additions: 1, deletions: 0 }],
+    });
+
+    await act(async () => {
+      await result.current.onGenerateCommitMessage("en", "claude", ["src/selected.ts"]);
+    });
+
+    expect(mockGenerateCommitMessageWithEngine).toHaveBeenCalledWith(
+      "ws-1",
+      "en",
+      "claude",
+      ["src/selected.ts"],
+    );
+    expect(result.current.commitMessage).toBe("feat: generated");
   });
 
   it("allows commit-and-push and commit-and-sync only when staged files exist", async () => {

--- a/src/features/app/hooks/useGitCommitController.ts
+++ b/src/features/app/hooks/useGitCommitController.ts
@@ -43,6 +43,7 @@ type GitCommitController = {
   onGenerateCommitMessage: (
     language?: CommitMessageLanguage,
     engine?: CommitMessageEngine,
+    selectedPaths?: string[],
   ) => Promise<void>;
   onCommit: (selectedPaths?: string[]) => Promise<void>;
   onCommitAndPush: (selectedPaths?: string[]) => Promise<void>;
@@ -173,6 +174,7 @@ export function useGitCommitController({
   const handleGenerateCommitMessage = useCallback(async (
     language: CommitMessageLanguage = "zh",
     engine: CommitMessageEngine = "codex",
+    selectedPaths?: string[],
   ) => {
     if (!activeWorkspace || commitMessageLoading) {
       return;
@@ -181,7 +183,7 @@ export function useGitCommitController({
     setCommitMessageLoading(true);
     setCommitMessageError(null);
     try {
-      const message = await generateCommitMessageWithEngine(workspaceId, language, engine);
+      const message = await generateCommitMessageWithEngine(workspaceId, language, engine, selectedPaths);
       if (!shouldApplyCommitMessage(activeWorkspaceIdRef.current, workspaceId)) {
         return;
       }

--- a/src/features/git-history/components/GitHistoryWorktreePanel.test.tsx
+++ b/src/features/git-history/components/GitHistoryWorktreePanel.test.tsx
@@ -6,7 +6,12 @@ import { GitHistoryWorktreePanel } from "./GitHistoryWorktreePanel";
 const mockGetGitStatus = vi.fn<(workspaceId: string) => Promise<unknown>>();
 const mockCommitGit = vi.fn<(workspaceId: string, message: string) => Promise<void>>();
 const mockGenerateCommitMessage = vi.fn<
-  (workspaceId: string, language?: "zh" | "en", engine?: "codex" | "claude" | "gemini" | "opencode") => Promise<string>
+  (
+    workspaceId: string,
+    language?: "zh" | "en",
+    engine?: "codex" | "claude" | "gemini" | "opencode",
+    selectedPaths?: string[],
+  ) => Promise<string>
 >();
 const mockStageGitFile = vi.fn<(workspaceId: string, path: string) => Promise<void>>();
 const mockStageGitAll = vi.fn<(workspaceId: string) => Promise<void>>();
@@ -63,7 +68,11 @@ vi.mock("../../../services/tauri", () => ({
     workspaceId: string,
     language?: "zh" | "en",
     engine?: "codex" | "claude" | "gemini" | "opencode",
-  ) => mockGenerateCommitMessage(workspaceId, language, engine),
+    selectedPaths?: string[],
+  ) =>
+    selectedPaths
+      ? mockGenerateCommitMessage(workspaceId, language, engine, selectedPaths)
+      : mockGenerateCommitMessage(workspaceId, language, engine),
   getGitStatus: (workspaceId: string) => mockGetGitStatus(workspaceId),
   revertGitAll: vi.fn(async () => undefined),
   revertGitFile: vi.fn(async () => undefined),

--- a/src/features/git/components/GitDiffPanel.test.tsx
+++ b/src/features/git/components/GitDiffPanel.test.tsx
@@ -253,6 +253,35 @@ describe("GitDiffPanel", () => {
     });
   });
 
+  it("passes selected commit paths when generating commit message", async () => {
+    mockMenuPopup
+      .mockImplementationOnce(async (items) => {
+        const claudeItem = items.find((item) => item.text === "Use Claude engine");
+        await claudeItem?.action?.();
+      })
+      .mockImplementationOnce(async (items) => {
+        const chineseItem = items.find((item) => item.text === "Generate Chinese commit message");
+        await chineseItem?.action?.();
+      });
+    const onGenerateCommitMessage = vi.fn();
+
+    render(
+      <GitDiffPanel
+        {...baseProps}
+        onGenerateCommitMessage={onGenerateCommitMessage}
+        stagedFiles={[{ path: "src/selected.ts", status: "M", additions: 1, deletions: 0 }]}
+        unstagedFiles={[{ path: "src/excluded.ts", status: "M", additions: 1, deletions: 0 }]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Toggle commit section" }));
+    fireEvent.click(screen.getByRole("button", { name: "Generate commit message" }));
+
+    await waitFor(() => {
+      expect(onGenerateCommitMessage).toHaveBeenCalledWith("zh", "claude", ["src/selected.ts"]);
+    });
+  });
+
   it("shows spinning engine icon while generating commit message", () => {
     render(
       <GitDiffPanel

--- a/src/features/git/components/GitDiffPanel.tsx
+++ b/src/features/git/components/GitDiffPanel.tsx
@@ -149,6 +149,7 @@ type GitDiffPanelProps = {
   onGenerateCommitMessage?: (
     language?: CommitMessageLanguage,
     engine?: CommitMessageEngine,
+    selectedPaths?: string[],
   ) => void | Promise<void>;
   // Git operations
   onCommit?: (selectedPaths?: string[]) => void | Promise<void>;
@@ -1704,14 +1705,22 @@ export function GitDiffPanel({
           text: t("git.generateCommitMessageChinese"),
           action: async () => {
             setCommitMessageMenuEngine(engine);
-            await onGenerateCommitMessage("zh", engine);
+            if (selectedCommitPaths.length > 0) {
+              await onGenerateCommitMessage("zh", engine, selectedCommitPaths);
+            } else {
+              await onGenerateCommitMessage("zh", engine);
+            }
           },
         }),
         await MenuItem.new({
           text: t("git.generateCommitMessageEnglish"),
           action: async () => {
             setCommitMessageMenuEngine(engine);
-            await onGenerateCommitMessage("en", engine);
+            if (selectedCommitPaths.length > 0) {
+              await onGenerateCommitMessage("en", engine, selectedCommitPaths);
+            } else {
+              await onGenerateCommitMessage("en", engine);
+            }
           },
         }),
       ];
@@ -1719,7 +1728,14 @@ export function GitDiffPanel({
       const window = getCurrentWindow();
       await menu.popup(position, window);
     },
-    [canGenerateCommitMessage, commitLoading, commitMessageLoading, onGenerateCommitMessage, t],
+    [
+      canGenerateCommitMessage,
+      commitLoading,
+      commitMessageLoading,
+      onGenerateCommitMessage,
+      selectedCommitPaths,
+      t,
+    ],
   );
   const showCommitMessageEngineMenu = useCallback(
     async (event: ReactMouseEvent<HTMLButtonElement>) => {

--- a/src/features/layout/hooks/useLayoutNodes.tsx
+++ b/src/features/layout/hooks/useLayoutNodes.tsx
@@ -456,6 +456,7 @@ type LayoutNodesOptions = {
   onGenerateCommitMessage: (
     language?: "zh" | "en",
     engine?: "codex" | "claude" | "gemini" | "opencode",
+    selectedPaths?: string[],
   ) => void | Promise<void>;
   onCommit?: (selectedPaths?: string[]) => void | Promise<void>;
   onCommitAndPush?: (selectedPaths?: string[]) => void | Promise<void>;

--- a/src/services/tauri.ts
+++ b/src/services/tauri.ts
@@ -1841,19 +1841,19 @@ export async function deleteOpenCodeSession(workspaceId: string, sessionId: stri
 export type CommitMessageLanguage = "zh" | "en";
 export type CommitMessageEngine = EngineType;
 
-export async function getCommitMessagePrompt(workspaceId: string, language: CommitMessageLanguage = "zh"): Promise<string> {
-  return invoke("get_commit_message_prompt", { workspaceId, language });
+export async function getCommitMessagePrompt(workspaceId: string, language: CommitMessageLanguage = "zh", selectedPaths?: string[]): Promise<string> {
+  return invoke("get_commit_message_prompt", { workspaceId, language, selectedPaths });
 }
 
-export async function generateCommitMessage(workspaceId: string, language: CommitMessageLanguage = "zh"): Promise<string> {
-  return invoke("generate_commit_message", { workspaceId, language });
+export async function generateCommitMessage(workspaceId: string, language: CommitMessageLanguage = "zh", selectedPaths?: string[]): Promise<string> {
+  return invoke("generate_commit_message", { workspaceId, language, selectedPaths });
 }
 
-export async function generateCommitMessageWithEngine(workspaceId: string, language: CommitMessageLanguage = "zh", engine: CommitMessageEngine = "codex"): Promise<string> {
+export async function generateCommitMessageWithEngine(workspaceId: string, language: CommitMessageLanguage = "zh", engine: CommitMessageEngine = "codex", selectedPaths?: string[]): Promise<string> {
   if (engine === "codex") {
-    return generateCommitMessage(workspaceId, language);
+    return generateCommitMessage(workspaceId, language, selectedPaths);
   }
-  const prompt = await getCommitMessagePrompt(workspaceId, language);
+  const prompt = await getCommitMessagePrompt(workspaceId, language, selectedPaths);
   const response = await engineSendMessageSync(workspaceId, {
     text: prompt,
     engine,


### PR DESCRIPTION
## Summary

Fixes #467.

- Pass selected commit paths from `GitDiffPanel` into AI commit message generation.
- Thread `selectedPaths` through the Tauri service for Codex and non-Codex engines.
- Filter backend staged/worktree diffs by git pathspec when selected paths are supplied.

## Spec / Task

- OpenSpec change: `openspec/changes/fix-selected-commit-message-scope`
- Trellis task: `.trellis/tasks/04-30-fix-selected-commit-message-scope`

## Verification

- `npm exec vitest -- run src/features/git/components/GitDiffPanel.test.tsx src/features/app/hooks/useGitCommitController.test.tsx src/features/git-history/components/GitHistoryWorktreePanel.test.tsx`
- `cargo test --manifest-path src-tauri/Cargo.toml collect_workspace_diff_for_paths`
- `npm run typecheck`
- `npm exec eslint -- src/services/tauri.ts src/features/git/components/GitDiffPanel.tsx src/features/app/hooks/useGitCommitController.ts src/features/layout/hooks/useLayoutNodes.tsx src/features/git/components/GitDiffPanel.test.tsx src/features/app/hooks/useGitCommitController.test.tsx src/features/git-history/components/GitHistoryWorktreePanel.test.tsx`
- `git diff --check`

## Not Run

- `openspec validate fix-selected-commit-message-scope --strict`: `openspec` CLI is not available in this local PATH.