### PR TITLE
fix(ci): 关闭 rust-cache 的 cargo bin 缓存避免 rustup shim 损坏

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,7 @@ jobs:
         uses: swatinem/rust-cache@v2
         with:
           workspaces: './src-tauri -> target'
+          cache-bin: false
 
       - name: Install CMake
         run: brew install cmake
@@ -203,6 +204,7 @@ jobs:
         uses: swatinem/rust-cache@v2
         with:
           workspaces: './src-tauri -> target'
+          cache-bin: false
 
       - name: install frontend dependencies
         run: npm ci
@@ -279,6 +281,7 @@ jobs:
         uses: swatinem/rust-cache@v2
         with:
           workspaces: './src-tauri -> target'
+          cache-bin: false
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
swatinem/rust-cache@v2 默认 cache-bin: true 会缓存 ~/.cargo/bin。 macOS runner 镜像升级到 rustup 1.28+ 后改用硬链接 proxy，tar 打 包时硬链接被打散，恢复后 cargo shim 实际变成 rustup-init 副本，
导致 tauri build 调用 cargo metadata 时报错。为 macOS/Linux/ Windows 三处 rust-cache 步骤显式设置 cache-bin: false，target 编译产物缓存保留不受影响。