### PR TITLE
fix(composer): 刷新 Claude 配置后使用最新模型标签

### DIFF
--- a/.trellis/tasks/05-01-fix-claude-model-refresh-stale-mapping/prd.md
+++ b/.trellis/tasks/05-01-fix-claude-model-refresh-stale-mapping/prd.md
@@ -1,0 +1,21 @@
+# Fix stale Claude model label after config refresh
+
+## Background
+
+GitHub issue #436 asks for a manual refresh path so changes in Claude Code `settings.json` can be read immediately. The main refresh UI already exists in the composer model selector, but `ModelSelect` can still show an old Claude mapping because it reads `CLAUDE_MODEL_MAPPING` from localStorage once and gives that value priority over refreshed labels from the parent model catalog.
+
+## Goal
+
+After the user clicks `Refresh Config`, the model selector should display the refreshed Claude settings label delivered by the parent catalog, not a stale selector-local mapping.
+
+## Acceptance Criteria
+
+- [x] `ModelSelect` treats the `models` prop label as the refreshed source of truth.
+- [x] Stale `CLAUDE_MODEL_MAPPING` localStorage data cannot override a parent-provided refreshed label.
+- [x] Default label fallback and i18n-backed known model labels continue working.
+- [x] Focused regression test covers the stale mapping case.
+- [ ] Verification commands pass before PR publication.
+
+## Linked OpenSpec Change
+
+- `openspec/changes/fix-claude-model-refresh-stale-mapping`

--- a/.trellis/tasks/05-01-fix-claude-model-refresh-stale-mapping/task.json
+++ b/.trellis/tasks/05-01-fix-claude-model-refresh-stale-mapping/task.json
@@ -1,0 +1,59 @@
+{
+  "id": "fix-claude-model-refresh-stale-mapping",
+  "name": "fix-claude-model-refresh-stale-mapping",
+  "title": "Fix stale Claude model label after config refresh",
+  "description": "Ensure manual Refresh Config reflects the refreshed Claude settings label instead of a stale ModelSelect-local mapping.",
+  "status": "planning",
+  "dev_type": "frontend",
+  "scope": null,
+  "package": null,
+  "priority": "P1",
+  "creator": "watsonk1998",
+  "assignee": "watsonk1998",
+  "createdAt": "2026-05-01",
+  "completedAt": null,
+  "branch": null,
+  "base_branch": "main",
+  "worktree_path": null,
+  "current_phase": 0,
+  "next_action": [
+    {
+      "phase": 1,
+      "action": "brainstorm"
+    },
+    {
+      "phase": 2,
+      "action": "research"
+    },
+    {
+      "phase": 3,
+      "action": "implement"
+    },
+    {
+      "phase": 4,
+      "action": "check"
+    },
+    {
+      "phase": 5,
+      "action": "update-spec"
+    },
+    {
+      "phase": 6,
+      "action": "record-session"
+    }
+  ],
+  "commit": null,
+  "pr_url": null,
+  "subtasks": [],
+  "children": [],
+  "parent": null,
+  "relatedFiles": [
+    "src/features/composer/components/ChatInputBox/selectors/ModelSelect.tsx",
+    "src/features/composer/components/ChatInputBox/selectors/ModelSelect.test.tsx",
+    "openspec/changes/fix-claude-model-refresh-stale-mapping"
+  ],
+  "notes": "Covers GitHub issue #436 follow-up: Refresh Config already exists; this fixes stale selector-local mapping overriding refreshed labels.",
+  "meta": {
+    "githubIssue": 436
+  }
+}

--- a/.trellis/workspace/watsonk1998/index.md
+++ b/.trellis/workspace/watsonk1998/index.md
@@ -1,0 +1,41 @@
+# Workspace Index - watsonk1998
+
+> Journal tracking for AI development sessions.
+
+---
+
+## Current Status
+
+<!-- @@@auto:current-status -->
+- **Active File**: `journal-1.md`
+- **Total Sessions**: 1
+- **Last Active**: 2026-05-01
+<!-- @@@/auto:current-status -->
+
+---
+
+## Active Documents
+
+<!-- @@@auto:active-documents -->
+| File | Lines | Status |
+|------|-------|--------|
+| `journal-1.md` | ~44 | Active |
+<!-- @@@/auto:active-documents -->
+
+---
+
+## Session History
+
+<!-- @@@auto:session-history -->
+| # | Date | Title | Commits | Branch |
+|---|------|-------|---------|--------|
+| 1 | 2026-05-01 | 迁移 Claude 配置刷新 PR 到 0.4.12 分支 | `4a4963830f5a8f86f22c6a681f3babf1eaefc7c0` | `fix/claude-settings-refresh` |
+<!-- @@@/auto:session-history -->
+
+---
+
+## Notes
+
+- Sessions are appended to journal files
+- New journal file created when current exceeds 2000 lines
+- Use `add_session.py` to record sessions

