### PR TITLE
fix(threads): 结算 AskUserQuestion 超时残留

### DIFF
--- a/.trellis/tasks/05-01-fix-ask-user-question-timeout-settlement/prd.md
+++ b/.trellis/tasks/05-01-fix-ask-user-question-timeout-settlement/prd.md
@@ -1,0 +1,21 @@
+# Fix AskUserQuestion timeout settlement
+
+## Background
+
+Issue #411 reports that Claude Code auto mode can leave an `AskUserQuestion` dialog visible after timeout. The backend timeout clears the pending request, but the frontend queue can still keep the dialog. Later cancel/submit attempts fail as stale responses and the queue remains stuck.
+
+## Goal
+
+When the backend has already timed out an AskUserQuestion request, a later empty cancel/timeout response should settle the frontend queue and close the dialog instead of preserving an impossible-to-submit request.
+
+## Acceptance Criteria
+
+- [x] Empty cancel/timeout response that reaches an already-settled Claude AskUserQuestion clears the pending request.
+- [x] The optimistic processing marker is cleared when stale settlement is detected.
+- [x] No synthetic submitted-answer history item is inserted for stale timeout responses.
+- [x] Ordinary submit failures still keep the request visible for retry.
+- [ ] Verification commands pass before PR publication.
+
+## Linked OpenSpec Change
+
+- `openspec/changes/fix-ask-user-question-timeout-settlement`

--- a/.trellis/tasks/05-01-fix-ask-user-question-timeout-settlement/task.json
+++ b/.trellis/tasks/05-01-fix-ask-user-question-timeout-settlement/task.json
@@ -1,0 +1,59 @@
+{
+  "id": "fix-ask-user-question-timeout-settlement",
+  "name": "fix-ask-user-question-timeout-settlement",
+  "title": "Fix AskUserQuestion timeout settlement",
+  "description": "Remove stale Claude AskUserQuestion requests from the frontend queue when cancel arrives after backend timeout settlement.",
+  "status": "planning",
+  "dev_type": "frontend",
+  "scope": null,
+  "package": null,
+  "priority": "P1",
+  "creator": "watsonk1998",
+  "assignee": "watsonk1998",
+  "createdAt": "2026-05-01",
+  "completedAt": null,
+  "branch": null,
+  "base_branch": "main",
+  "worktree_path": null,
+  "current_phase": 0,
+  "next_action": [
+    {
+      "phase": 1,
+      "action": "brainstorm"
+    },
+    {
+      "phase": 2,
+      "action": "research"
+    },
+    {
+      "phase": 3,
+      "action": "implement"
+    },
+    {
+      "phase": 4,
+      "action": "check"
+    },
+    {
+      "phase": 5,
+      "action": "update-spec"
+    },
+    {
+      "phase": 6,
+      "action": "record-session"
+    }
+  ],
+  "commit": null,
+  "pr_url": null,
+  "subtasks": [],
+  "children": [],
+  "parent": null,
+  "relatedFiles": [
+    "src/features/threads/hooks/useThreadUserInput.ts",
+    "src/features/threads/hooks/useThreadUserInput.test.tsx",
+    "openspec/changes/fix-ask-user-question-timeout-settlement"
+  ],
+  "notes": "Covers GitHub issue #411: Claude Code AskUserQuestion timeout should not leave an unclosable dialog.",
+  "meta": {
+    "githubIssue": 411
+  }
+}

--- a/.trellis/workspace/watsonk1998/index.md
+++ b/.trellis/workspace/watsonk1998/index.md
@@ -1,0 +1,41 @@
+# Workspace Index - watsonk1998
+
+> Journal tracking for AI development sessions.
+
+---
+
+## Current Status
+
+<!-- @@@auto:current-status -->
+- **Active File**: `journal-1.md`
+- **Total Sessions**: 1
+- **Last Active**: 2026-05-01
+<!-- @@@/auto:current-status -->
+
+---
+
+## Active Documents
+
+<!-- @@@auto:active-documents -->
+| File | Lines | Status |
+|------|-------|--------|
+| `journal-1.md` | ~44 | Active |
+<!-- @@@/auto:active-documents -->
+
+---
+
+## Session History
+
+<!-- @@@auto:session-history -->
+| # | Date | Title | Commits | Branch |
+|---|------|-------|---------|--------|
+| 1 | 2026-05-01 | 迁移 AskUserQuestion 超时修复 PR 到 0.4.12 分支 | `a6b50d1177b8e28b04bf592fb77858c39f466532` | `fix/ask-user-question-timeout-settlement` |
+<!-- @@@/auto:session-history -->
+
+---
+
+## Notes
+
+- Sessions are appended to journal files
+- New journal file created when current exceeds 2000 lines
+- Use `add_session.py` to record sessions

