### PR TITLE
fix(settings): 修复邮件设置卡片背景

### DIFF
--- a/.trellis/workspace/watsonk1998/index.md
+++ b/.trellis/workspace/watsonk1998/index.md
@@ -8,8 +8,8 @@
 
 <!-- @@@auto:current-status -->
 - **Active File**: `journal-1.md`
-- **Total Sessions**: 4
-- **Last Active**: 2026-05-01
+- **Total Sessions**: 5
+- **Last Active**: 2026-05-02
 <!-- @@@/auto:current-status -->
 
 ---
@@ -19,7 +19,7 @@
 <!-- @@@auto:active-documents -->
 | File | Lines | Status |
 |------|-------|--------|
-| `journal-1.md` | ~177 | Active |
+| `journal-1.md` | ~192 | Active |
 <!-- @@@/auto:active-documents -->
 
 ---
@@ -29,6 +29,7 @@
 <!-- @@@auto:session-history -->
 | # | Date | Title | Commits | Branch |
 |---|------|-------|---------|--------|
+| 5 | 2026-05-02 | 修复邮件设置卡片背景 | `7bbaaba1672d08108d1f584d7d80464f559eac00` | `fix/issue-464-email-card-surface` |
 | 1 | 2026-05-01 | 迁移 Claude 插件技能发现 PR 到 0.4.12 分支 | `9b1b63c623b6f2e10d234298ee81aa17506a4146` | `fix/claude-plugin-skill-discovery` |
 | 2 | 2026-05-01 | 迁移终端 Shell 配置 PR 到 0.4.12 分支 | `9bf3de6e952f2fc14aebbe2fd4efac0386481ac7` | `fix/configurable-terminal-shell` |
 | 3 | 2026-05-01 | 迁移 Claude 配置刷新 PR 到 0.4.12 分支 | `4a4963830f5a8f86f22c6a681f3babf1eaefc7c0` | `fix/claude-settings-refresh` |

--- a/.trellis/workspace/watsonk1998/journal-1.md
+++ b/.trellis/workspace/watsonk1998/journal-1.md
@@ -152,3 +152,41 @@
 ### Next Steps
 
 - None - task complete
+
+
+## Session 5: 修复邮件设置卡片背景
+
+**Date**: 2026-05-02
+**Task**: 修复邮件设置卡片背景
+**Branch**: `fix/issue-464-email-card-surface`
+
+### Summary
+
+(Add summary)
+
+### Main Changes
+
+任务目标：修复 #464 邮件发送设置在 Windows/light theme 下出现黑框的问题，并提交独立 PR。
+主要改动：为 settings-email-card 增加独立 theme token 背景、边框、header/content 布局和 shadcn pseudo surface 覆盖；新增 CSS guard test，防止卡片退回硬编码黑色背景或依赖 basic section 作用域样式。
+涉及模块：src/styles/settings.part2.css；src/styles/settings-email-card-surface.test.ts。
+验证结果：先运行 npx vitest run src/styles/settings-email-card-surface.test.ts 得到预期红灯；实现后该测试通过；npx eslint src/styles/settings-email-card-surface.test.ts 通过；npm run typecheck 通过；npm run check:large-files 通过；git diff --check 通过。
+后续事项：创建 draft PR，base 为 chore/bump-version-0.4.12，head 为 watsonctl:fix/issue-464-email-card-surface。
+
+
+### Git Commits
+
+| Hash | Message |
+|------|---------|
+| `7bbaaba1672d08108d1f584d7d80464f559eac00` | (see git log) |
+
+### Testing
+
+- [OK] (Add test results)
+
+### Status
+
+[OK] **Completed**
+
+### Next Steps
+
+- None - task complete

