### PR TITLE
fix(skills): 支持软链技能目录扫描

### DIFF
--- a/.trellis/workspace/watsonk1998/index.md
+++ b/.trellis/workspace/watsonk1998/index.md
@@ -1,0 +1,41 @@
+# Workspace Index - watsonk1998
+
+> Journal tracking for AI development sessions.
+
+---
+
+## Current Status
+
+<!-- @@@auto:current-status -->
+- **Active File**: `journal-1.md`
+- **Total Sessions**: 1
+- **Last Active**: 2026-05-01
+<!-- @@@/auto:current-status -->
+
+---
+
+## Active Documents
+
+<!-- @@@auto:active-documents -->
+| File | Lines | Status |
+|------|-------|--------|
+| `journal-1.md` | ~45 | Active |
+<!-- @@@/auto:active-documents -->
+
+---
+
+## Session History
+
+<!-- @@@auto:session-history -->
+| # | Date | Title | Commits | Branch |
+|---|------|-------|---------|--------|
+| 1 | 2026-05-01 | 修复软链技能目录扫描 | `f0c3ecc7` | `fix/issue-303-symlink-skills` |
+<!-- @@@/auto:session-history -->
+
+---
+
+## Notes
+
+- Sessions are appended to journal files
+- New journal file created when current exceeds 2000 lines
+- Use `add_session.py` to record sessions

--- a/.trellis/workspace/watsonk1998/journal-1.md
+++ b/.trellis/workspace/watsonk1998/journal-1.md
@@ -1,0 +1,45 @@
+# Journal - watsonk1998 (Part 1)
+
+> AI development session journal
+> Started: 2026-05-01
+
+---
+
+
+
+## Session 1: 修复软链技能目录扫描
+
+**Date**: 2026-05-01
+**Task**: 修复软链技能目录扫描
+**Branch**: `fix/issue-303-symlink-skills`
+
+### Summary
+
+(Add summary)
+
+### Main Changes
+
+任务目标：修复 #303 Skills 页面无法扫描 .claude/skills 下 symlink skill 目录的问题。
+主要改动：src-tauri/src/skills.rs 在扫描 skill entry 时允许跟随指向目录的 symlink，继续跳过非目录 symlink，并新增 Unix 回归测试覆盖 symlink skill directory。
+涉及模块：Rust backend skills scanner。
+验证结果：cargo test --manifest-path src-tauri/Cargo.toml discover_skills_follows_symlinked_skill_directories 通过。
+后续事项：完整 cargo test 与 UI 手测未运行；PR 需说明只覆盖目录 symlink，不新增自定义 skill root 配置。
+
+
+### Git Commits
+
+| Hash | Message |
+|------|---------|
+| `f0c3ecc7` | (see git log) |
+
+### Testing
+
+- [OK] (Add test results)
+
+### Status
+
+[OK] **Completed**
+
+### Next Steps
+
+- None - task complete

--- a/src-tauri/src/skills.rs
+++ b/src-tauri/src/skills.rs
@@ -256,17 +256,25 @@ fn discover_skills_in(dir: &Path, source: &str) -> Result<Vec<SkillEntry>, Skill
 
         let path = entry.path();
 
-        // Use symlink_metadata to skip symlinks (won't follow links)
-        let metadata = match fs::symlink_metadata(&path) {
+        let link_metadata = match fs::symlink_metadata(&path) {
             Ok(m) => m,
             Err(err) => {
                 log::warn!("Failed to stat {:?}: {}", path, err);
                 continue;
             }
         };
-        if metadata.file_type().is_symlink() {
-            continue;
-        }
+        let metadata = if link_metadata.file_type().is_symlink() {
+            match fs::metadata(&path) {
+                Ok(m) if m.is_dir() => m,
+                Ok(_) => continue,
+                Err(err) => {
+                    log::warn!("Failed to resolve skill symlink {:?}: {}", path, err);
+                    continue;
+                }
+            }
+        } else {
+            link_metadata
+        };
 
         if metadata.is_dir() {
             let nested_skill_path = path.join("SKILL.md");
@@ -535,6 +543,36 @@ mod tests {
         assert!(!names.contains(&"inner".to_string()));
 
         let _ = fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn discover_skills_follows_symlinked_skill_directories() {
+        use std::os::unix::fs::symlink;
+
+        let root = new_temp_dir("skills-symlink-discovery");
+        let target_root = new_temp_dir("skills-symlink-target");
+        let target_skill = target_root.join("brainstorming");
+        fs::create_dir_all(&target_skill).expect("create target skill dir");
+        fs::write(
+            target_skill.join("SKILL.md"),
+            "---\ndescription: symlinked skill\n---\nbody",
+        )
+        .expect("write symlinked skill");
+        symlink(&target_skill, root.join("brainstorming")).expect("create skill symlink");
+
+        let entries =
+            discover_skills_in(&root, SKILL_SOURCE_GLOBAL_CLAUDE).expect("discover skills");
+
+        let skill = entries
+            .iter()
+            .find(|entry| entry.name == "brainstorming")
+            .expect("symlinked skill directory should be discovered");
+        assert_eq!(skill.description.as_deref(), Some("symlinked skill"));
+        assert!(skill.path.ends_with("brainstorming/SKILL.md"));
+
+        let _ = fs::remove_dir_all(root);
+        let _ = fs::remove_dir_all(target_root);
     }
 
     #[test]


### PR DESCRIPTION
## Summary\n- Fixes #303.\n- Allow the local skills scanner to follow symlinks that point to skill directories.\n- Keep non-directory symlinks skipped and reuse the existing SKILL.md parsing/size checks.\n\n## Verification\n- cargo test --manifest-path src-tauri/Cargo.toml discover_skills_follows_symlinked_skill_directories\n\n## Notes\n- This is intentionally scoped to directory symlinks such as ~/.claude/skills/<name> -> external skill directory.\n- It does not add custom skill root configuration; that remains separate from #303.