--- a/.trellis/workspace/watsonk1998/journal-1.md
+++ b/.trellis/workspace/watsonk1998/journal-1.md
@@ -1,0 +1,44 @@
+# Journal - watsonk1998 (Part 1)
+
+> AI development session journal
+> Started: 2026-05-01
+
+---
+
+
+## Session 1: 迁移 AskUserQuestion 超时修复 PR 到 0.4.12 分支
+
+**Date**: 2026-05-01
+**Task**: 迁移 AskUserQuestion 超时修复 PR 到 0.4.12 分支
+**Branch**: `fix/ask-user-question-timeout-settlement`
+
+### Summary
+
+(Add summary)
+
+### Main Changes
+
+任务目标：按维护者反馈，将 PR #481 从 main 目标迁移到 chore/bump-version-0.4.12 目标分支，同时保持 diff 干净。
+主要改动：基于 origin/chore/bump-version-0.4.12 重建 fix/ask-user-question-timeout-settlement 分支，并 cherry-pick 原 AskUserQuestion timeout settlement 修复。
+涉及模块：src/features/threads/hooks/useThreadUserInput.ts；src/features/threads/hooks/useThreadUserInput.test.tsx；openspec/changes/fix-ask-user-question-timeout-settlement；.trellis/tasks/05-01-fix-ask-user-question-timeout-settlement。
+验证结果：npm exec vitest -- run src/features/threads/hooks/useThreadUserInput.test.tsx src/features/app/components/AskUserQuestionDialog.test.tsx 通过；npm exec eslint -- src/features/threads/hooks/useThreadUserInput.ts src/features/threads/hooks/useThreadUserInput.test.tsx src/features/app/components/AskUserQuestionDialog.tsx src/features/app/components/AskUserQuestionDialog.test.tsx 通过；npm run typecheck 通过；git diff --check origin/chore/bump-version-0.4.12..HEAD 通过。
+后续事项：推送 fork/fix/ask-user-question-timeout-settlement 后，将 PR #481 base 改为 chore/bump-version-0.4.12。
+
+
+### Git Commits
+
+| Hash | Message |
+|------|---------|
+| `a6b50d1177b8e28b04bf592fb77858c39f466532` | (see git log) |
+
+### Testing
+
+- [OK] (Add test results)
+
+### Status
+
+[OK] **Completed**
+
+### Next Steps
+
+- None - task complete

--- a/openspec/changes/fix-ask-user-question-timeout-settlement/.openspec.yaml
+++ b/openspec/changes/fix-ask-user-question-timeout-settlement/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-01

--- a/openspec/changes/fix-ask-user-question-timeout-settlement/design.md
+++ b/openspec/changes/fix-ask-user-question-timeout-settlement/design.md
@@ -1,0 +1,28 @@
+## Context
+
+`AskUserQuestionDialog` submits empty answers on cancel and auto-cancel timeout. `useThreadUserInput` sends those answers through `respondToUserInputRequest`, optimistically marks the thread as processing, then removes the request after a successful backend response.
+
+For Claude Code timeout, backend and frontend timers can race. The backend may clear the pending request before the frontend auto-cancel or user cancel reaches `respond_to_server_request`. In that stale case the response is no longer deliverable, but keeping the request visible is worse: it leaves a dialog that cannot be closed or submitted.
+
+## Decision
+
+Add a narrow stale-settlement classifier inside `useThreadUserInput`:
+
+- `unknown request_id for AskUserQuestion` means Claude already removed that request.
+- `workspace not connected` with an empty response means the cancel/timeout response fell through after the Claude pending request was already cleared and no Codex workspace session can consume it.
+
+When the classifier matches, the hook clears the optimistic processing marker and removes the pending request without inserting a submitted-answer history item.
+
+## Alternatives
+
+| 方案 | 结论 | 原因 |
+|---|---|---|
+| 让 dialog 本地隐藏 request | 不采用 | 会绕过 reducer queue，切换视图或重挂载后仍可能重现 stale request |
+| 后端新增 timeout completion event | 暂不采用 | 需要扩展 Claude event contract；当前 PR 可以用前端 stale settlement 解除用户阻塞 |
+| 所有 submit failure 都移除 request | 不采用 | 会吞掉真实可重试错误，破坏现有失败可见性 |
+
+## Validation
+
+- 新增 focused Vitest：backend stale timeout error + empty cancel response 会清理 request。
+- 运行 `useThreadUserInput` 全量测试，确认普通失败仍保留 request。
+- 运行 targeted ESLint、typecheck、diff check。