--- a/.trellis/workspace/watsonk1998/journal-1.md
+++ b/.trellis/workspace/watsonk1998/journal-1.md
@@ -1,0 +1,44 @@
+# Journal - watsonk1998 (Part 1)
+
+> AI development session journal
+> Started: 2026-05-01
+
+---
+
+
+## Session 1: 迁移 Claude 配置刷新 PR 到 0.4.12 分支
+
+**Date**: 2026-05-01
+**Task**: 迁移 Claude 配置刷新 PR 到 0.4.12 分支
+**Branch**: `fix/claude-settings-refresh`
+
+### Summary
+
+(Add summary)
+
+### Main Changes
+
+任务目标：按维护者反馈，将 PR #479 从 main 目标迁移到 chore/bump-version-0.4.12 目标分支，同时保持 diff 干净。
+主要改动：基于 origin/chore/bump-version-0.4.12 重建 fix/claude-settings-refresh 分支，并 cherry-pick 原 Claude settings refresh stale label 修复。
+涉及模块：src/features/composer/components/ChatInputBox/selectors/ModelSelect.tsx；src/features/composer/components/ChatInputBox/selectors/ModelSelect.test.tsx；openspec/changes/fix-claude-model-refresh-stale-mapping；.trellis/tasks/05-01-fix-claude-model-refresh-stale-mapping。
+验证结果：npm exec vitest -- run src/features/composer/components/ChatInputBox/selectors/ModelSelect.test.tsx src/features/composer/components/ChatInputBox/ButtonArea.test.tsx 通过；npm exec eslint -- src/features/composer/components/ChatInputBox/selectors/ModelSelect.tsx src/features/composer/components/ChatInputBox/selectors/ModelSelect.test.tsx src/features/composer/components/ChatInputBox/ButtonArea.tsx src/features/composer/components/ChatInputBox/ButtonArea.test.tsx 通过；npm run typecheck 通过；git diff --check origin/chore/bump-version-0.4.12..HEAD 通过。
+后续事项：推送 fork/fix/claude-settings-refresh 后，将 PR #479 base 改为 chore/bump-version-0.4.12。
+
+
+### Git Commits
+
+| Hash | Message |
+|------|---------|
+| `4a4963830f5a8f86f22c6a681f3babf1eaefc7c0` | (see git log) |
+
+### Testing
+
+- [OK] (Add test results)
+
+### Status
+
+[OK] **Completed**
+
+### Next Steps
+
+- None - task complete

--- a/openspec/changes/fix-claude-model-refresh-stale-mapping/.openspec.yaml
+++ b/openspec/changes/fix-claude-model-refresh-stale-mapping/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-01

--- a/openspec/changes/fix-claude-model-refresh-stale-mapping/design.md
+++ b/openspec/changes/fix-claude-model-refresh-stale-mapping/design.md
@@ -1,0 +1,29 @@
+## Context
+
+Composer 模型选择器的手动刷新链路已经在父级完成：`ButtonArea` 解析当前 provider，`app-shell` / engine controller 负责刷新当前 provider 的 model catalog，再把刷新后的 `models` 传给 `ModelSelect`。
+
+这次修复的缺口在 UI source of truth。`ModelSelect` 之前为了显示 Claude settings mapping，会在组件内读取并缓存 localStorage。该缓存只在 mount 时建立，既不会随 `Refresh Config` 重新读取，也会优先覆盖父级传入的 refreshed label。
+
+## Decision
+
+`ModelSelect` 不再读取 `CLAUDE_MODEL_MAPPING`。刷新后的 model label 由父级 model catalog 负责提供，selector 只做展示、选择和 footer action 交互。
+
+## Rationale
+
+- 符合 component guideline：`ModelSelect` 是 presentational component，runtime/config orchestration 留在父级。
+- 符合 state guideline：同一份 model label 不在 component、localStorage、engine catalog 多处维护事实源。
+- 避免为 `Refresh Config` 再补一套 localStorage event / storage listener，降低竞态和 stale cache 风险。
+
+## Alternatives
+
+| 方案 | 结论 | 原因 |
+|---|---|---|
+| 在 `ModelSelect` 里监听 localStorage / custom storage event | 不采用 | 会继续让 selector 持有第二份 source of truth，并复制父级 refresh 责任 |
+| 点击刷新后强制 remount `ModelSelect` | 不采用 | 只能绕过当前 stale cache，不能修复 source-of-truth 边界 |
+| 父级传入 refreshed `models`，selector 信任该 label | 采用 | 变更最小，边界清晰，测试可直接覆盖 |
+
+## Validation
+
+- 新增 focused regression test：旧 localStorage mapping 不覆盖 parent-provided refreshed label。
+- 继续运行 `ModelSelect` / `ButtonArea` focused tests，确认 footer action 行为不回退。
+- 运行 typecheck、targeted eslint 和 diff whitespace check。

