### PR TITLE
fix(composer): 清理自定义命令发送后的上下文残留

### DIFF
--- a/.trellis/workspace/watsonk1998/index.md
+++ b/.trellis/workspace/watsonk1998/index.md
@@ -1,0 +1,41 @@
+# Workspace Index - watsonk1998
+
+> Journal tracking for AI development sessions.
+
+---
+
+## Current Status
+
+<!-- @@@auto:current-status -->
+- **Active File**: `journal-1.md`
+- **Total Sessions**: 1
+- **Last Active**: 2026-05-01
+<!-- @@@/auto:current-status -->
+
+---
+
+## Active Documents
+
+<!-- @@@auto:active-documents -->
+| File | Lines | Status |
+|------|-------|--------|
+| `journal-1.md` | ~41 | Active |
+<!-- @@@/auto:active-documents -->
+
+---
+
+## Session History
+
+<!-- @@@auto:session-history -->
+| # | Date | Title | Commits | Branch |
+|---|------|-------|---------|--------|
+| 1 | 2026-05-01 | 修复自定义 slash command 残留 | `ac8d246f` | `fix/custom-claude-command-slash` |
+<!-- @@@/auto:session-history -->
+
+---
+
+## Notes
+
+- Sessions are appended to journal files
+- New journal file created when current exceeds 2000 lines
+- Use `add_session.py` to record sessions

--- a/.trellis/workspace/watsonk1998/journal-1.md
+++ b/.trellis/workspace/watsonk1998/journal-1.md
@@ -1,0 +1,46 @@
+# Journal - watsonk1998 (Part 1)
+
+> AI development session journal
+> Started: 2026-05-01
+
+---
+
+
+
+## Session 1: 修复自定义 slash command 残留
+
+**Date**: 2026-05-01
+**Task**: 修复自定义 slash command 残留
+**Branch**: `fix/custom-claude-command-slash`
+
+### Summary
+
+为 #473 修复自定义 Claude slash command `/next` 发送后的 Composer 选择状态残留，并补充回归测试。
+
+### Main Changes
+
+修复 #473 自定义 Claude slash command 发送后状态残留：Composer 在发送完成后清理 selectedSkillNames/selectedCommonsNames，避免 /next 被作为隐式上下文继续拼接到下一条普通消息；同时为 ChatInputBoxAdapter 补充自定义 /next 命令匹配与加载后重渲染回归测试。验证：目标 vitest、useCustomCommands vitest、npm run typecheck、npm run lint、npm run check:large-files、npm test 均通过。后续：推送分支并基于 chore/bump-version-0.4.12 创建 PR，Closes #473。
+
+
+### Git Commits
+
+| Hash | Message |
+|------|---------|
+| `ac8d246f` | (see git log) |
+
+### Testing
+
+- [OK] `npm exec vitest -- run src/features/composer/components/ComposerEditorHelpers.test.tsx src/features/composer/components/ChatInputBox/ChatInputBoxAdapter.test.tsx`
+- [OK] `npm exec vitest -- run src/features/commands/hooks/useCustomCommands.test.tsx`
+- [OK] `npm run typecheck`
+- [OK] `npm run lint`
+- [OK] `npm run check:large-files`
+- [OK] `npm test`
+
+### Status
+
+[OK] **Completed**
+
+### Next Steps
+
+- None - task complete

--- a/src/features/composer/components/ChatInputBox/ChatInputBoxAdapter.test.tsx
+++ b/src/features/composer/components/ChatInputBox/ChatInputBoxAdapter.test.tsx
@@ -258,6 +258,72 @@ describe('ChatInputBoxAdapter toggle bridge', () => {
     expect(mockState.renderCount).toBe(1);
   });
 