--- a/openspec/changes/fix-ask-user-question-timeout-settlement/proposal.md
+++ b/openspec/changes/fix-ask-user-question-timeout-settlement/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+GitHub issue #411 reports that Claude Code auto mode can leave an `AskUserQuestion` dialog stuck after timeout. The backend waits up to 5 minutes for the answer, clears the pending request when the wait expires, and continues. The frontend queue does not receive a completion event for that timeout, so the dialog can remain visible.
+
+When the user later clicks cancel, the response can no longer be delivered because the backend has already settled the request. The current hook treats that stale response as a normal submit failure and keeps the request in the queue, which makes the dialog impossible to close.
+
+## What Changes
+
+- Treat stale timeout settlement errors for empty AskUserQuestion responses as a local queue settlement, not as a retryable submit failure.
+- Keep ordinary submit failures unchanged: the request remains visible when the backend may still accept the answer.
+- Add a regression test covering the timeout/cancel path.
+
+## Scope
+
+- Frontend hook only:
+  - `src/features/threads/hooks/useThreadUserInput.ts`
+  - `src/features/threads/hooks/useThreadUserInput.test.tsx`
+- No change to the AskUserQuestion dialog layout or question-answer payload.
+- No backend command or protocol schema change.
+
+## Acceptance
+
+- If a timed-out Claude AskUserQuestion request is cancelled after backend settlement, the frontend MUST remove it from the pending request queue.
+- The thread MUST leave the optimistic processing state created for the attempted response.
+- The hook MUST NOT create a synthetic submitted-answer history item for a response that the backend already rejected as stale.
+- Non-stale submit failures MUST still keep the request visible for retry.

--- a/openspec/changes/fix-ask-user-question-timeout-settlement/specs/codex-chat-canvas-user-input-elicitation/spec.md
+++ b/openspec/changes/fix-ask-user-question-timeout-settlement/specs/codex-chat-canvas-user-input-elicitation/spec.md
@@ -1,0 +1,19 @@
+## MODIFIED Requirements
+
+### Requirement: RequestUserInput Stale Timeout Settlement MUST Release The Pending Dialog
+
+When a user-input request has already been settled by runtime timeout, the frontend MUST treat a later empty cancel response as stale settlement rather than a retryable submission failure.
+
+#### Scenario: Claude AskUserQuestion cancel arrives after backend timeout
+- **GIVEN** a Claude Code `AskUserQuestion` request is visible in the frontend queue
+- **AND** the backend has already timed out and cleared the pending request
+- **WHEN** the user cancels the dialog or the frontend timeout submits an empty response
+- **THEN** the frontend MUST remove the pending request from the queue
+- **AND** the thread MUST clear the optimistic processing marker created for that response attempt
+- **AND** the frontend MUST NOT insert a submitted-answer history item for the stale response
+
+#### Scenario: ordinary submit failure remains retryable
+- **GIVEN** a user-input request is still expected to be answerable
+- **WHEN** sending the answer fails with an ordinary backend or bridge error
+- **THEN** the frontend MUST keep the request visible
+- **AND** the user MUST be able to retry or cancel again

--- a/openspec/changes/fix-ask-user-question-timeout-settlement/tasks.md
+++ b/openspec/changes/fix-ask-user-question-timeout-settlement/tasks.md
@@ -1,0 +1,16 @@
+## 1. Spec
+
+- [x] 明确 Claude AskUserQuestion backend timeout 与 frontend pending queue 的 race
+- [x] 定义 stale timeout response 与普通 submit failure 的边界
+
+## 2. Implementation
+
+- [x] 在 `useThreadUserInput` 中增加 stale settlement error classifier
+- [x] stale cancel/timeout response 清理 processing 与 pending request
+- [x] 普通 submit failure 保持 request 可见
+
+## 3. Tests
+
+- [x] 新增 regression test：backend 已 timeout 后 cancel response 结算前端队列
+- [x] 运行 focused Vitest / ESLint / typecheck / diff check
+- [x] 记录 OpenSpec CLI 不在 PATH，无法运行 `openspec validate fix-ask-user-question-timeout-settlement --strict`