--- a/openspec/changes/fix-claude-model-refresh-stale-mapping/proposal.md
+++ b/openspec/changes/fix-claude-model-refresh-stale-mapping/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+`add-model-selector-config-actions` 已经把 `Refresh Config` 接入 composer 模型选择器，用户可以在编辑 `~/.claude/settings.json` 后手动刷新当前 provider 的模型 catalog。
+
+但 `ModelSelect` 仍会在 mount 时从 localStorage 读取一次 `CLAUDE_MODEL_MAPPING`，并优先使用这份缓存值作为 Claude 模型显示名。这样会造成一个状态漂移：父级已经刷新出新的 settings label，selector 仍可能继续显示旧的 localStorage mapping，用户看起来就像手动刷新没有生效。
+
+## What Changes
+
+- 让 `ModelSelect` 保持 presentational，只信任父级传入的 `models` catalog label。
+- 移除 selector 内部对 `CLAUDE_MODEL_MAPPING` 的一次性读取和缓存。
+- 增加回归测试，覆盖 stale localStorage mapping 不得覆盖刷新后的 parent-provided label。
+
+## Scope
+
+- Frontend only:
+  - `src/features/composer/components/ChatInputBox/selectors/ModelSelect.tsx`
+  - `src/features/composer/components/ChatInputBox/selectors/ModelSelect.test.tsx`
+- 不新增 runtime command。
+- 不改变 `Refresh Config` 的 provider 路由和 engine refresh 行为。
+- 不改变 Claude settings 文件格式。
+
+## Acceptance
+
+- 当 localStorage 中存在旧 Claude model mapping，且父级 `models` prop 已传入新的 label 时，selector MUST 显示新的 parent-provided label。
+- `ModelSelect` MUST 不再把旧 localStorage mapping 作为模型显示名 source of truth。
+- 既有默认模型 i18n fallback 继续保持。
+- `Refresh Config` 已有按钮与 loading 行为继续通过现有 tests。

--- a/openspec/changes/fix-claude-model-refresh-stale-mapping/specs/composer-model-selector-config-actions/spec.md
+++ b/openspec/changes/fix-claude-model-refresh-stale-mapping/specs/composer-model-selector-config-actions/spec.md
@@ -1,0 +1,12 @@
+## ADDED Requirements
+
+### Requirement: Model Selector MUST Render Refreshed Labels From Parent Catalog
+
+The model selector MUST treat the `models` prop as the current source of truth for visible model labels after provider config refresh.
+
+#### Scenario: refreshed Claude settings label replaces stale local mapping
+- **GIVEN** the selector previously observed a Claude model mapping from `settings.json`
+- **AND** stale mapping data still exists in localStorage
+- **WHEN** the parent model catalog is refreshed with a new label for the same model id
+- **THEN** the selector MUST display the refreshed parent-provided label
+- **AND** it MUST NOT keep showing the stale localStorage mapping value

--- a/openspec/changes/fix-claude-model-refresh-stale-mapping/tasks.md
+++ b/openspec/changes/fix-claude-model-refresh-stale-mapping/tasks.md
@@ -1,0 +1,15 @@
+## 1. Spec
+
+- [x] 明确 stale localStorage mapping 会覆盖 refreshed parent label 的问题边界
+- [x] 定义 selector label source-of-truth contract
+
+## 2. Implementation
+
+- [x] 移除 `ModelSelect` 内部对 `CLAUDE_MODEL_MAPPING` 的读取和 memo cache
+- [x] 保留 default model i18n fallback 与 custom label 展示逻辑
+
+## 3. Tests
+
+- [x] 新增 regression test：stale localStorage mapping 不覆盖 parent-provided refreshed label
+- [x] 运行 focused Vitest / ESLint / typecheck / diff check
+- [x] 记录 OpenSpec CLI 不在 PATH，无法运行 `openspec validate fix-claude-model-refresh-stale-mapping --strict`

