### PR TITLE
test(project-memory): 用 findByText 修复诊断面板异步断言

### DIFF
--- a/src/features/project-memory/components/ProjectMemoryPanel.test.tsx
+++ b/src/features/project-memory/components/ProjectMemoryPanel.test.tsx
@@ -802,14 +802,16 @@ describe("ProjectMemoryPanel", () => {
       expect(mockFacade.diagnostics).toHaveBeenCalledWith("ws-1");
     });
     expect(
-      screen.getByText("Diagnostics: 2 total, 1 incomplete, 0 duplicate turn groups, 0 bad files."),
+      await screen.findByText(
+        "Diagnostics: 2 total, 1 incomplete, 0 duplicate turn groups, 0 bad files.",
+      ),
     ).toBeTruthy();
 
     fireEvent.click(screen.getByRole("button", { name: "Dry run" }));
     await waitFor(() => {
       expect(mockFacade.reconcile).toHaveBeenCalledWith("ws-1", true);
     });
-    expect(screen.getByText("Reconcile: 2 fixable, 0 fixed, 0 skipped.")).toBeTruthy();
+    expect(await screen.findByText("Reconcile: 2 fixable, 0 fixed, 0 skipped.")).toBeTruthy();
 
     fireEvent.click(screen.getByRole("button", { name: "Apply repair" }));
     fireEvent.click(screen.getAllByRole("button", { name: "Apply repair" }).at(-1)!);


### PR DESCRIPTION
## 背景
- 从 `main` 合并到 `feature/v0.5.0-md`。

## 改动点
- 

## 验证
- [ ] npm run typecheck
- [ ] npm run lint