--- a/src/styles/settings-email-card-surface.test.ts
+++ b/src/styles/settings-email-card-surface.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const settingsCss = readFileSync(
+  fileURLToPath(new URL("./settings.part2.css", import.meta.url)),
+  "utf8",
+);
+
+function getCssRuleBlock(css: string, selector: string): string {
+  const escapedSelector = selector
+    .replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+    .replace(/\s+/g, "\\s+");
+  const match = css.match(new RegExp(`${escapedSelector}\\s*\\{([^}]*)\\}`));
+  return match?.[1] ?? "";
+}
+
+describe("settings email card surface", () => {
+  it("keeps email sender card surfaces theme-driven outside the basic settings section", () => {
+    const cardRule = getCssRuleBlock(settingsCss, ".settings-email-card");
+    const cardBeforeRule = getCssRuleBlock(settingsCss, '.settings-email-card[data-slot="card"]::before');
+    const headerRule = getCssRuleBlock(
+      settingsCss,
+      ".settings-email-card .settings-card-switch-header",
+    );
+    const contentRule = getCssRuleBlock(
+      settingsCss,
+      ".settings-email-card .settings-basic-sounds-card-content",
+    );
+
+    expect(cardRule).toContain("background: var(--surface-card);");
+    expect(cardRule).toContain("border: 1px solid var(--border-muted);");
+    expect(cardBeforeRule).toContain("box-shadow: none;");
+    expect(headerRule).toContain("grid-template-columns: minmax(0, 1fr) auto;");
+    expect(contentRule).toContain("display: flex;");
+    expect(settingsCss).not.toMatch(
+      /\.settings-email-card\s*\{[^}]*background:\s*(?:#000|black|rgba\(\s*0,\s*0,\s*0)/is,
+    );
+  });
+});

--- a/src/styles/settings.part2.css
+++ b/src/styles/settings.part2.css
@@ -312,6 +312,52 @@
   gap: 16px;
 }
 
+.settings-email-card {
+  border: 1px solid var(--border-muted);
+  border-radius: 8px;
+  background: var(--surface-card);
+  color: var(--text-strong);
+  overflow: hidden;
+  box-shadow: none;
+}
+
+.settings-email-card[data-slot="card"]::before {
+  box-shadow: none;
+}
+
+.settings-email-card.is-enabled {
+  border-color: color-mix(in srgb, var(--primary) 30%, var(--border-muted) 70%);
+}
+
+.settings-email-card .settings-card-switch-header {
+  gap: 14px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  padding: 16px;
+  background: var(--surface-card);
+}
+
+.settings-email-card .settings-card-switch-meta {
+  min-width: 0;
+}
+
+.settings-email-card .settings-card-switch-action {
+  position: static;
+  align-self: center;
+}
+
+.settings-email-card .settings-card-switch-header .settings-toggle-subtitle {
+  margin-top: 4px;
+}
+
+.settings-email-card .settings-basic-sounds-card-content {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 0 16px 16px;
+  background: var(--surface-card);
+}
+
 .settings-form-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));


### PR DESCRIPTION
## Summary
- Fixes #464.
- Adds an explicit theme-token surface for the email sender settings card so it does not inherit the unstyled shadcn card background outside the basic settings section.
- Keeps the card header/content layout scoped to `.settings-email-card` and disables the shadcn pseudo-surface shadow that caused the visible black frame.
- Adds a CSS guard test to prevent regressions back to hard-coded black backgrounds.

## Root Cause
`EmailSenderSettings` reused `settings-basic-shadcn-card` classes, but the relevant background overrides were scoped under `.settings-section-basic`. The email sender panel is rendered under the `other` settings section, so those overrides were not applied.

## Validation
- Red first: `npx vitest run src/styles/settings-email-card-surface.test.ts` failed before the CSS fix.
- Green: `npx vitest run src/styles/settings-email-card-surface.test.ts`
- `npx eslint src/styles/settings-email-card-surface.test.ts`
- `npm run typecheck`
- `npm run check:large-files`
- `git diff --check`

## Notes
Base branch: `chore/bump-version-0.4.12`.