--- a/src/features/composer/components/ChatInputBox/selectors/ModelSelect.test.tsx
+++ b/src/features/composer/components/ChatInputBox/selectors/ModelSelect.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { ModelSelect } from "./ModelSelect";
+import { STORAGE_KEYS } from "../../../types/provider";
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
@@ -81,6 +82,27 @@ describe("ModelSelect", () => {
 
     expect(onAddModel).toHaveBeenCalledTimes(1);
     expect(onRefreshConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses refreshed model labels passed by the parent instead of stale localStorage mapping", () => {
+    window.localStorage.setItem(
+      STORAGE_KEYS.CLAUDE_MODEL_MAPPING,
+      JSON.stringify({ sonnet: "old-settings-model" }),
+    );
+
+    render(
+      <ModelSelect
+        value="claude-sonnet-4-6"
+        currentProvider="claude"
+        onChange={vi.fn()}
+        models={[{ id: "claude-sonnet-4-6", label: "new-settings-model" }]}
+      />,
+    );
+
+    const buttonText = screen.getByRole("button").textContent ?? "";
+
+    expect(buttonText).toContain("new-settings-model");
+    expect(buttonText).not.toContain("old-settings-model");
   });
 
   it("disables refresh config action while refreshing", () => {

--- a/src/features/composer/components/ChatInputBox/selectors/ModelSelect.tsx
+++ b/src/features/composer/components/ChatInputBox/selectors/ModelSelect.tsx
@@ -4,7 +4,6 @@ import { Claude, Gemini } from '@lobehub/icons';
 import xuanzhonIcon from '../../../../../assets/xuanzhong.svg';
 import { AVAILABLE_MODELS } from '../types';
 import type { ModelInfo } from '../types';
-import { STORAGE_KEYS } from '../../../types/provider';
 import { EngineIcon } from '../../../../engine/components/EngineIcon';
 
 interface ModelSelectProps {
@@ -49,34 +48,6 @@ const MODEL_DESCRIPTION_KEYS: Record<string, string> = {
   'gpt-5.3-codex': 'models.codex.gpt53codex.description',
   'gpt-5.3-codex-spark': 'models.codex.gpt53codexSpark.description',
   'gpt-5.2': 'models.codex.gpt52.description',
-};
-
-/**
- * Maps model IDs to mapping keys for looking up actual model names
- * from the 'claude-model-mapping' localStorage entry.
- * The opus 1M variant uses a separate 'opus_1m' key, falling back to 'opus'.
- */
-const MODEL_ID_TO_MAPPING_KEY: Record<string, string> = {
-  'claude-sonnet-4-6': 'sonnet',
-  'claude-opus-4-6': 'opus',
-  'claude-opus-4-6[1m]': 'opus_1m',
-  'claude-haiku-4-5': 'haiku',
-};
-
-/**
- * Retrieves model mapping from localStorage.
- * Returns format: { main: '', haiku: '', sonnet: '', opus: '' }
- */
-const getModelMapping = (): Record<string, string> => {
-  try {
-    const mappingStr = localStorage.getItem(STORAGE_KEYS.CLAUDE_MODEL_MAPPING);
-    if (mappingStr) {
-      return JSON.parse(mappingStr);
-    }
-  } catch {
-    // ignore parse errors
-  }
-  return {};
 };
 
 /**
@@ -130,22 +101,9 @@ export const ModelSelect = ({
       ? effectiveModels.find(m => m.id === selectedModelValue) ?? null
       : null;
 
-  // Cache model mapping to avoid redundant localStorage reads on every render
-  const modelMapping = useMemo(() => getModelMapping(), []);
-
   const getModelLabel = (model: ModelInfo): string => {
-    // Check model mapping first (from local settings.json or provider config)
-    const mappingKey = MODEL_ID_TO_MAPPING_KEY[model.id];
-    if (mappingKey) {
-      // opus_1m falls back to opus mapping
-      const mappedName = modelMapping[mappingKey]
-        || (mappingKey === 'opus_1m' ? modelMapping['opus'] : undefined);
-      if (mappedName && mappedName.trim()) {
-        return mappedName.trim();
-      }
-    }
-
-    // Fall back to default logic when no mapping is found
+    // The parent owns refreshed provider/model mapping. Keep this selector
+    // presentational so manual config refreshes can update labels immediately.
     const defaultModel = DEFAULT_MODEL_MAP[model.id];
     const labelKey = MODEL_LABEL_KEYS[model.id];
     const hasCustomLabel = defaultModel && model.label && model.label !== defaultModel.label;


### PR DESCRIPTION
## Summary

- Removed the selector-local Claude model mapping cache so refreshed parent model labels become the display source of truth.
- Added a regression test covering stale `CLAUDE_MODEL_MAPPING` data after manual Refresh Config.
- Added OpenSpec/Trellis trace files for the #436 follow-up.

Closes #436

## Verification

- `npm exec vitest -- run src/features/composer/components/ChatInputBox/selectors/ModelSelect.test.tsx src/features/composer/components/ChatInputBox/ButtonArea.test.tsx`
- `npm exec eslint -- src/features/composer/components/ChatInputBox/selectors/ModelSelect.tsx src/features/composer/components/ChatInputBox/selectors/ModelSelect.test.tsx src/features/composer/components/ChatInputBox/ButtonArea.tsx src/features/composer/components/ChatInputBox/ButtonArea.test.tsx`
- `npm run typecheck`
- `git diff --check`

## Not tested

- `openspec validate fix-claude-model-refresh-stale-mapping --strict` because `openspec` is not in PATH even after `source ~/.zshrc`.
