### PR TITLE
fix(composer): 隔离会话技能选择状态

### DIFF
--- a/.trellis/workspace/watsonk1998/index.md
+++ b/.trellis/workspace/watsonk1998/index.md
@@ -8,8 +8,8 @@
 
 <!-- @@@auto:current-status -->
 - **Active File**: `journal-1.md`
-- **Total Sessions**: 4
-- **Last Active**: 2026-05-01
+- **Total Sessions**: 5
+- **Last Active**: 2026-05-02
 <!-- @@@/auto:current-status -->
 
 ---
@@ -19,7 +19,7 @@
 <!-- @@@auto:active-documents -->
 | File | Lines | Status |
 |------|-------|--------|
-| `journal-1.md` | ~177 | Active |
+| `journal-1.md` | ~192 | Active |
 <!-- @@@/auto:active-documents -->
 
 ---
@@ -29,6 +29,7 @@
 <!-- @@@auto:session-history -->
 | # | Date | Title | Commits | Branch |
 |---|------|-------|---------|--------|
+| 5 | 2026-05-02 | 隔离会话技能选择状态 | `df3ae9a3cb1d36a33d9d0e826fcffa3bbaf3ce60` | `fix/issue-293-clear-composer-skills` |
 | 1 | 2026-05-01 | 迁移 Claude 插件技能发现 PR 到 0.4.12 分支 | `9b1b63c623b6f2e10d234298ee81aa17506a4146` | `fix/claude-plugin-skill-discovery` |
 | 2 | 2026-05-01 | 迁移终端 Shell 配置 PR 到 0.4.12 分支 | `9bf3de6e952f2fc14aebbe2fd4efac0386481ac7` | `fix/configurable-terminal-shell` |
 | 3 | 2026-05-01 | 迁移 Claude 配置刷新 PR 到 0.4.12 分支 | `4a4963830f5a8f86f22c6a681f3babf1eaefc7c0` | `fix/claude-settings-refresh` |

--- a/.trellis/workspace/watsonk1998/journal-1.md
+++ b/.trellis/workspace/watsonk1998/journal-1.md
@@ -152,3 +152,41 @@
 ### Next Steps
 
 - None - task complete
+
+
+## Session 5: 隔离会话技能选择状态
+
+**Date**: 2026-05-02
+**Task**: 隔离会话技能选择状态
+**Branch**: `fix/issue-293-clear-composer-skills`
+
+### Summary
+
+(Add summary)
+
+### Main Changes
+
+任务目标：修复 #293 中一个会话选择 skill 后会泄漏到其他会话的问题。
+主要改动：切换 active workspace/thread 时同步清理 selectedSkillNames 与 selectedCommonsNames。
+涉及模块：Composer 状态管理与上下文来源回归测试。
+验证结果：npx vitest run src/features/composer/components/Composer.context-source-grouping.test.tsx；npx eslint src/features/composer/components/Composer.tsx src/features/composer/components/Composer.context-source-grouping.test.tsx；npm run typecheck。
+后续事项：无。
+
+
+### Git Commits
+
+| Hash | Message |
+|------|---------|
+| `df3ae9a3cb1d36a33d9d0e826fcffa3bbaf3ce60` | (see git log) |
+
+### Testing
+
+- [OK] (Add test results)
+
+### Status
+
+[OK] **Completed**
+
+### Next Steps
+
+- None - task complete

--- a/src/features/composer/components/Composer.context-source-grouping.test.tsx
+++ b/src/features/composer/components/Composer.context-source-grouping.test.tsx
@@ -50,9 +50,15 @@ type HarnessProps = {
   skills?: SkillOption[];
   commands?: CustomCommandOption[];
   onSend?: (text: string, images: string[]) => void;
+  activeThreadId?: string;
 };
 
-function ComposerHarness({ skills = [], commands = [], onSend = () => {} }: HarnessProps) {
+function ComposerHarness({
+  skills = [],
+  commands = [],
+  onSend = () => {},
+  activeThreadId = "thread-1",
+}: HarnessProps) {
   const [draftText, setDraftText] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
 
@@ -99,7 +105,7 @@ function ComposerHarness({ skills = [], commands = [], onSend = () => {} }: Harn
       dictationEnabled={false}
       editorSettings={editorSettings}
       activeWorkspaceId="ws-1"
-      activeThreadId="thread-1"
+      activeThreadId={activeThreadId}
     />
   );
 }
@@ -202,5 +208,48 @@ describe("Composer context source grouping", () => {
     expect(sentText).toBe("/build-review /team-lint 检查一下");
     expect(sentText).not.toContain("project_claude");
     expect(sentText).not.toContain("User .claude");
+  });
+
+  it("clears selected skill chips when switching threads before sending", async () => {
+    const onSend = vi.fn();
+    const skill: SkillOption = {
+      name: "review-code",
+      path: "/repo/.claude/skills/review-code/SKILL.md",
+      source: "project_claude",
+      description: "review",
+    };
+    const view = render(
+      <ComposerHarness
+        onSend={onSend}
+        skills={[skill]}
+        activeThreadId="thread-1"
+      />,
+    );
+
+    const textarea = getTextarea(view.container);
+    const value = "/review-code 帮我看一下";
+    await act(async () => {
+      fireEvent.change(textarea, {
+        target: {
+          value,
+          selectionStart: value.length,
+        },
+      });
+    });
+
+    view.rerender(
+      <ComposerHarness
+        onSend={onSend}
+        skills={[skill]}
+        activeThreadId="thread-2"
+      />,
+    );
+
+    const switchedTextarea = getTextarea(view.container);
+    await act(async () => {
+      fireEvent.keyDown(switchedTextarea, { key: "Enter", bubbles: true });
+    });
+
+    expect(onSend.mock.calls[0]?.[0]).toBe("帮我看一下");
   });
 });

--- a/src/features/composer/components/Composer.tsx
+++ b/src/features/composer/components/Composer.tsx
@@ -1397,6 +1397,11 @@ export const Composer = memo(function Composer({
 
   useEffect(() => {
     resetContextLedgerSessionState();
+    setSelectedSkillNames([]);
+    setSelectedCommonsNames([]);
+    setSelectedManualMemories([]);
+    setSelectedNoteCards([]);
+    setSelectedInlineFileReferences([]);
   }, [activeThreadId, activeWorkspaceId, resetContextLedgerSessionState]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary\n- clear selected skill and command chips when the active workspace/thread changes\n- add a regression test that switches threads after selecting a skill before sending\n\n## Issue\nFixes #293\n\n## Tests\n- npx vitest run src/features/composer/components/Composer.context-source-grouping.test.tsx\n- npx eslint src/features/composer/components/Composer.tsx src/features/composer/components/Composer.context-source-grouping.test.tsx\n- npm run typecheck