+  it('rerenders ChatInputBox when custom commands are loaded after mount', async () => {
+    const stableProps: ComponentProps<typeof ChatInputBoxAdapter> = {
+      text: '',
+      isProcessing: false,
+      canStop: false,
+      selectedModelId: 'claude-sonnet-4-6',
+      onSend: () => {},
+      onStop: () => {},
+      onTextChange: () => {},
+      selectedEngine: 'claude',
+      commands: [],
+    };
+
+    const view = render(<ChatInputBoxAdapter {...stableProps} />);
+    await waitFor(() => expect(mockState.latestProps).toBeTruthy());
+    expect(mockState.renderCount).toBe(1);
+
+    view.rerender(
+      <ChatInputBoxAdapter
+        {...stableProps}
+        commands={[
+          {
+            name: 'next',
+            path: '/repo/.claude/commands/next.md',
+            description: 'continue with next step',
+            content: 'next',
+          },
+        ]}
+      />,
+    );
+
+    expect(mockState.renderCount).toBe(2);
+  });
+
+  it('matches project custom slash commands by slash name', async () => {
+    renderAdapter({
+      commands: [
+        {
+          name: 'next',
+          path: '/repo/.claude/commands/next.md',
+          description: 'continue with next step',
+          content: 'next',
+        },
+      ],
+    });
+
+    await waitFor(() => expect(mockState.latestProps).toBeTruthy());
+
+    const latest = mockState.latestProps as {
+      commandCompletionProvider?: (
+        query: string,
+        signal: AbortSignal,
+      ) => Promise<Array<{ id: string; label: string; category?: string }>>;
+    };
+
+    const results = await latest.commandCompletionProvider?.('next', new AbortController().signal);
+
+    expect(results).toContainEqual(
+      expect.objectContaining({
+        id: 'next',
+        label: '/next',
+        category: 'custom',
+      }),
+    );
+  });
+
   it('uses external thinking callback when supplied', async () => {
     const onToggleThinking = vi.fn();
     renderAdapter({

--- a/src/features/composer/components/Composer.tsx
+++ b/src/features/composer/components/Composer.tsx
@@ -1977,6 +1977,8 @@ export const Composer = memo(function Composer({
           : undefined;
       const sendResult = onSend(resolvedFinalText, mergedImages, sendOptions);
       void Promise.resolve(sendResult).finally(() => {
+        setSelectedSkillNames([]);
+        setSelectedCommonsNames([]);
         setSelectedManualMemories([]);
         setSelectedNoteCards([]);
         setSelectedInlineFileReferences([]);

--- a/src/features/composer/components/ComposerEditorHelpers.test.tsx
+++ b/src/features/composer/components/ComposerEditorHelpers.test.tsx
@@ -60,6 +60,13 @@ vi.mock("./ChatInputBox/ChatInputBoxAdapter", () => ({
       >
         Submit snapshot with image
       </button>
+      <button
+        type="button"
+        data-testid="submit-next-command"
+        onClick={() => onSend("/next")}
+      >
+        Submit /next
+      </button>
     </>
   ),
 }));
@@ -235,6 +242,35 @@ describe("Composer editor helpers", () => {
       ["persisted-image.png", "child-image.png"],
       undefined,
     );
+    harness.unmount();
+  });
+
+  it("does not reuse a submitted custom slash command as a later common prefix", async () => {
+    const onSend = vi.fn();
+    const harness = renderComposerHarness({
+      initialText: "/next",
+      commands: [{ name: "next", path: "/repo/.claude/commands/next.md", content: "next" }],
+      onSend,
+    });
+    const submitCommand = harness.container.querySelector(
+      '[data-testid="submit-next-command"]',
+    ) as HTMLButtonElement | null;
+    if (!submitCommand) {
+      throw new Error("Submit command button not found");
+    }
+    const textarea = getTextarea(harness.container);
+
+    await act(async () => {
+      submitCommand.click();
+    });
+
+    await act(async () => {
+      fireEvent.change(textarea, { target: { value: "follow up" } });
+      fireEvent.keyDown(textarea, { key: "Enter" });
+    });
+
+    expect(onSend).toHaveBeenNthCalledWith(1, "/next", [], undefined);
+    expect(onSend).toHaveBeenNthCalledWith(2, "follow up", [], undefined);
     harness.unmount();
   });
 


### PR DESCRIPTION
## Summary\n- clear selected skill/common command chips after a composer send completes\n- prevent a submitted custom slash command like /next from being reused as a hidden prefix on later normal messages\n- add regression coverage for /next command matching and post-submit residue\n\nCloses #473\n\n## Verification\n- npm exec vitest -- run src/features/composer/components/ComposerEditorHelpers.test.tsx src/features/composer/components/ChatInputBox/ChatInputBoxAdapter.test.tsx\n- npm exec vitest -- run src/features/commands/hooks/useCustomCommands.test.tsx\n- npm run typecheck\n- npm run lint\n- npm run check:large-files\n- npm test