### PR TITLE
fix(messages): prevent timeline hydration scroll jump

### DIFF
--- a/src/features/messages/components/Markdown.file-links.test.tsx
+++ b/src/features/messages/components/Markdown.file-links.test.tsx
@@ -69,6 +69,22 @@ describe("Markdown file links", () => {
     ).toBeTruthy();
   });
 
+  it("copies inline code from its copy button", async () => {
+    const writeTextMock = vi.fn(async () => undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText: writeTextMock },
+      configurable: true,
+    });
+
+    render(<Markdown value={"运行 `npm run test` 后继续。"} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "messages.copyInlineCode" }));
+
+    await waitFor(() => {
+      expect(writeTextMock).toHaveBeenCalledWith("npm run test");
+    });
+  });
+
   it("preserves fragmented inline code content during markdown normalization", () => {
     const { container } = render(
       <Markdown value={"命令是 `pnpm\nrun\nlint`，执行后继续。"} />,

--- a/src/features/messages/components/Markdown.tsx
+++ b/src/features/messages/components/Markdown.tsx
@@ -1,4 +1,6 @@
 import { Fragment, lazy, memo, startTransition, Suspense, useCallback, useEffect, useMemo, useRef, useState, isValidElement, type ImgHTMLAttributes, type ReactNode, type MouseEvent } from "react";
+import Check from "lucide-react/dist/esm/icons/check";
+import Copy from "lucide-react/dist/esm/icons/copy";
 import { useTranslation } from "react-i18next";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { convertFileSrc } from "@tauri-apps/api/core";
@@ -80,6 +82,58 @@ type MarkdownProps = {
   onRenderedValueChange?: (value: string) => void;
   onOutlineReady?: (outline: MarkdownOutlineEntry[]) => void;
 };
+
+type InlineCodeProps = {
+  children: ReactNode;
+  text: string;
+};
+
+function InlineCode({ children, text }: InlineCodeProps) {
+  const { t } = useTranslation();
+  const [copied, setCopied] = useState(false);
+  const copyTimeoutRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (copyTimeoutRef.current) {
+        window.clearTimeout(copyTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const handleCopy = async (event: MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      if (copyTimeoutRef.current) {
+        window.clearTimeout(copyTimeoutRef.current);
+      }
+      copyTimeoutRef.current = window.setTimeout(() => {
+        setCopied(false);
+      }, 1200);
+    } catch {
+      // No-op: clipboard errors can occur in restricted contexts.
+    }
+  };
+
+  return (
+    <span className={`markdown-inline-code-copy${copied ? " is-copied" : ""}`}>
+      <code>{children}</code>
+      <button
+        type="button"
+        className="markdown-inline-code-copy-button"
+        onClick={handleCopy}
+        aria-label={t("messages.copyInlineCode", "复制行内代码")}
+        title={copied ? t("messages.copied") : t("messages.copyInlineCode", "复制行内代码")}
+      >
+        <Copy className="markdown-inline-code-copy-icon markdown-inline-code-copy-icon-copy" size={11} />
+        <Check className="markdown-inline-code-copy-icon markdown-inline-code-copy-icon-check" size={11} />
+      </button>
+    </span>
+  );
+}
 
 type CodeBlockProps = {
   className?: string;
@@ -2004,9 +2058,10 @@ export const Markdown = memo(function Markdown({
         if (codeClassName) {
           return <code className={codeClassName}>{children}</code>;
         }
-        const text = String(children ?? "").trim();
+        const text = flattenNodeText(children).trim();
+        const inlineCode = <InlineCode text={text}>{children}</InlineCode>;
         if (!text || !isLinkableFilePath(text)) {
-          return <code>{children}</code>;
+          return inlineCode;
         }
         const href = toFileLink(text);
         return (
@@ -2015,7 +2070,7 @@ export const Markdown = memo(function Markdown({
             onClick={(event) => handleFileLinkClick(event, text)}
             onContextMenu={(event) => handleFileLinkContextMenu(event, text)}
           >
-            <code>{children}</code>
+            {inlineCode}
           </a>
         );
       },

--- a/src/features/messages/components/MessagesTimeline.tsx
+++ b/src/features/messages/components/MessagesTimeline.tsx
@@ -101,6 +101,27 @@ const TIMELINE_RENDER_WEIGHT_DIAGNOSTIC_COOLDOWN_MS = 5_000;
 const TIMELINE_HYDRATION_REMEASURE_DIAGNOSTIC_COOLDOWN_MS = 5_000;
 const CONVERSATION_LIGHTWEIGHT_DIAGNOSTIC_COOLDOWN_MS = 5_000;
 const TIMELINE_LIVE_ROW_BOTTOM_PROXIMITY_PX = 720;
+const TIMELINE_SCROLL_DIAGNOSTIC_MIN_INTERVAL_MS = 250;
+const TIMELINE_SCROLL_DIAGNOSTIC_MIN_DELTA_PX = 24;
+
+type TimelineScrollDiagnosticSnapshot = {
+  clientHeight: number;
+  distanceFromBottom: number;
+  scrollHeight: number;
+  scrollTop: number;
+};
+
+function collectTimelineScrollDiagnosticSnapshot(
+  element: HTMLElement,
+): TimelineScrollDiagnosticSnapshot {
+  const distanceFromBottom = element.scrollHeight - element.scrollTop - element.clientHeight;
+  return {
+    clientHeight: Math.round(element.clientHeight),
+    distanceFromBottom: Math.round(distanceFromBottom),
+    scrollHeight: Math.round(element.scrollHeight),
+    scrollTop: Math.round(element.scrollTop),
+  };
+}
 
 type MessagesTimelineProps = {
   activeCollaborationModeId: string | null;
@@ -348,6 +369,15 @@ export const MessagesTimeline = memo(function MessagesTimeline({
     at: number;
     signature: string;
   }>({ at: 0, signature: "" });
+  const lastTimelineScrollDiagnosticRef = useRef<{
+    at: number;
+    eventKind: string;
+    snapshot: TimelineScrollDiagnosticSnapshot | null;
+  }>({ at: 0, eventKind: "", snapshot: null });
+  const retainedHydratedTimelineRowKeysRef = useRef<{
+    scopeKey: string;
+    rowKeys: Set<string>;
+  }>({ scopeKey: "", rowKeys: new Set() });
   const lastVirtualizedTimelineScopeResetRef = useRef<string | null>(null);
 
   useEffect(() => {
@@ -519,6 +549,90 @@ export const MessagesTimeline = memo(function MessagesTimeline({
     () => virtualTimelineRows.map((row) => row.key),
     [virtualTimelineRows],
   );
+
+  useEffect(() => {
+    const scrollElement = scrollElementRef.current;
+    if (!scrollElement) {
+      return undefined;
+    }
+
+    const appendScrollDiagnostic = (
+      eventKind: "scroll" | "scrollend" | "wheel",
+      extra: Record<string, unknown> = {},
+    ) => {
+      const snapshot = collectTimelineScrollDiagnosticSnapshot(scrollElement);
+      const previous = lastTimelineScrollDiagnosticRef.current;
+      const now = Date.now();
+      const previousSnapshot = previous.snapshot;
+      const scrollTopDelta = previousSnapshot
+        ? snapshot.scrollTop - previousSnapshot.scrollTop
+        : 0;
+      const distanceFromBottomDelta = previousSnapshot
+        ? snapshot.distanceFromBottom - previousSnapshot.distanceFromBottom
+        : 0;
+      const isMeaningfulDelta =
+        Math.abs(scrollTopDelta) >= TIMELINE_SCROLL_DIAGNOSTIC_MIN_DELTA_PX ||
+        Math.abs(distanceFromBottomDelta) >= TIMELINE_SCROLL_DIAGNOSTIC_MIN_DELTA_PX ||
+        eventKind === "wheel" ||
+        previous.eventKind !== eventKind;
+      if (
+        !isMeaningfulDelta ||
+        now - previous.at < TIMELINE_SCROLL_DIAGNOSTIC_MIN_INTERVAL_MS
+      ) {
+        return;
+      }
+      lastTimelineScrollDiagnosticRef.current = { at: now, eventKind, snapshot };
+      appendRendererDiagnostic("messages/timeline-scroll-behavior", {
+        component: "MessagesTimeline",
+        eventKind,
+        threadId,
+        workspaceId: workspaceId ?? null,
+        isThinking,
+        isWorking,
+        shouldVirtualizeTimeline,
+        rowCount: timelineProjectionRows.length,
+        renderWeight: timelineRenderWeightSummary.renderWeight,
+        virtualItemCount: virtualTimelineRowKeys.length,
+        activeLiveRowCount: activeLiveTimelineRowKeys.length,
+        scrollTopDelta: Math.round(scrollTopDelta),
+        distanceFromBottomDelta: Math.round(distanceFromBottomDelta),
+        ...snapshot,
+        ...extra,
+      });
+    };
+
+    const handleScroll = () => appendScrollDiagnostic("scroll");
+    const handleScrollEnd = () => appendScrollDiagnostic("scrollend");
+    const handleWheel = (event: WheelEvent) => {
+      appendScrollDiagnostic("wheel", {
+        deltaMode: event.deltaMode,
+        deltaX: Math.round(event.deltaX),
+        deltaY: Math.round(event.deltaY),
+      });
+    };
+
+    scrollElement.addEventListener("scroll", handleScroll, { passive: true });
+    scrollElement.addEventListener("wheel", handleWheel, { passive: true });
+    scrollElement.addEventListener("scrollend", handleScrollEnd, { passive: true });
+    appendScrollDiagnostic("scroll", { reason: "listener-attached" });
+    return () => {
+      scrollElement.removeEventListener("scroll", handleScroll);
+      scrollElement.removeEventListener("wheel", handleWheel);
+      scrollElement.removeEventListener("scrollend", handleScrollEnd);
+    };
+  }, [
+    activeLiveTimelineRowKeys.length,
+    isThinking,
+    isWorking,
+    scrollElementRef,
+    shouldVirtualizeTimeline,
+    threadId,
+    timelineProjectionRows.length,
+    timelineRenderWeightSummary.renderWeight,
+    virtualTimelineRowKeys.length,
+    workspaceId,
+  ]);
+
   const visibleTimelineRowKeySet = useMemo(
     () => new Set(virtualTimelineRowKeys.map(String)),
     [virtualTimelineRowKeys],
@@ -553,6 +667,15 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       presentationProfile?.preferCommandSummary,
     ],
   );
+  const retainedHydratedTimelineRowScopeKey = `${virtualizedTimelineScopeKey} ${timelineRendererOptionsKey}`;
+  const retainedHydratedTimelineRowKeys = useMemo(() => {
+    const retained = retainedHydratedTimelineRowKeysRef.current;
+    if (retained.scopeKey !== retainedHydratedTimelineRowScopeKey) {
+      retained.scopeKey = retainedHydratedTimelineRowScopeKey;
+      retained.rowKeys = new Set();
+    }
+    return retained.rowKeys;
+  }, [retainedHydratedTimelineRowScopeKey]);
   const timelineRowHydrationStates = useMemo(
     () => {
       if (isThinking || isWorking) {
@@ -566,15 +689,22 @@ export const MessagesTimeline = memo(function MessagesTimeline({
           hydrationReason: "not-heavy" as const,
         }));
       }
-      return deriveTimelineRowHydrationStates({
+      const nextStates = deriveTimelineRowHydrationStates({
         rows: timelineProjectionRows,
         shouldVirtualize: shouldDeferHeavyTimelineRows,
         visibleRowKeys: shouldVirtualizeTimeline ? visibleTimelineRowKeySet : new Set<string>(),
         activeRowKeys: activeLiveTimelineRowKeySet,
+        retainedHydratedRowKeys: retainedHydratedTimelineRowKeys,
         anchorTargetRowKey: pendingJumpRowKey,
         detailHydrationRequested: conversationDetailHydrationRequested,
         rendererOptionsKey: timelineRendererOptionsKey,
       });
+      for (const state of nextStates) {
+        if (state.heavy && state.mode === "hydrated") {
+          retainedHydratedTimelineRowKeys.add(state.rowKey);
+        }
+      }
+      return nextStates;
     },
     [
       activeLiveTimelineRowKeySet,
@@ -582,6 +712,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       isThinking,
       isWorking,
       pendingJumpRowKey,
+      retainedHydratedTimelineRowKeys,
       shouldDeferHeavyTimelineRows,
       shouldVirtualizeTimeline,
       timelineRendererOptionsKey,

--- a/src/features/messages/components/messagesTimelineHydration.test.ts
+++ b/src/features/messages/components/messagesTimelineHydration.test.ts
@@ -50,6 +50,31 @@ describe("messagesTimelineHydration", () => {
     expect(countHydratedHeavyTimelineRows(states)).toBe(3);
   });
 
+  it("retains heavy row hydration after it leaves the visible set", () => {
+    const { rows } = createHeavyHistoryFixture("heavy");
+    const heavyCandidateRows = deriveTimelineRowHydrationStates({
+      rows,
+      shouldVirtualize: false,
+      visibleRowKeys: new Set(),
+      activeRowKeys: new Set(),
+      anchorTargetRowKey: null,
+    }).filter((state) => state.heavy);
+    const retainedHeavyRowKey = heavyCandidateRows[0]?.rowKey ?? "";
+
+    const states = deriveTimelineRowHydrationStates({
+      rows,
+      shouldVirtualize: true,
+      visibleRowKeys: new Set(),
+      activeRowKeys: new Set(),
+      retainedHydratedRowKeys: new Set([retainedHeavyRowKey]),
+      anchorTargetRowKey: null,
+    });
+    const retainedState = states.find((state) => state.rowKey === retainedHeavyRowKey);
+
+    expect(retainedState?.mode).toBe("hydrated");
+    expect(retainedState?.hydrationReason).toBe("visible");
+  });
+
   it("hydrates every heavy row after explicit detail hydration is requested", () => {
     const { rows } = createHeavyHistoryFixture("heavy");
     const states = deriveTimelineRowHydrationStates({

--- a/src/features/messages/components/messagesTimelineHydration.ts
+++ b/src/features/messages/components/messagesTimelineHydration.ts
@@ -82,6 +82,7 @@ export function deriveTimelineRowHydrationStates(input: {
   shouldVirtualize: boolean;
   visibleRowKeys: ReadonlySet<string>;
   activeRowKeys: ReadonlySet<string>;
+  retainedHydratedRowKeys?: ReadonlySet<string>;
   anchorTargetRowKey?: string | null;
   detailHydrationRequested?: boolean;
   heavyRowWeight?: number;
@@ -148,7 +149,7 @@ export function deriveTimelineRowHydrationStates(input: {
         hydrationReason: "anchor",
       };
     }
-    if (input.visibleRowKeys.has(row.key)) {
+    if (input.visibleRowKeys.has(row.key) || input.retainedHydratedRowKeys?.has(row.key)) {
       return {
         rowKey: row.key,
         contentHash: getRowContentHash(row, rendererOptionsKey),

--- a/src/features/messages/components/messagesTimelineVirtualization.test.ts
+++ b/src/features/messages/components/messagesTimelineVirtualization.test.ts
@@ -45,15 +45,15 @@ describe("messagesTimelineVirtualization", () => {
     })).toBe(false);
   });
 
-  it("keeps active streaming timelines virtualized when rowCount is above the minimum (chat-stream-render-isolation-2026-06 task 2.1)", () => {
+  it("keeps active streaming timelines in static flow to avoid bottom-follow jumps", () => {
     expect(shouldVirtualizeTimelineRows({
       isThinking: true,
       rowCount: 1_000,
-    })).toBe(true);
+    })).toBe(false);
     expect(shouldVirtualizeTimelineRows({
       isThinking: true,
       rowCount: 200,
-    })).toBe(true);
+    })).toBe(false);
     expect(shouldVirtualizeTimelineRows({
       isThinking: true,
       rowCount: 50,
@@ -385,6 +385,21 @@ describe("messagesTimelineVirtualization", () => {
     expect(exhaustedRecovery.shouldRemeasure).toBe(true);
     expect(exhaustedRecovery.nextBudget.remeasureCount).toBe(1);
     expect(exhaustedRecovery.remeasureSuppressed).toBe(false);
+  });
+
+  it("measures first stable virtualized history mount without jumping to top", () => {
+    expect(resolveVirtualizedTimelineScopeReset({
+      previousScopeKey: null,
+      nextScopeKey: "ws-1 thread-1 200 120 virtualized",
+      shouldVirtualize: true,
+      stableHistoryView: true,
+      hasPendingJump: false,
+      hasScrollElement: true,
+    })).toEqual({
+      nextScopeKey: "ws-1 thread-1 200 120 virtualized",
+      shouldResetScroll: false,
+      shouldMeasure: true,
+    });
   });
 
   it("resets stale scroll scope only for a new stable virtualized history thread", () => {

--- a/src/features/messages/components/messagesTimelineVirtualization.ts
+++ b/src/features/messages/components/messagesTimelineVirtualization.ts
@@ -41,14 +41,11 @@ export type TimelineRenderWeightSummary = {
 };
 
 /**
- * Escape hatch for chat-stream-render-isolation-2026-06 task 2.1.
- * When `true`, `shouldVirtualizeTimelineRows` keeps the long-row virtualizer
- * enabled during streaming even when `isThinking === true`; the legacy
- * `!isThinking` short-circuit only ran for short conversations and let
- * row counts above 200 produce unvirtualized DOM trees during long
- * parallel-streaming sessions.
+ * Keep active streaming timelines in static flow. Live rows change height while
+ * auto-follow scrolls to the tail; virtualizer offset correction can otherwise
+ * fight bottom-follow and produce rapid up/down jumps in long conversations.
  */
-export const TIMELINE_VIRTUALIZATION_DURING_STREAMING_ENABLED = true;
+export const TIMELINE_VIRTUALIZATION_DURING_STREAMING_ENABLED = false;
 
 function canReadBaselineFlag() {
   if (typeof globalThis === "undefined") {
@@ -79,7 +76,8 @@ export function shouldVirtualizeTimelineRows(input: {
   renderWeight?: number;
 }) {
   if (input.isThinking) {
-    return input.rowCount >= TIMELINE_VIRTUALIZATION_MIN_ROWS;
+    return TIMELINE_VIRTUALIZATION_DURING_STREAMING_ENABLED &&
+      input.rowCount >= TIMELINE_VIRTUALIZATION_MIN_ROWS;
   }
   const renderWeightGateEnabled = isTimelineRenderWeightGateEnabled();
   const hasHighRenderDensity = renderWeightGateEnabled &&
@@ -569,22 +567,21 @@ export function resolveVirtualizedTimelineScopeReset(input: {
       shouldMeasure: false,
     };
   }
-  if (input.previousScopeKey === input.nextScopeKey) {
-    return {
-      nextScopeKey: input.previousScopeKey,
-      shouldResetScroll: false,
-      shouldMeasure: false,
-    };
-  }
-  if (
-    input.previousScopeKey !== null &&
-    resolveVirtualizedTimelineScopeIdentity(input.previousScopeKey) ===
-      resolveVirtualizedTimelineScopeIdentity(input.nextScopeKey)
-  ) {
+  if (input.previousScopeKey === null) {
     return {
       nextScopeKey: input.nextScopeKey,
       shouldResetScroll: false,
       shouldMeasure: true,
+    };
+  }
+  if (
+    resolveVirtualizedTimelineScopeIdentity(input.previousScopeKey) ===
+    resolveVirtualizedTimelineScopeIdentity(input.nextScopeKey)
+  ) {
+    return {
+      nextScopeKey: input.nextScopeKey,
+      shouldResetScroll: false,
+      shouldMeasure: input.previousScopeKey !== input.nextScopeKey,
     };
   }
   return {
@@ -595,8 +592,8 @@ export function resolveVirtualizedTimelineScopeReset(input: {
 }
 
 function resolveVirtualizedTimelineScopeIdentity(scopeKey: string): string {
-  const [workspaceId = "", threadId = "", , , mode = ""] = scopeKey.split("\u0000");
-  return [workspaceId, threadId, mode].join("\u0000");
+  const [workspaceId = "", threadId = ""] = scopeKey.split("\u0000");
+  return [workspaceId, threadId].join("\u0000");
 }
 
 export function observeTimelineElementOffset<TScrollElement extends Element>(

--- a/src/i18n/locales/en.part1.ts
+++ b/src/i18n/locales/en.part1.ts
@@ -2749,6 +2749,7 @@ const enPart1 = {
     toggleDetails: "Toggle details",
     copyCodeBlock: "Copy code block",
     copyCodeBlockWithFence: "Copy fenced code block",
+    copyInlineCode: "Copy inline code",
     copy: "Copy",
     copyWithFence: "Fence copy",
     toolCallCard: {

--- a/src/i18n/locales/zh.part1.ts
+++ b/src/i18n/locales/zh.part1.ts
@@ -2714,6 +2714,7 @@ const zhPart1 = {
     toggleDetails: "切换详情",
     copyCodeBlock: "复制代码块",
     copyCodeBlockWithFence: "复制带围栏代码块",
+    copyInlineCode: "复制行内代码",
     copy: "复制",
     copyWithFence: "围栏复制",
     toolCallCard: {

--- a/src/styles/messages.part2.css
+++ b/src/styles/messages.part2.css
@@ -318,13 +318,64 @@
   line-height: var(--code-line-height, 1.28);
 }
 
-.message .markdown :not(pre) > code {
+.message .markdown :not(pre) > code,
+.message .markdown .markdown-inline-code-copy > code {
   color: var(--text-stronger);
   background: color-mix(in srgb, var(--surface-command) 82%, transparent);
   border: 1px solid var(--border-subtle);
   padding: 1px 5px;
   border-radius: 6px;
   font-size: 0.97em;
+}
+
+.message .markdown .markdown-inline-code-copy {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  vertical-align: baseline;
+}
+
+.message .markdown .markdown-inline-code-copy-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--surface-command) 74%, transparent);
+  color: var(--text-muted);
+  cursor: pointer;
+  opacity: 0;
+  transform: translateY(1px);
+  transition: opacity 120ms ease, color 120ms ease, border-color 120ms ease, background 120ms ease;
+}
+
+.message .markdown .markdown-inline-code-copy:hover .markdown-inline-code-copy-button,
+.message .markdown .markdown-inline-code-copy:focus-within .markdown-inline-code-copy-button,
+.message .markdown .markdown-inline-code-copy.is-copied .markdown-inline-code-copy-button {
+  opacity: 1;
+}
+
+.message .markdown .markdown-inline-code-copy-button:hover,
+.message .markdown .markdown-inline-code-copy-button:focus-visible {
+  color: var(--text-stronger);
+  border-color: var(--border-strong);
+  background: var(--surface-control-hover);
+}
+
+.message .markdown .markdown-inline-code-copy-icon-check {
+  display: none;
+}
+
+.message .markdown .markdown-inline-code-copy.is-copied .markdown-inline-code-copy-icon-copy {
+  display: none;
+}
+
+.message .markdown .markdown-inline-code-copy.is-copied .markdown-inline-code-copy-icon-check {
+  display: block;
+  color: var(--status-success, #22c55e);
 }
 
 .message .markdown .katex {


### PR DESCRIPTION
## Summary
- retain hydrated heavy rows within the same timeline scope to break the summary/hydrated feedback loop
- keep streaming timelines in static flow to avoid bottom-follow scroll oscillation while live rows resize
- add regression coverage for hydration retention and inline code copy behavior

## Verification
- npm exec vitest run src/features/messages/components/messagesTimelineHydration.test.ts src/features/messages/components/messagesTimelineVirtualization.test.ts src/features/messages/components/Markdown.file-links.test.tsx
- npm run typecheck

## Notes
- this PR intentionally excludes local-only workflow files and machine-specific launcher changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)