### PR TITLE
fix composer model scoping per thread

### DIFF
--- a/src/app-shell-parts/modelSelection.test.ts
+++ b/src/app-shell-parts/modelSelection.test.ts
@@ -46,6 +46,8 @@ describe("modelSelection", () => {
       getEffectiveSelectedModelId({
         activeEngine: "codex",
         selectedModelId: "codex-alt",
+        activeThreadSelectedModelId: null,
+        hasActiveThread: false,
         engineModelsAsOptions: engineModels,
         engineSelectedModelIdByType: {},
         defaultClaudeModelId: "claude-fallback",
@@ -58,6 +60,8 @@ describe("modelSelection", () => {
       getEffectiveSelectedModelId({
         activeEngine: "claude",
         selectedModelId: "codex-alt",
+        activeThreadSelectedModelId: null,
+        hasActiveThread: false,
         engineModelsAsOptions: [],
         engineSelectedModelIdByType: {},
         defaultClaudeModelId: "claude-fallback",
@@ -73,6 +77,8 @@ describe("modelSelection", () => {
       getEffectiveSelectedModelId({
         activeEngine: "gemini",
         selectedModelId: "codex-alt",
+        activeThreadSelectedModelId: null,
+        hasActiveThread: false,
         engineModelsAsOptions: engineModels,
         engineSelectedModelIdByType,
         defaultClaudeModelId: "claude-fallback",
@@ -88,6 +94,42 @@ describe("modelSelection", () => {
       getEffectiveSelectedModelId({
         activeEngine: "opencode",
         selectedModelId: "codex-alt",
+        activeThreadSelectedModelId: null,
+        hasActiveThread: false,
+        engineModelsAsOptions: engineModels,
+        engineSelectedModelIdByType,
+        defaultClaudeModelId: "claude-fallback",
+      }),
+    ).toBe("engine-default");
+  });
+
+  it("prefers the active thread model over the global engine selection", () => {
+    const engineSelectedModelIdByType: Partial<Record<EngineType, string | null>> = {
+      claude: "engine-default",
+    };
+    expect(
+      getEffectiveSelectedModelId({
+        activeEngine: "claude",
+        selectedModelId: "codex-alt",
+        activeThreadSelectedModelId: "engine-alt",
+        hasActiveThread: true,
+        engineModelsAsOptions: engineModels,
+        engineSelectedModelIdByType,
+        defaultClaudeModelId: "claude-fallback",
+      }),
+    ).toBe("engine-alt");
+  });
+
+  it("ignores the global engine selection for active threads without a stored model", () => {
+    const engineSelectedModelIdByType: Partial<Record<EngineType, string | null>> = {
+      claude: "engine-alt",
+    };
+    expect(
+      getEffectiveSelectedModelId({
+        activeEngine: "claude",
+        selectedModelId: "codex-alt",
+        activeThreadSelectedModelId: null,
+        hasActiveThread: true,
         engineModelsAsOptions: engineModels,
         engineSelectedModelIdByType,
         defaultClaudeModelId: "claude-fallback",

--- a/src/app-shell-parts/modelSelection.ts
+++ b/src/app-shell-parts/modelSelection.ts
@@ -3,6 +3,8 @@ import type { EngineType, ModelOption } from "../types";
 type GetEffectiveSelectedModelIdOptions = {
   activeEngine: EngineType;
   selectedModelId: string | null;
+  activeThreadSelectedModelId: string | null;
+  hasActiveThread: boolean;
   engineModelsAsOptions: ModelOption[];
   engineSelectedModelIdByType: Partial<Record<EngineType, string | null>>;
   defaultClaudeModelId: string;
@@ -50,6 +52,8 @@ export function getNextEngineSelectedModelId({
 export function getEffectiveSelectedModelId({
   activeEngine,
   selectedModelId,
+  activeThreadSelectedModelId,
+  hasActiveThread,
   engineModelsAsOptions,
   engineSelectedModelIdByType,
   defaultClaudeModelId,
@@ -59,9 +63,21 @@ export function getEffectiveSelectedModelId({
   }
   const engineSelection = engineSelectedModelIdByType[activeEngine] ?? null;
   if (engineModelsAsOptions.length === 0) {
+    if (hasActiveThread) {
+      return activeThreadSelectedModelId ?? (activeEngine === "claude" ? defaultClaudeModelId : null);
+    }
     return activeEngine === "claude" ? engineSelection ?? defaultClaudeModelId : engineSelection;
   }
-  return findModelById(engineModelsAsOptions, engineSelection)?.id ?? getDefaultModelId(engineModelsAsOptions);
+  if (hasActiveThread) {
+    return (
+      findModelById(engineModelsAsOptions, activeThreadSelectedModelId)?.id ??
+      getDefaultModelId(engineModelsAsOptions)
+    );
+  }
+  return (
+    findModelById(engineModelsAsOptions, engineSelection)?.id ??
+    getDefaultModelId(engineModelsAsOptions)
+  );
 }
 
 export function getEffectiveReasoningSupported(

--- a/src/app-shell-parts/selectedComposerSession.flow.test.ts
+++ b/src/app-shell-parts/selectedComposerSession.flow.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import type { ComposerSessionSelection } from "./selectedComposerSession";
+import {
+  getThreadComposerSelectionStorageKey,
+  shouldApplyDraftComposerSelectionToThread,
+  shouldMigrateComposerSelectionBetweenThreadIds,
+} from "./selectedComposerSession";
+
+type SessionMap = Record<string, ComposerSessionSelection | null>;
+
+function migrateSelection(
+  state: SessionMap,
+  input: {
+    previousThreadId: string | null;
+    activeThreadId: string | null;
+    previousSessionKey: string | null;
+    activeSessionKey: string | null;
+    resolveCanonicalThreadId: (threadId: string) => string;
+  },
+): SessionMap {
+  if (
+    !shouldMigrateComposerSelectionBetweenThreadIds({
+      ...input,
+      hasSourceSelection:
+        (input.previousSessionKey ? state[input.previousSessionKey] ?? null : null) !== null,
+      hasTargetSelection:
+        (input.activeSessionKey ? state[input.activeSessionKey] ?? null : null) !== null,
+    })
+  ) {
+    return state;
+  }
+  const sourceSessionKey = input.previousSessionKey!;
+  const targetSessionKey = input.activeSessionKey!;
+  return {
+    ...state,
+    [targetSessionKey]: state[sourceSessionKey] ?? null,
+  };
+}
+
+describe("selected composer session flow", () => {
+  it("keeps model and effort after pending -> finalized thread migration", () => {
+    const workspaceId = "ws-frontend";
+    const pendingThreadId = "codex-pending-1001";
+    const finalizedThreadId = "codex:session-abc";
+    const draftSelection: ComposerSessionSelection = {
+      modelId: "gpt-5.4",
+      effort: "high",
+    };
+
+    let selectionBySessionKey: SessionMap = {};
+    let shouldApplyDraftToNextThread = true;
+
+    const pendingSessionKey = getThreadComposerSelectionStorageKey(
+      workspaceId,
+      pendingThreadId,
+    );
+    const pendingCandidate = selectionBySessionKey[pendingSessionKey] ?? null;
+    const shouldApplyToPending = shouldApplyDraftComposerSelectionToThread({
+      candidate: pendingCandidate,
+      shouldApplyDraftToNextThread,
+      draftComposerSelection: draftSelection,
+      activeThreadId: pendingThreadId,
+    });
+    expect(shouldApplyToPending).toBe(true);
+    if (shouldApplyToPending) {
+      selectionBySessionKey[pendingSessionKey] = draftSelection;
+      shouldApplyDraftToNextThread = false;
+    }
+
+    const finalizedSessionKey = getThreadComposerSelectionStorageKey(
+      workspaceId,
+      finalizedThreadId,
+    );
+    selectionBySessionKey = migrateSelection(selectionBySessionKey, {
+      previousThreadId: pendingThreadId,
+      activeThreadId: finalizedThreadId,
+      previousSessionKey: pendingSessionKey,
+      activeSessionKey: finalizedSessionKey,
+      resolveCanonicalThreadId: (threadId) =>
+        threadId === pendingThreadId ? finalizedThreadId : threadId,
+    });
+
+    expect(selectionBySessionKey[finalizedSessionKey]).toEqual(draftSelection);
+    expect(
+      shouldApplyDraftComposerSelectionToThread({
+        candidate: selectionBySessionKey[finalizedSessionKey] ?? null,
+        shouldApplyDraftToNextThread,
+        draftComposerSelection: draftSelection,
+        activeThreadId: finalizedThreadId,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps selections isolated across workspaces even for identical thread ids", () => {
+    const threadId = "codex:session-shared";
+    const workspaceAKey = getThreadComposerSelectionStorageKey("ws-a", threadId);
+    const workspaceBKey = getThreadComposerSelectionStorageKey("ws-b", threadId);
+    const state: SessionMap = {
+      [workspaceAKey]: { modelId: "gpt-5.4", effort: "high" },
+      [workspaceBKey]: { modelId: "gpt-5.5", effort: "medium" },
+    };
+
+    expect(state[workspaceAKey]).toEqual({ modelId: "gpt-5.4", effort: "high" });
+    expect(state[workspaceBKey]).toEqual({ modelId: "gpt-5.5", effort: "medium" });
+  });
+});

--- a/src/app-shell-parts/selectedComposerSession.test.ts
+++ b/src/app-shell-parts/selectedComposerSession.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  getThreadComposerSelectionStorageKey,
+  shouldApplyDraftComposerSelectionToThread,
+  shouldMigrateComposerSelectionBetweenThreadIds,
+  type ComposerSessionSelection,
+} from "./selectedComposerSession";
+
+describe("selectedComposerSession", () => {
+  const identity = (threadId: string) => threadId;
+  const draftSelection: ComposerSessionSelection = {
+    modelId: "gpt-5.4",
+    effort: "high",
+  };
+
+  it("builds a workspace-scoped session key for each thread", () => {
+    expect(getThreadComposerSelectionStorageKey("ws-a", "codex:session-1")).toBe(
+      "selectedModelByThread.ws-a:codex:session-1",
+    );
+    expect(getThreadComposerSelectionStorageKey("ws-b", "codex:session-1")).toBe(
+      "selectedModelByThread.ws-b:codex:session-1",
+    );
+  });
+
+  it("applies a draft selection to the first pending thread", () => {
+    expect(
+      shouldApplyDraftComposerSelectionToThread({
+        candidate: null,
+        shouldApplyDraftToNextThread: true,
+        draftComposerSelection: draftSelection,
+        activeThreadId: "codex-pending-1",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not apply a draft selection to a finalized thread", () => {
+    expect(
+      shouldApplyDraftComposerSelectionToThread({
+        candidate: null,
+        shouldApplyDraftToNextThread: true,
+        draftComposerSelection: draftSelection,
+        activeThreadId: "codex:session-1",
+      }),
+    ).toBe(false);
+  });
+
+  it("migrates a persisted selection from pending to finalized thread ids", () => {
+    expect(
+      shouldMigrateComposerSelectionBetweenThreadIds({
+        previousThreadId: "codex-pending-1",
+        activeThreadId: "codex:session-1",
+        previousSessionKey: "selectedModelByThread.ws-a:codex-pending-1",
+        activeSessionKey: "selectedModelByThread.ws-a:codex:session-1",
+        hasSourceSelection: true,
+        hasTargetSelection: false,
+        resolveCanonicalThreadId: identity,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not migrate across unrelated threads or engines", () => {
+    expect(
+      shouldMigrateComposerSelectionBetweenThreadIds({
+        previousThreadId: "codex:session-1",
+        activeThreadId: "claude:session-2",
+        previousSessionKey: "selectedModelByThread.ws-a:codex:session-1",
+        activeSessionKey: "selectedModelByThread.ws-a:claude:session-2",
+        hasSourceSelection: true,
+        hasTargetSelection: false,
+        resolveCanonicalThreadId: identity,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/app-shell-parts/selectedComposerSession.ts
+++ b/src/app-shell-parts/selectedComposerSession.ts
@@ -1,0 +1,121 @@
+export type ComposerSessionSelection = {
+  modelId: string | null;
+  effort: string | null;
+};
+
+const THREAD_COMPOSER_SELECTION_STORAGE_KEY_PREFIX = "selectedModelByThread.";
+
+function resolveThreadEngine(
+  threadId: string,
+): "claude" | "gemini" | "opencode" | "codex" | null {
+  if (threadId.startsWith("claude:") || threadId.startsWith("claude-pending-")) {
+    return "claude";
+  }
+  if (threadId.startsWith("gemini:") || threadId.startsWith("gemini-pending-")) {
+    return "gemini";
+  }
+  if (threadId.startsWith("opencode:") || threadId.startsWith("opencode-pending-")) {
+    return "opencode";
+  }
+  if (threadId.startsWith("codex:") || threadId.startsWith("codex-pending-")) {
+    return "codex";
+  }
+  return null;
+}
+
+function normalizeNullableString(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function normalizeComposerSessionSelection(
+  value: unknown,
+): ComposerSessionSelection | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  const record = value as Record<string, unknown>;
+  const modelId = normalizeNullableString(record.modelId);
+  const effort = normalizeNullableString(record.effort);
+  if (modelId === null && effort === null) {
+    return null;
+  }
+  return { modelId, effort };
+}
+
+export function getThreadComposerSelectionStorageKey(
+  workspaceId: string | null,
+  threadId: string,
+): string {
+  const workspaceKey =
+    typeof workspaceId === "string" && workspaceId.trim().length > 0
+      ? workspaceId.trim()
+      : "__workspace__unknown__";
+  return `${THREAD_COMPOSER_SELECTION_STORAGE_KEY_PREFIX}${workspaceKey}:${threadId}`;
+}
+
+export function shouldApplyDraftComposerSelectionToThread(input: {
+  candidate: ComposerSessionSelection | null;
+  shouldApplyDraftToNextThread: boolean;
+  draftComposerSelection: ComposerSessionSelection | null;
+  activeThreadId: string | null;
+}): boolean {
+  return Boolean(
+    !input.candidate &&
+      input.shouldApplyDraftToNextThread &&
+      input.draftComposerSelection &&
+      input.activeThreadId &&
+      input.activeThreadId.includes("-pending-"),
+  );
+}
+
+export function shouldMigrateComposerSelectionBetweenThreadIds(input: {
+  previousThreadId: string | null;
+  activeThreadId: string | null;
+  previousSessionKey: string | null;
+  activeSessionKey: string | null;
+  hasSourceSelection: boolean;
+  hasTargetSelection: boolean;
+  resolveCanonicalThreadId: (threadId: string) => string;
+}): boolean {
+  const {
+    previousThreadId,
+    activeThreadId,
+    previousSessionKey,
+    activeSessionKey,
+    hasSourceSelection,
+    hasTargetSelection,
+    resolveCanonicalThreadId,
+  } = input;
+
+  const previousEngine = previousThreadId ? resolveThreadEngine(previousThreadId) : null;
+  const activeEngine = activeThreadId ? resolveThreadEngine(activeThreadId) : null;
+  const hasEngineMismatch =
+    previousEngine !== null && activeEngine !== null && previousEngine !== activeEngine;
+  const hasForwardFinalizeTransition = Boolean(
+    previousThreadId &&
+      activeThreadId &&
+      previousThreadId.includes("-pending-") &&
+      !activeThreadId.includes("-pending-"),
+  );
+  const hasCanonicalMatch = Boolean(
+    previousThreadId &&
+      activeThreadId &&
+      resolveCanonicalThreadId(previousThreadId) === resolveCanonicalThreadId(activeThreadId),
+  );
+
+  return Boolean(
+    previousThreadId &&
+      activeThreadId &&
+      previousThreadId !== activeThreadId &&
+      previousSessionKey &&
+      activeSessionKey &&
+      hasSourceSelection &&
+      !hasTargetSelection &&
+      !hasEngineMismatch &&
+      (hasForwardFinalizeTransition || hasCanonicalMatch),
+  );
+}

--- a/src/app-shell-parts/useAppShellSections.kanban-text.test.ts
+++ b/src/app-shell-parts/useAppShellSections.kanban-text.test.ts
@@ -103,73 +103,61 @@ describe("shouldSyncComposerEngineForKanbanExecution", () => {
 describe("syncKanbanExecutionEngineAndModel", () => {
   it("does not sync global composer engine for background execution", async () => {
     const setActiveEngine = vi.fn(async () => undefined);
-    const setSelectedModelId = vi.fn();
-    const setEngineSelectedModelIdByType = vi.fn();
 
     const result = await syncKanbanExecutionEngineAndModel({
       activate: false,
       engine: "claude",
       modelId: "claude-sonnet-4-5",
       setActiveEngine,
-      setSelectedModelId,
-      setEngineSelectedModelIdByType,
     });
 
     expect(setActiveEngine).not.toHaveBeenCalled();
-    expect(setSelectedModelId).not.toHaveBeenCalled();
-    expect(setEngineSelectedModelIdByType).not.toHaveBeenCalled();
     expect(result).toEqual({
       shouldSyncComposerSelection: false,
       outboundModel: "claude-sonnet-4-5",
+      composerSelection: null,
     });
   });
 
-  it("syncs codex model into composer state for foreground execution", async () => {
+  it("returns a codex composer selection for foreground execution without mutating global state", async () => {
     const setActiveEngine = vi.fn(async () => undefined);
-    const setSelectedModelId = vi.fn();
-    const setEngineSelectedModelIdByType = vi.fn();
 
     const result = await syncKanbanExecutionEngineAndModel({
       activate: true,
       engine: "codex",
       modelId: "gpt-5.4",
       setActiveEngine,
-      setSelectedModelId,
-      setEngineSelectedModelIdByType,
     });
 
     expect(setActiveEngine).toHaveBeenCalledWith("codex");
-    expect(setSelectedModelId).toHaveBeenCalledWith("gpt-5.4");
-    expect(setEngineSelectedModelIdByType).not.toHaveBeenCalled();
     expect(result).toEqual({
       shouldSyncComposerSelection: true,
       outboundModel: undefined,
+      composerSelection: {
+        modelId: "gpt-5.4",
+        effort: null,
+      },
     });
   });
 
-  it("syncs claude model into engine model map for foreground execution", async () => {
+  it("returns a claude composer selection for foreground execution without mutating global state", async () => {
     const setActiveEngine = vi.fn(async () => undefined);
-    const setSelectedModelId = vi.fn();
-    const setEngineSelectedModelIdByType = vi.fn(
-      (updater: (prev: Record<string, string>) => Record<string, string>) =>
-      updater({ claude: "claude-sonnet-3-7", codex: "gpt-5.3-codex" }),
-    );
 
-    await syncKanbanExecutionEngineAndModel({
+    const result = await syncKanbanExecutionEngineAndModel({
       activate: true,
       engine: "claude",
       modelId: "claude-sonnet-4-5",
       setActiveEngine,
-      setSelectedModelId,
-      setEngineSelectedModelIdByType,
     });
 
     expect(setActiveEngine).toHaveBeenCalledWith("claude");
-    expect(setSelectedModelId).not.toHaveBeenCalled();
-    expect(setEngineSelectedModelIdByType).toHaveBeenCalledTimes(1);
-    expect(setEngineSelectedModelIdByType.mock.results[0]?.value).toEqual({
-      claude: "claude-sonnet-4-5",
-      codex: "gpt-5.3-codex",
+    expect(result).toEqual({
+      shouldSyncComposerSelection: true,
+      outboundModel: undefined,
+      composerSelection: {
+        modelId: "claude-sonnet-4-5",
+        effort: null,
+      },
     });
   });
 });

--- a/src/app-shell-parts/useAppShellSections.ts
+++ b/src/app-shell-parts/useAppShellSections.ts
@@ -45,6 +45,7 @@ import { normalizeSharedSessionEngine } from "../features/shared-session/utils/s
 import type { WorkspaceHomeDeleteResult } from "../features/workspaces/components/WorkspaceHome";
 import type { EngineType, MessageSendOptions, WorkspaceInfo } from "../types";
 import type { KanbanContextMode } from "../features/kanban/utils/contextMode";
+import type { ComposerSessionSelection } from "./selectedComposerSession";
 
 const KANBAN_TAG_REGEX = /&@[^\s]+/g;
 const KANBAN_SCHEDULER_INTERVAL_MS = 20_000;
@@ -106,33 +107,39 @@ export async function syncKanbanExecutionEngineAndModel(params: {
   engine: "claude" | "codex";
   modelId?: string | null;
   setActiveEngine: (engine: "claude" | "codex") => Promise<void> | void;
-  setSelectedModelId: (modelId: string) => void;
-  setEngineSelectedModelIdByType: (
-    updater: (prev: Record<string, string>) => Record<string, string>,
-  ) => void;
-}): Promise<{ shouldSyncComposerSelection: boolean; outboundModel?: string }> {
+}): Promise<{
+  shouldSyncComposerSelection: boolean;
+  outboundModel?: string;
+  composerSelection: ComposerSessionSelection | null;
+}> {
   const shouldSyncComposerSelection = shouldSyncComposerEngineForKanbanExecution({
     activate: params.activate,
   });
   if (shouldSyncComposerSelection) {
     await params.setActiveEngine(params.engine);
   }
-  let outboundModel: string | undefined;
-  if (params.modelId) {
-    if (shouldSyncComposerSelection) {
-      if (params.engine === "codex") {
-        params.setSelectedModelId(params.modelId);
-      } else {
-        params.setEngineSelectedModelIdByType((prev) => ({
-          ...prev,
-          [params.engine]: params.modelId,
-        }));
-      }
-    } else {
-      outboundModel = params.modelId;
-    }
+  if (!params.modelId) {
+    return {
+      shouldSyncComposerSelection,
+      outboundModel: undefined,
+      composerSelection: null,
+    };
   }
-  return { shouldSyncComposerSelection, outboundModel };
+  if (!shouldSyncComposerSelection) {
+    return {
+      shouldSyncComposerSelection,
+      outboundModel: params.modelId,
+      composerSelection: null,
+    };
+  }
+  return {
+    shouldSyncComposerSelection,
+    outboundModel: undefined,
+    composerSelection: {
+      modelId: params.modelId,
+      effort: null,
+    },
+  };
 }
 
 function isRewindSupportedThreadId(threadId: string): boolean {
@@ -206,8 +213,8 @@ export function useAppShellSections(ctx: any) {
     clearDraftForThread,
     removeImagesForThread,
     t,
-    setSelectedModelId,
-    setEngineSelectedModelIdByType,
+    persistComposerSelectionForThread,
+    resolveComposerSelectionForThread,
     threadItemsByThread,
     threadStatusById,
     kanbanTasks,
@@ -1062,6 +1069,20 @@ export function useAppShellSections(ctx: any) {
     [kanbanUpdateTask],
   );
 
+  const persistKanbanTaskComposerSelection = useCallback(
+    (workspaceId: string, threadId: string, modelId: string | null | undefined) => {
+      if (!modelId) {
+        return;
+      }
+      const currentSelection = resolveComposerSelectionForThread(workspaceId, threadId);
+      persistComposerSelectionForThread(workspaceId, threadId, {
+        modelId,
+        effort: currentSelection?.effort ?? null,
+      });
+    },
+    [persistComposerSelectionForThread, resolveComposerSelectionForThread],
+  );
+
   const launchKanbanTaskExecution = useCallback(
     async (params: {
       taskId: string;
@@ -1116,14 +1137,13 @@ export function useAppShellSections(ctx: any) {
         await connectWorkspace(workspace);
         const engine = (task.engineType ?? activeEngine) as "claude" | "codex";
         const workspaceThreads = threadsByWorkspace[workspace.id] ?? [];
-        const { outboundModel } = await syncKanbanExecutionEngineAndModel({
-          activate: params.activate,
-          engine,
-          modelId: task.modelId,
-          setActiveEngine,
-          setSelectedModelId,
-          setEngineSelectedModelIdByType,
-        });
+        const { outboundModel, shouldSyncComposerSelection, composerSelection } =
+          await syncKanbanExecutionEngineAndModel({
+            activate: params.activate,
+            engine,
+            modelId: task.modelId,
+            setActiveEngine,
+          });
 
         const shouldForceNewThread = Boolean(params.forceNewThread);
         const canonicalTaskThreadId =
@@ -1163,6 +1183,10 @@ export function useAppShellSections(ctx: any) {
             throw new Error("thread_create_failed");
           }
           kanbanUpdateTask(task.id, { threadId });
+        }
+
+        if (shouldSyncComposerSelection && composerSelection?.modelId) {
+          persistKanbanTaskComposerSelection(workspace.id, threadId, composerSelection.modelId);
         }
 
         const executionStartedAt = Date.now();
@@ -1206,9 +1230,8 @@ export function useAppShellSections(ctx: any) {
       activeEngine,
       threadsByWorkspace,
       setActiveEngine,
-      setSelectedModelId,
-      setEngineSelectedModelIdByType,
       startThreadForWorkspace,
+      persistKanbanTaskComposerSelection,
       kanbanUpdateTask,
       sendUserMessageToThread,
       updateTaskExecution,
@@ -1230,18 +1253,6 @@ export function useAppShellSections(ctx: any) {
       const engine = (task.engineType ?? activeEngine) as "claude" | "codex";
       const workspaceThreads = threadsByWorkspace[workspace.id] ?? [];
       await setActiveEngine(engine);
-
-      // Apply the model that was selected when the task was created
-      if (task.modelId) {
-        if (engine === "codex") {
-          setSelectedModelId(task.modelId);
-        } else {
-          setEngineSelectedModelIdByType((prev) => ({
-            ...prev,
-            [engine]: task.modelId,
-          }));
-        }
-      }
 
       if (task.threadId) {
         let resolvedThreadId =
@@ -1302,6 +1313,7 @@ export function useAppShellSections(ctx: any) {
           resolvedThreadId.startsWith("claude-pending-") ||
           resolvedThreadId.startsWith("opencode-pending-");
         if (canActivateExistingThread) {
+          persistKanbanTaskComposerSelection(workspace.id, resolvedThreadId, task.modelId);
           setActiveThreadId(resolvedThreadId, workspace.id);
           return;
         }
@@ -1310,6 +1322,7 @@ export function useAppShellSections(ctx: any) {
       const threadId = await startThreadForWorkspace(workspace.id, { engine });
       if (threadId) {
         kanbanUpdateTask(task.id, { threadId });
+        persistKanbanTaskComposerSelection(workspace.id, threadId, task.modelId);
         setActiveThreadId(threadId, workspace.id);
       }
     },
@@ -1322,8 +1335,7 @@ export function useAppShellSections(ctx: any) {
       kanbanUpdateTask,
       activeEngine,
       setActiveEngine,
-      setSelectedModelId,
-      setEngineSelectedModelIdByType,
+      persistKanbanTaskComposerSelection,
       threadStatusById,
       threadsByWorkspace,
       kanbanTasks,

--- a/src/app-shell-parts/useSelectedComposerSession.test.tsx
+++ b/src/app-shell-parts/useSelectedComposerSession.test.tsx
@@ -1,0 +1,152 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useSelectedComposerSession } from "./useSelectedComposerSession";
+
+type Store = Record<string, unknown>;
+
+const { composerStore, getClientStoreSync, writeClientStoreValue } = vi.hoisted(() => {
+  const composerStore: Store = {};
+  return {
+    composerStore,
+    getClientStoreSync: vi.fn((store: string, key: string) => {
+      if (store !== "composer") {
+        return undefined;
+      }
+      return composerStore[key];
+    }),
+    writeClientStoreValue: vi.fn((store: string, key: string, value: unknown) => {
+      if (store === "composer") {
+        composerStore[key] = value;
+      }
+    }),
+  };
+});
+
+vi.mock("../services/clientStorage", () => ({
+  getClientStoreSync,
+  writeClientStoreValue,
+}));
+
+describe("useSelectedComposerSession", () => {
+  beforeEach(() => {
+    Object.keys(composerStore).forEach((key) => delete composerStore[key]);
+    getClientStoreSync.mockClear();
+    writeClientStoreValue.mockClear();
+  });
+
+  it("applies a draft selection to a pending thread and migrates it to the finalized thread", async () => {
+    type HookProps = {
+      activeWorkspaceId: string | null;
+      activeThreadId: string | null;
+      resolveCanonicalThreadId: (threadId: string) => string;
+    };
+
+    const initialProps: HookProps = {
+      activeWorkspaceId: "ws-a",
+      activeThreadId: null,
+      resolveCanonicalThreadId: (threadId: string) => threadId,
+    };
+
+    const { result, rerender } = renderHook(
+      ({ activeWorkspaceId, activeThreadId, resolveCanonicalThreadId }: HookProps) =>
+        useSelectedComposerSession({
+          activeWorkspaceId,
+          activeThreadId,
+          resolveCanonicalThreadId,
+        }),
+      {
+        initialProps,
+      },
+    );
+
+    act(() => {
+      result.current.handleSelectComposerSelection({
+        modelId: "gpt-5.4",
+        effort: "high",
+      });
+    });
+
+    expect(result.current.selectedComposerSelection).toEqual({
+      modelId: "gpt-5.4",
+      effort: "high",
+    });
+    expect(writeClientStoreValue).not.toHaveBeenCalled();
+
+    rerender({
+      activeWorkspaceId: "ws-a",
+      activeThreadId: "codex-pending-1",
+      resolveCanonicalThreadId: (threadId: string) => threadId,
+    });
+
+    await waitFor(() => {
+      expect(result.current.selectedComposerSelection).toEqual({
+        modelId: "gpt-5.4",
+        effort: "high",
+      });
+    });
+    expect(writeClientStoreValue).toHaveBeenCalledWith(
+      "composer",
+      "selectedModelByThread.ws-a:codex-pending-1",
+      { modelId: "gpt-5.4", effort: "high" },
+    );
+
+    rerender({
+      activeWorkspaceId: "ws-a",
+      activeThreadId: "codex:session-1",
+      resolveCanonicalThreadId: (threadId: string) =>
+        threadId === "codex-pending-1" ? "codex:session-1" : threadId,
+    });
+
+    await waitFor(() => {
+      expect(result.current.selectedComposerSelection).toEqual({
+        modelId: "gpt-5.4",
+        effort: "high",
+      });
+    });
+    expect(writeClientStoreValue).toHaveBeenCalledWith(
+      "composer",
+      "selectedModelByThread.ws-a:codex:session-1",
+      { modelId: "gpt-5.4", effort: "high" },
+    );
+  });
+
+  it("keeps identical thread ids isolated across workspaces", async () => {
+    composerStore["selectedModelByThread.ws-a:codex:session-1"] = {
+      modelId: "gpt-5.4",
+      effort: "high",
+    };
+    composerStore["selectedModelByThread.ws-b:codex:session-1"] = {
+      modelId: "gpt-5.5",
+      effort: "medium",
+    };
+
+    const { result, rerender } = renderHook(
+      ({ activeWorkspaceId }: { activeWorkspaceId: string | null }) =>
+        useSelectedComposerSession({
+          activeWorkspaceId,
+          activeThreadId: "codex:session-1",
+          resolveCanonicalThreadId: (threadId: string) => threadId,
+        }),
+      {
+        initialProps: { activeWorkspaceId: "ws-a" },
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.selectedComposerSelection).toEqual({
+        modelId: "gpt-5.4",
+        effort: "high",
+      });
+    });
+
+    rerender({ activeWorkspaceId: "ws-b" });
+
+    await waitFor(() => {
+      expect(result.current.selectedComposerSelection).toEqual({
+        modelId: "gpt-5.5",
+        effort: "medium",
+      });
+    });
+  });
+});

--- a/src/app-shell-parts/useSelectedComposerSession.ts
+++ b/src/app-shell-parts/useSelectedComposerSession.ts
@@ -1,0 +1,308 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { MutableRefObject } from "react";
+import { getClientStoreSync, writeClientStoreValue } from "../services/clientStorage";
+import type { DebugEntry } from "../types";
+import {
+  getThreadComposerSelectionStorageKey,
+  normalizeComposerSessionSelection,
+  shouldApplyDraftComposerSelectionToThread,
+  shouldMigrateComposerSelectionBetweenThreadIds,
+  type ComposerSessionSelection,
+} from "./selectedComposerSession";
+
+function selectionsEqual(
+  left: ComposerSessionSelection | null,
+  right: ComposerSessionSelection | null,
+): boolean {
+  if (left === right) {
+    return true;
+  }
+  if (!left || !right) {
+    return false;
+  }
+  return left.modelId === right.modelId && left.effort === right.effort;
+}
+
+function readStoredThreadComposerSelectionEntryBySessionKey(
+  sessionKey: string,
+): { exists: boolean; value: ComposerSessionSelection | null } {
+  const raw = getClientStoreSync<unknown>("composer", sessionKey);
+  if (raw === undefined) {
+    return {
+      exists: false,
+      value: null,
+    };
+  }
+  return {
+    exists: true,
+    value: normalizeComposerSessionSelection(raw),
+  };
+}
+
+type UseSelectedComposerSessionOptions = {
+  activeThreadId: string | null;
+  activeWorkspaceId: string | null;
+  resolveCanonicalThreadId: (threadId: string) => string;
+  onDebug?: (entry: DebugEntry) => void;
+};
+
+type UseSelectedComposerSessionResult = {
+  selectedComposerSelection: ComposerSessionSelection | null;
+  selectedComposerSelectionRef: MutableRefObject<ComposerSessionSelection | null>;
+  handleSelectComposerSelection: (selection: ComposerSessionSelection | null) => void;
+  persistComposerSelectionForThread: (
+    workspaceId: string | null,
+    threadId: string | null,
+    selection: ComposerSessionSelection | null,
+  ) => void;
+  reloadSelectedComposerSelection: () => void;
+  resolveComposerSelectionForThread: (
+    workspaceId: string | null,
+    threadId: string | null,
+  ) => ComposerSessionSelection | null;
+};
+
+export function useSelectedComposerSession({
+  activeThreadId,
+  activeWorkspaceId,
+  resolveCanonicalThreadId,
+}: UseSelectedComposerSessionOptions): UseSelectedComposerSessionResult {
+  const [selectedComposerSelectionBySessionKey, setSelectedComposerSelectionBySessionKey] =
+    useState<Record<string, ComposerSessionSelection | null>>({});
+  const [draftComposerSelection, setDraftComposerSelection] =
+    useState<ComposerSessionSelection | null>(null);
+  const [selectedComposerSelection, setSelectedComposerSelection] =
+    useState<ComposerSessionSelection | null>(null);
+  const selectedComposerSelectionRef = useRef<ComposerSessionSelection | null>(null);
+  const draftComposerSelectionWorkspaceIdRef = useRef<string | null>(null);
+  const shouldApplyDraftToNextThreadRef = useRef(false);
+
+  const resolveSelectedComposerSessionKey = useCallback(
+    (workspaceId: string | null, threadId: string | null): string | null => {
+      if (!threadId) {
+        return null;
+      }
+      return getThreadComposerSelectionStorageKey(workspaceId, threadId);
+    },
+    [],
+  );
+
+  const writeSelectionForSessionKey = useCallback(
+    (sessionKey: string, selection: ComposerSessionSelection | null) => {
+      setSelectedComposerSelectionBySessionKey((prev) => {
+        if (selectionsEqual(prev[sessionKey] ?? null, selection)) {
+          return prev;
+        }
+        return {
+          ...prev,
+          [sessionKey]: selection,
+        };
+      });
+      writeClientStoreValue("composer", sessionKey, selection);
+    },
+    [],
+  );
+
+  const persistComposerSelectionForThread = useCallback(
+    (
+      workspaceId: string | null,
+      threadId: string | null,
+      selection: ComposerSessionSelection | null,
+    ) => {
+      if (!threadId) {
+        return;
+      }
+      const sessionKey = resolveSelectedComposerSessionKey(workspaceId, threadId);
+      if (!sessionKey) {
+        return;
+      }
+      const normalized = normalizeComposerSessionSelection(selection);
+      writeSelectionForSessionKey(sessionKey, normalized);
+    },
+    [resolveSelectedComposerSessionKey, writeSelectionForSessionKey],
+  );
+
+  const handleSelectComposerSelection = useCallback(
+    (selection: ComposerSessionSelection | null) => {
+      const normalized = normalizeComposerSessionSelection(selection);
+      selectedComposerSelectionRef.current = normalized;
+      setSelectedComposerSelection(normalized);
+      if (!activeThreadId) {
+        setDraftComposerSelection(normalized);
+        draftComposerSelectionWorkspaceIdRef.current = activeWorkspaceId ?? null;
+        shouldApplyDraftToNextThreadRef.current = Boolean(normalized);
+        return;
+      }
+      shouldApplyDraftToNextThreadRef.current = false;
+      persistComposerSelectionForThread(activeWorkspaceId, activeThreadId, normalized);
+    },
+    [activeThreadId, activeWorkspaceId, persistComposerSelectionForThread],
+  );
+
+  const resolveComposerSelectionForThread = useCallback(
+    (workspaceId: string | null, threadId: string | null): ComposerSessionSelection | null => {
+      const sessionKey = resolveSelectedComposerSessionKey(workspaceId, threadId);
+      if (!sessionKey) {
+        return null;
+      }
+      if (Object.prototype.hasOwnProperty.call(selectedComposerSelectionBySessionKey, sessionKey)) {
+        return selectedComposerSelectionBySessionKey[sessionKey] ?? null;
+      }
+      return readStoredThreadComposerSelectionEntryBySessionKey(sessionKey).value;
+    },
+    [resolveSelectedComposerSessionKey, selectedComposerSelectionBySessionKey],
+  );
+
+  const reloadSelectedComposerSelection = useCallback(() => {
+    if (!activeThreadId) {
+      const draftForActiveWorkspace =
+        draftComposerSelectionWorkspaceIdRef.current === (activeWorkspaceId ?? null)
+          ? draftComposerSelection
+          : null;
+      selectedComposerSelectionRef.current = draftForActiveWorkspace;
+      setSelectedComposerSelection(draftForActiveWorkspace);
+      return;
+    }
+
+    const sessionKey = resolveSelectedComposerSessionKey(activeWorkspaceId, activeThreadId);
+    if (!sessionKey) {
+      selectedComposerSelectionRef.current = null;
+      setSelectedComposerSelection(null);
+      return;
+    }
+
+    let candidate: ComposerSessionSelection | null = null;
+    let hasCandidate = false;
+    if (Object.prototype.hasOwnProperty.call(selectedComposerSelectionBySessionKey, sessionKey)) {
+      candidate = selectedComposerSelectionBySessionKey[sessionKey] ?? null;
+      hasCandidate = true;
+    } else {
+      const stored = readStoredThreadComposerSelectionEntryBySessionKey(sessionKey);
+      candidate = stored.value;
+      hasCandidate = stored.exists;
+      const shouldApplyDraftSelection =
+        draftComposerSelectionWorkspaceIdRef.current === (activeWorkspaceId ?? null) &&
+        shouldApplyDraftComposerSelectionToThread({
+          candidate,
+          shouldApplyDraftToNextThread: shouldApplyDraftToNextThreadRef.current,
+          draftComposerSelection,
+          activeThreadId,
+        });
+      if (shouldApplyDraftSelection) {
+        candidate = draftComposerSelection;
+        hasCandidate = true;
+        shouldApplyDraftToNextThreadRef.current = false;
+        writeClientStoreValue("composer", sessionKey, candidate);
+      }
+      if (hasCandidate) {
+        setSelectedComposerSelectionBySessionKey((prev) => ({
+          ...prev,
+          [sessionKey]: candidate ?? null,
+        }));
+      }
+    }
+
+    selectedComposerSelectionRef.current = candidate;
+    setSelectedComposerSelection(candidate);
+  }, [
+    activeThreadId,
+    activeWorkspaceId,
+    draftComposerSelection,
+    resolveSelectedComposerSessionKey,
+    selectedComposerSelectionBySessionKey,
+  ]);
+
+  const previousThreadIdForDraftCarryRef = useRef<string | null>(activeThreadId ?? null);
+  useEffect(() => {
+    const previousThreadId = previousThreadIdForDraftCarryRef.current;
+    if (previousThreadId && !activeThreadId) {
+      const latestSelection = selectedComposerSelectionRef.current;
+      setDraftComposerSelection(latestSelection ?? null);
+      draftComposerSelectionWorkspaceIdRef.current = activeWorkspaceId ?? null;
+      shouldApplyDraftToNextThreadRef.current = Boolean(latestSelection);
+    }
+    previousThreadIdForDraftCarryRef.current = activeThreadId ?? null;
+  }, [activeThreadId, activeWorkspaceId]);
+
+  const previousThreadIdRef = useRef<string | null>(null);
+  const previousThreadWorkspaceIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    const previousThreadId = previousThreadIdRef.current;
+    const previousWorkspaceId = previousThreadWorkspaceIdRef.current;
+    const previousSelectedComposerSessionKey = resolveSelectedComposerSessionKey(
+      previousWorkspaceId,
+      previousThreadId,
+    );
+    const activeSelectedComposerSessionKey = resolveSelectedComposerSessionKey(
+      activeWorkspaceId,
+      activeThreadId,
+    );
+    const previousSelectedComposerFromMemory =
+      previousSelectedComposerSessionKey &&
+      Object.prototype.hasOwnProperty.call(
+        selectedComposerSelectionBySessionKey,
+        previousSelectedComposerSessionKey,
+      )
+        ? selectedComposerSelectionBySessionKey[previousSelectedComposerSessionKey] ?? null
+        : null;
+    const activeSelectedComposerFromMemory =
+      activeSelectedComposerSessionKey &&
+      Object.prototype.hasOwnProperty.call(
+        selectedComposerSelectionBySessionKey,
+        activeSelectedComposerSessionKey,
+      )
+        ? selectedComposerSelectionBySessionKey[activeSelectedComposerSessionKey] ?? null
+        : null;
+    const previousSelectedComposerFromStore = previousSelectedComposerSessionKey
+      ? readStoredThreadComposerSelectionEntryBySessionKey(previousSelectedComposerSessionKey)
+          .value
+      : null;
+    const activeSelectedComposerFromStore = activeSelectedComposerSessionKey
+      ? readStoredThreadComposerSelectionEntryBySessionKey(activeSelectedComposerSessionKey).value
+      : null;
+    const previousSelectedComposerValue =
+      previousSelectedComposerFromMemory ?? previousSelectedComposerFromStore;
+    const activeSelectedComposerValue =
+      activeSelectedComposerFromMemory ?? activeSelectedComposerFromStore;
+    const shouldMigrateComposerSelection =
+      shouldMigrateComposerSelectionBetweenThreadIds({
+        previousThreadId,
+        activeThreadId,
+        previousSessionKey: previousSelectedComposerSessionKey,
+        activeSessionKey: activeSelectedComposerSessionKey,
+        hasSourceSelection: Boolean(previousSelectedComposerValue),
+        hasTargetSelection: Boolean(activeSelectedComposerValue),
+        resolveCanonicalThreadId,
+      });
+    if (
+      shouldMigrateComposerSelection &&
+      previousSelectedComposerSessionKey &&
+      activeSelectedComposerSessionKey
+    ) {
+      const migratedSelection = previousSelectedComposerValue;
+      writeSelectionForSessionKey(activeSelectedComposerSessionKey, migratedSelection);
+    }
+    previousThreadIdRef.current = activeThreadId ?? null;
+    previousThreadWorkspaceIdRef.current = activeWorkspaceId ?? null;
+  }, [
+    activeThreadId,
+    activeWorkspaceId,
+    resolveCanonicalThreadId,
+    resolveSelectedComposerSessionKey,
+    selectedComposerSelectionBySessionKey,
+    writeSelectionForSessionKey,
+  ]);
+
+  useEffect(() => {
+    reloadSelectedComposerSelection();
+  }, [reloadSelectedComposerSelection]);
+
+  return {
+    selectedComposerSelection,
+    selectedComposerSelectionRef,
+    handleSelectComposerSelection,
+    persistComposerSelectionForThread,
+    reloadSelectedComposerSelection,
+    resolveComposerSelectionForThread,
+  };
+}

--- a/src/app-shell.tsx
+++ b/src/app-shell.tsx
@@ -161,6 +161,8 @@ import {
 } from "./app-shell-parts/modelSelection";
 import { useOpenCodeSelection } from "./app-shell-parts/useOpenCodeSelection";
 import { useSelectedAgentSession } from "./app-shell-parts/useSelectedAgentSession";
+import { useSelectedComposerSession } from "./app-shell-parts/useSelectedComposerSession";
+import type { ComposerSessionSelection } from "./app-shell-parts/selectedComposerSession";
 import { APP_SHELL_LEGACY_CONTEXT_DEFAULTS } from "./app-shell-parts/legacyContextDefaults";
 import { usePanelLockState } from "./app-shell-parts/usePanelLockState";
 import { usePlanApplyHandlers } from "./app-shell-parts/usePlanApplyHandlers";
@@ -550,6 +552,11 @@ export function AppShell() {
     setDepth: setGitRootScanDepth,
     clear: clearGitRootCandidates,
   } = useGitRepoScan(activeWorkspace);
+  const [composerSelectionScopeKey, setComposerSelectionScopeKey] = useState(
+    `${activeWorkspaceId ?? "__workspace__unknown__"}:__thread__none__`,
+  );
+  const [threadComposerSelection, setThreadComposerSelection] =
+    useState<ComposerSessionSelection | null>(null);
   const {
     models,
     selectedModelId,
@@ -565,6 +572,7 @@ export function AppShell() {
     preferredModelId: appSettings.lastComposerModelId,
     preferredEffort: appSettings.lastComposerReasoningEffort,
     preferredSelectionReady: !appSettingsLoading,
+    selectionScopeKey: composerSelectionScopeKey,
   });
 
   const {
@@ -697,10 +705,21 @@ export function AppShell() {
 
   const [engineSelectedModelIdByType, setEngineSelectedModelIdByType] =
     useState<Partial<Record<EngineType, string | null>>>({});
+  const composerSelectionHandlerRef = useRef<
+    (selection: ComposerSessionSelection | null) => void
+  >(() => {});
+  const persistActiveComposerSelection = useCallback(
+    (selection: ComposerSessionSelection | null) => {
+      composerSelectionHandlerRef.current(selection);
+    },
+    [],
+  );
 
   const handleSelectModel = useCallback(
     (id: string | null) => {
-      if (id === null) return;
+      if (id === null) {
+        return;
+      }
       if (import.meta.env.DEV) {
         console.info("[model/select]", {
           activeEngine,
@@ -709,14 +728,18 @@ export function AppShell() {
       }
       if (activeEngine === "codex") {
         setSelectedModelId(id);
-        return;
+      } else {
+        setEngineSelectedModelIdByType((prev) => ({
+          ...prev,
+          [activeEngine]: id,
+        }));
       }
-      setEngineSelectedModelIdByType((prev) => ({
-        ...prev,
-        [activeEngine]: id,
-      }));
+      persistActiveComposerSelection({
+        modelId: id,
+        effort: selectedEffort,
+      });
     },
-    [activeEngine, setSelectedModelId],
+    [activeEngine, persistActiveComposerSelection, selectedEffort, setSelectedModelId],
   );
 
   const effectiveModels = useMemo(() => {
@@ -745,11 +768,20 @@ export function AppShell() {
     return getEffectiveSelectedModelId({
       activeEngine,
       selectedModelId,
+      activeThreadSelectedModelId: threadComposerSelection?.modelId ?? null,
+      hasActiveThread: !composerSelectionScopeKey.endsWith(":__thread__none__"),
       engineModelsAsOptions,
       engineSelectedModelIdByType,
       defaultClaudeModelId: DEFAULT_CLAUDE_MODEL_ID,
     });
-  }, [activeEngine, engineModelsAsOptions, engineSelectedModelIdByType, selectedModelId]);
+  }, [
+    activeEngine,
+    composerSelectionScopeKey,
+    engineModelsAsOptions,
+    engineSelectedModelIdByType,
+    selectedModelId,
+    threadComposerSelection,
+  ]);
 
   const effectiveReasoningSupported = useMemo(() => {
     return getEffectiveReasoningSupported(activeEngine, reasoningSupported);
@@ -759,6 +791,17 @@ export function AppShell() {
   const effectiveSelectedModel = useMemo(() => {
     return effectiveModels.find((m) => m.id === effectiveSelectedModelId) ?? null;
   }, [effectiveModels, effectiveSelectedModelId]);
+
+  const handleSelectComposerEffort = useCallback(
+    (effort: string | null) => {
+      setSelectedEffort(effort);
+      persistActiveComposerSelection({
+        modelId: effectiveSelectedModelId,
+        effort,
+      });
+    },
+    [effectiveSelectedModelId, persistActiveComposerSelection, setSelectedEffort],
+  );
 
   // Sync accessMode when switching engines (Codex forces full-access, Claude restores saved mode)
   useEffect(() => {
@@ -801,7 +844,7 @@ export function AppShell() {
     onSelectAccessMode: handleSetAccessMode,
     reasoningOptions,
     selectedEffort,
-    onSelectEffort: setSelectedEffort,
+    onSelectEffort: handleSelectComposerEffort,
     reasoningSupported: effectiveReasoningSupported,
   });
 
@@ -816,7 +859,7 @@ export function AppShell() {
     onSelectAccessMode: handleSetAccessMode,
     reasoningOptions,
     selectedEffort,
-    onSelectEffort: setSelectedEffort,
+    onSelectEffort: handleSelectComposerEffort,
     reasoningSupported: effectiveReasoningSupported,
     onFocusComposer: () => composerInputRef.current?.focus(),
   });
@@ -1153,6 +1196,20 @@ export function AppShell() {
   );
 
   const {
+    selectedComposerSelection,
+    handleSelectComposerSelection,
+    persistComposerSelectionForThread,
+    resolveComposerSelectionForThread,
+  } = useSelectedComposerSession({
+    activeThreadId,
+    activeWorkspaceId,
+    resolveCanonicalThreadId,
+    onDebug: addDebugEntry,
+  });
+
+  composerSelectionHandlerRef.current = handleSelectComposerSelection;
+
+  const {
     selectedAgent,
     selectedAgentRef,
     handleSelectAgent,
@@ -1164,6 +1221,39 @@ export function AppShell() {
     resolveCanonicalThreadId,
     onDebug: addDebugEntry,
   });
+
+  useEffect(() => {
+    const nextScopeKey = `${activeWorkspaceId ?? "__workspace__unknown__"}:${activeThreadId ?? "__thread__none__"}`;
+    setComposerSelectionScopeKey((current) =>
+      current === nextScopeKey ? current : nextScopeKey,
+    );
+    setThreadComposerSelection(null);
+  }, [activeThreadId, activeWorkspaceId]);
+
+  useEffect(() => {
+    setThreadComposerSelection(selectedComposerSelection);
+  }, [selectedComposerSelection]);
+
+  useEffect(() => {
+    if (activeEngine !== "codex") {
+      return;
+    }
+    const nextModelId = threadComposerSelection?.modelId ?? null;
+    const nextEffort = threadComposerSelection?.effort ?? null;
+    if (nextModelId && nextModelId !== selectedModelId) {
+      setSelectedModelId(nextModelId);
+    }
+    if (nextEffort !== null && nextEffort !== selectedEffort) {
+      setSelectedEffort(nextEffort);
+    }
+  }, [
+    activeEngine,
+    selectedEffort,
+    selectedModelId,
+    setSelectedEffort,
+    setSelectedModelId,
+    threadComposerSelection,
+  ]);
 
   const claudeModelRefreshThreadKeyRef = useRef<string | null>(null);
 
@@ -2184,7 +2274,7 @@ export function AppShell() {
     normalizePath, onCloseTerminal,
     onDebugPanelResizeStart, onGitHistoryPanelResizeStart, onKanbanConversationResizeStart, onNewTerminal, onPlanPanelResizeStart, onRightPanelResizeStart, onSelectTerminal, onSidebarResizeStart,
     onTerminalPanelResizeStart, onTextareaHeightChange, openAppIconById, openClonePrompt, openCodeAgents, openDeleteThreadPrompt, openFileTabs, openPlanPanel, openReleaseNotes, openRenamePrompt, openRenameWorktreePrompt, openSettings,
-    openTerminal, openWorktreePrompt, perfSnapshotRef, persistProjectCopiesFolder, pickImages, pinThread,
+    openTerminal, openWorktreePrompt, perfSnapshotRef, persistComposerSelectionForThread, persistProjectCopiesFolder, pickImages, pinThread,
     pinnedThreadsVersion, planByThread, planPanelHeight, prefillDraft,
     prompts, pushError, pushLoading, queueGitStatusRefresh, queueMessage,
     queueSaveSettings, rateLimitsByWorkspace, reasoningOptions, reasoningSupported, recentThreads, reduceTransparency, refreshAccountInfo,
@@ -2192,7 +2282,7 @@ export function AppShell() {
     releaseNotesEntries, releaseNotesError, releaseNotesLoading, releaseNotesOpen, reloadSelectedAgent, removeImage, removeImagesForThread, removeThread, removeThreads,
     removeWorkspace, removeWorktree, renamePrompt, renameThread, renameWorkspaceGroup, renameWorktree, renameWorktreeNotice, renameWorktreePrompt,
     renameWorktreeUpstream, renameWorktreeUpstreamPrompt, resetGitHubPanelState, resetSoloSplitToHalf, resetWorkspaceThreads, resolveCloneProjectContext,
-    resolveCanonicalThreadId, resolveCollaborationRuntimeMode, resolveCollaborationUiMode, resolveOpenCodeAgentForThread, resolveOpenCodeVariantForThread, resolvedEffort, resolvedModel, restartTerminalSession,
+    resolveCanonicalThreadId, resolveCollaborationRuntimeMode, resolveCollaborationUiMode, resolveComposerSelectionForThread, resolveOpenCodeAgentForThread, resolveOpenCodeVariantForThread, resolvedEffort, resolvedModel, restartTerminalSession,
     retryReleaseNotesLoad, reviewPrompt, rightPanelCollapsed, rightPanelWidth, runtimeRunState,
     scaleShortcutText, scaleShortcutTitle, scanGitRoots, scopedKanbanTasks, searchContentFilters, searchPaletteQuery, searchPaletteSelectedIndex,
     searchResults, searchScope, selectBranch, selectBranchAtIndex, selectCommit, selectCommitAtIndex, selectHome, selectWorkspace,
@@ -2204,7 +2294,7 @@ export function AppShell() {
     setDiffSource, setEditorSplitLayout, setEngineSelectedModelIdByType, setFilePanelMode, setFileReferenceMode, setGitDiffListView, setGitDiffViewStyle, setGitHistoryPanelHeight,
     setGitPanelMode, setGitRootScanDepth, setGlobalSearchFilesByWorkspace, setHighlightedBranchIndex, setHighlightedCommitIndex, setHighlightedPresetIndex, setIsEditorFileMaximized, setIsPanelLocked,
     setIsPlanPanelDismissed, setIsSearchPaletteOpen, setKanbanViewState, setLiveEditPreviewEnabled, setPrefillDraft, setReduceTransparency, setRightPanelWidth, setSearchContentFilters, setSearchPaletteQuery, setSearchPaletteSelectedIndex, setSearchScope,
-    setSelectedCollaborationModeId, setSelectedCommitSha, setSelectedDiffPath, setSelectedEffort, setSelectedKanbanTaskId, setSelectedModelId, setSelectedPullRequest,
+    setSelectedCollaborationModeId, setSelectedCommitSha, setSelectedDiffPath, setSelectedEffort: handleSelectComposerEffort, setSelectedKanbanTaskId, setSelectedModelId, setSelectedPullRequest,
     setHomeOpen, setWorkspaceHomeWorkspaceId, settingsHighlightTarget, settingsOpen, settingsSection, loadingProgressDialog, dismissLoadingProgressDialog, shouldLoadDiffs, shouldLoadGitHubPanelData,
     showLoadingProgressDialog, hideLoadingProgressDialog,
     showDebugButton, showGitHistory, showHome, showKanban, showNextReleaseNotes, showPresetStep, showPreviousReleaseNotes, showWorkspaceHome,

--- a/src/features/app/hooks/usePersistComposerSettings.ts
+++ b/src/features/app/hooks/usePersistComposerSettings.ts
@@ -17,27 +17,11 @@ export function usePersistComposerSettings({
   queueSaveSettings,
 }: Params) {
   useEffect(() => {
-    if (appSettingsLoading) {
-      return;
-    }
-    if (!selectedModelId && selectedEffort === null) {
-      return;
-    }
-    setAppSettings((current) => {
-      if (
-        current.lastComposerModelId === selectedModelId &&
-        current.lastComposerReasoningEffort === selectedEffort
-      ) {
-        return current;
-      }
-      const nextSettings = {
-        ...current,
-        lastComposerModelId: selectedModelId,
-        lastComposerReasoningEffort: selectedEffort,
-      };
-      void queueSaveSettings(nextSettings);
-      return nextSettings;
-    });
+    void appSettingsLoading;
+    void selectedModelId;
+    void selectedEffort;
+    void setAppSettings;
+    void queueSaveSettings;
   }, [
     appSettingsLoading,
     queueSaveSettings,

--- a/src/features/models/hooks/useModels.test.tsx
+++ b/src/features/models/hooks/useModels.test.tsx
@@ -227,4 +227,72 @@ describe("useModels", () => {
       expect(result.current.selectedModel?.displayName).toBe("Demo");
     });
   });
+
+  it("resets the user-selected model and effort when the selection scope changes within the same workspace", async () => {
+    vi.mocked(getModelList).mockResolvedValueOnce({
+      result: {
+        data: [
+          {
+            id: "gpt-5.5",
+            model: "gpt-5.5",
+            displayName: "gpt-5.5",
+            supportedReasoningEfforts: [
+              { reasoningEffort: "medium", description: "Medium" },
+            ],
+            defaultReasoningEffort: "medium",
+            isDefault: true,
+          },
+        ],
+      },
+    });
+    vi.mocked(getConfigModel).mockResolvedValueOnce("gpt-5.5");
+
+    type HookProps = {
+      preferredModelId: string | null;
+      preferredEffort: string | null;
+      selectionScopeKey: string;
+    };
+
+    const { result, rerender } = renderHook(
+      ({ preferredModelId, preferredEffort, selectionScopeKey }: HookProps) =>
+        useModels({
+          activeWorkspace: workspace,
+          preferredModelId,
+          preferredEffort,
+          preferredSelectionReady: true,
+          selectionScopeKey,
+        }),
+      {
+        initialProps: {
+          preferredModelId: "gpt-5.5",
+          preferredEffort: "medium",
+          selectionScopeKey: "ws-1:thread-a",
+        },
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.selectedModelId).toBe("gpt-5.5");
+      expect(result.current.selectedEffort).toBe("medium");
+    });
+
+    act(() => {
+      result.current.setSelectedEffort("high");
+    });
+
+    await waitFor(() => {
+      expect(result.current.selectedEffort).toBe("high");
+    });
+
+    rerender({
+      preferredModelId: "gpt-5.5",
+      preferredEffort: "medium",
+      selectionScopeKey: "ws-1:thread-b",
+    });
+
+    await waitFor(() => {
+      expect(result.current.selectedModelId).toBe("gpt-5.5");
+      expect(result.current.selectedEffort).toBe("medium");
+    });
+  });
 });

--- a/src/features/models/hooks/useModels.ts
+++ b/src/features/models/hooks/useModels.ts
@@ -18,6 +18,7 @@ type UseModelsOptions = {
   preferredModelId?: string | null;
   preferredEffort?: string | null;
   preferredSelectionReady?: boolean;
+  selectionScopeKey?: string;
 };
 
 const CONFIG_MODEL_DESCRIPTION = "Configured in CODEX_HOME/config.toml";
@@ -144,6 +145,7 @@ export function useModels({
   preferredModelId = null,
   preferredEffort = null,
   preferredSelectionReady = true,
+  selectionScopeKey,
 }: UseModelsOptions) {
   const [rawModels, setRawModels] = useState<ModelOption[]>([]);
   const [models, setModels] = useState<ModelOption[]>([]);
@@ -156,6 +158,7 @@ export function useModels({
   const hasUserSelectedModel = useRef(false);
   const hasUserSelectedEffort = useRef(false);
   const lastWorkspaceId = useRef<string | null>(null);
+  const lastSelectionScopeKey = useRef<string | null>(selectionScopeKey ?? null);
 
   const workspaceId = activeWorkspace?.id ?? null;
   const isConnected = Boolean(activeWorkspace?.connected);
@@ -216,6 +219,16 @@ export function useModels({
     lastWorkspaceId.current = workspaceId;
     setConfigModel(null);
   }, [workspaceId]);
+
+  useEffect(() => {
+    const nextSelectionScopeKey = selectionScopeKey ?? null;
+    if (nextSelectionScopeKey === lastSelectionScopeKey.current) {
+      return;
+    }
+    hasUserSelectedModel.current = false;
+    hasUserSelectedEffort.current = false;
+    lastSelectionScopeKey.current = nextSelectionScopeKey;
+  }, [selectionScopeKey]);
 
   useEffect(() => {
     if (selectedEffort === null) {
@@ -494,6 +507,7 @@ export function useModels({
     selectedEffort,
     selectedModelId,
     resolveEffort,
+    selectionScopeKey,
   ]);
 
   return {


### PR DESCRIPTION
## Summary
- store composer model and reasoning effort per workspace/thread with draft carry-forward plus pending/finalized thread migration
- route AppShell and Kanban model selection through thread-scoped composer state instead of leaking through global composer settings
- add regression coverage for thread-scoped selection, migration, Kanban syncing, and same-workspace scope resets

## Test plan
- [x] `npm exec vitest run src/app-shell-parts/selectedComposerSession.test.ts src/app-shell-parts/selectedComposerSession.flow.test.ts src/app-shell-parts/useSelectedComposerSession.test.tsx src/app-shell-parts/modelSelection.test.ts src/app-shell-parts/useAppShellSections.kanban-text.test.ts src/features/models/hooks/useModels.test.tsx`
- [x] `npm run typecheck`
- [x] `npm run check:app-shell:runtime-contract`
- [ ] Manual Tauri UI verification of A/B session switching and pending->finalized carry-over

🤖 Generated with [Claude Code](https://claude.com/claude-code)