--- a/src/features/threads/hooks/useThreadUserInput.test.tsx
+++ b/src/features/threads/hooks/useThreadUserInput.test.tsx
@@ -143,6 +143,49 @@ describe("useThreadUserInput", () => {
     });
   });
 
+  it("settles a stale timeout request when cancel reaches an already timed out Claude prompt", async () => {
+    const dispatch = vi.fn();
+    vi.mocked(respondToUserInputRequest).mockRejectedValue(
+      new Error("workspace not connected"),
+    );
+
+    const { result } = renderHook(() => useThreadUserInput({ dispatch }));
+
+    await act(async () => {
+      await result.current.handleUserInputSubmit(request, { answers: {} });
+    });
+
+    expect(respondToUserInputRequest).toHaveBeenCalledWith(
+      "ws-1",
+      "req-1",
+      {},
+      {
+        threadId: "thread-1",
+        turnId: "turn-1",
+      },
+    );
+    expect(dispatch).toHaveBeenNthCalledWith(1, {
+      type: "markProcessing",
+      threadId: "thread-1",
+      isProcessing: true,
+      timestamp: expect.any(Number),
+    });
+    expect(dispatch).toHaveBeenNthCalledWith(2, {
+      type: "markProcessing",
+      threadId: "thread-1",
+      isProcessing: false,
+      timestamp: expect.any(Number),
+    });
+    expect(dispatch).toHaveBeenNthCalledWith(3, {
+      type: "removeUserInputRequest",
+      requestId: "req-1",
+      workspaceId: "ws-1",
+    });
+    expect(dispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "upsertItem" }),
+    );
+  });
+
   it("keeps runtime payload stable but remaps Claude continuity state updates", async () => {
     const dispatch = vi.fn();
     vi.mocked(respondToUserInputRequest).mockResolvedValue(undefined as never);

--- a/src/features/threads/hooks/useThreadUserInput.ts
+++ b/src/features/threads/hooks/useThreadUserInput.ts
@@ -117,6 +117,33 @@ function buildSubmittedTitle(payload: SubmittedUserInputPayload) {
   return "请求输入";
 }
 
+function getErrorMessage(error: unknown) {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  return "";
+}
+
+function isEmptyResponse(response: RequestUserInputResponse) {
+  return Object.values(response.answers).every((answer) =>
+    answer.answers.every((value) => value.trim().length === 0),
+  );
+}
+
+function isStaleSettledRequestError(
+  error: unknown,
+  response: RequestUserInputResponse,
+) {
+  const normalizedMessage = getErrorMessage(error).toLowerCase();
+  if (normalizedMessage.includes("unknown request_id for askuserquestion")) {
+    return true;
+  }
+  return isEmptyResponse(response) && normalizedMessage.includes("workspace not connected");
+}
+
 export function useThreadUserInput({
   dispatch,
   resolveClaudeContinuationThreadId,
@@ -160,6 +187,14 @@ export function useThreadUserInput({
             isProcessing: false,
             timestamp: Date.now(),
           });
+        }
+        if (isStaleSettledRequestError(error, response)) {
+          dispatch({
+            type: "removeUserInputRequest",
+            requestId: request.request_id,
+            workspaceId: request.workspace_id,
+          });
+          return;
         }
         throw error;
       }


### PR DESCRIPTION
## Summary

- Settles stale Claude AskUserQuestion timeout/cancel responses by removing the pending frontend request.
- Keeps ordinary submit failures retryable, preserving the existing request when the backend may still accept an answer.
- Adds OpenSpec/Trellis trace files for issue #411.

Closes #411

## Verification

- `npm exec vitest -- run src/features/threads/hooks/useThreadUserInput.test.tsx src/features/app/components/AskUserQuestionDialog.test.tsx`
- `npm exec eslint -- src/features/threads/hooks/useThreadUserInput.ts src/features/threads/hooks/useThreadUserInput.test.tsx src/features/app/components/AskUserQuestionDialog.tsx src/features/app/components/AskUserQuestionDialog.test.tsx`
- `npm run typecheck`
- `git diff --check`

## Not tested

- `openspec validate fix-ask-user-question-timeout-settlement --strict` because `openspec` is not in PATH even after `source ~/.zshrc`.
