### PR TITLE
fix(daemon): 修复启动不可达并暴露 Codex 历史读取

### DIFF
--- a/.trellis/workspace/zhanghang/index.md
+++ b/.trellis/workspace/zhanghang/index.md
@@ -1,0 +1,41 @@
+# Workspace Index - zhanghang
+
+> Journal tracking for AI development sessions.
+
+---
+
+## Current Status
+
+<!-- @@@auto:current-status -->
+- **Active File**: `journal-1.md`
+- **Total Sessions**: 1
+- **Last Active**: 2026-07-10
+<!-- @@@/auto:current-status -->
+
+---
+
+## Active Documents
+
+<!-- @@@auto:active-documents -->
+| File | Lines | Status |
+|------|-------|--------|
+| `journal-1.md` | ~54 | Active |
+<!-- @@@/auto:active-documents -->
+
+---
+
+## Session History
+
+<!-- @@@auto:session-history -->
+| # | Date | Title | Commits | Branch |
+|---|------|-------|---------|--------|
+| 1 | 2026-07-10 | 更新 daemon 修复 PR | `68dc272f` | `pr-752-update` |
+<!-- @@@/auto:session-history -->
+
+---
+
+## Notes
+
+- Sessions are appended to journal files
+- New journal file created when current exceeds 2000 lines
+- Use `add_session.py` to record sessions

--- a/.trellis/workspace/zhanghang/journal-1.md
+++ b/.trellis/workspace/zhanghang/journal-1.md
@@ -1,0 +1,54 @@
+# Journal - zhanghang (Part 1)
+
+> AI development session journal
+> Started: 2026-07-10
+
+---
+
+
+
+## Session 1: 更新 daemon 修复 PR
+
+**Date**: 2026-07-10
+**Task**: 更新 daemon 修复 PR
+**Branch**: `pr-752-update`
+
+### Summary
+
+(Add summary)
+
+### Main Changes
+
+目标：更新 PR #752 到最新 upstream main，并包含本会话全部 daemon 修复。
+
+主要改动：
+- 将旧 PR 的 orphan_sweep_on_startup blocking_lock panic 修复和 daemon stderr 日志捕获 rebase 到 origin/main f63b2aa7。
+- 新增 daemon JSON-RPC 的 load_codex_session dispatch，复用 local_usage 的 Codex session loader，修复远程 Web Codex 历史读取为空白的问题。
+- 新增回归测试，确保 daemon dispatch 暴露 load_codex_session，且 startup orphan sweep 不再使用 diagnostics.blocking_lock()。
+
+验证：
+- npm run build
+- cargo test --manifest-path src-tauri/Cargo.toml orphan_sweep_on_startup -- --nocapture
+- cargo test --manifest-path src-tauri/Cargo.toml --bin cc_gui_daemon daemon_dispatch_exposes_codex_history_loader -- --nocapture
+- cargo build --manifest-path src-tauri/Cargo.toml --release --bin cc_gui_daemon
+
+后续：推送 pr-752-update 到 zhanghang02/fix/daemon-orphan-sweep-blocking-lock-panic，并更新 GitHub PR 正文。
+
+
+### Git Commits
+
+| Hash | Message |
+|------|---------|
+| `68dc272f` | (see git log) |
+
+### Testing
+
+- [OK] (Add test results)
+
+### Status
+
+[OK] **Completed**
+
+### Next Steps
+
+- None - task complete

--- a/src-tauri/src/bin/cc_gui_daemon.rs
+++ b/src-tauri/src/bin/cc_gui_daemon.rs
@@ -1881,6 +1881,11 @@ async fn handle_rpc_request(
             let session_id = parse_string(&params, "sessionId")?;
             state.load_gemini_session(workspace_path, session_id).await
         }
+        "load_codex_session" => {
+            let workspace_id = parse_string(&params, "workspaceId")?;
+            let session_id = parse_string(&params, "sessionId")?;
+            state.load_codex_session(workspace_id, session_id).await
+        }
         "delete_gemini_session" => {
             let workspace_path = parse_string(&params, "workspacePath")?;
             let session_id = parse_string(&params, "sessionId")?;
@@ -2263,4 +2268,16 @@ fn main() {
             }
         }
     });
+}
+
+#[cfg(test)]
+mod ccgui_repair_regression_tests {
+    #[test]
+    fn daemon_dispatch_exposes_codex_history_loader() {
+        let daemon_dispatch = include_str!("cc_gui_daemon.rs");
+        assert!(
+            daemon_dispatch.contains("\"load_codex_session\" =>"),
+            "daemon dispatch is missing load_codex_session"
+        );
+    }
 }

--- a/src-tauri/src/bin/cc_gui_daemon/daemon_state.rs
+++ b/src-tauri/src/bin/cc_gui_daemon/daemon_state.rs
@@ -2227,6 +2227,15 @@ impl DaemonState {
         serde_json::to_value(result).map_err(|error| error.to_string())
     }
 
+    pub(super) async fn load_codex_session(
+        &self,
+        workspace_id: String,
+        session_id: String,
+    ) -> Result<Value, String> {
+        local_usage::load_codex_session_for_workspace(&self.workspaces, workspace_id, session_id)
+            .await
+    }
+
     pub(super) async fn hydrate_claude_deferred_image(
         &self,
         workspace_path: String,

--- a/src-tauri/src/local_usage.rs
+++ b/src-tauri/src/local_usage.rs
@@ -288,6 +288,14 @@ pub(crate) async fn load_codex_session(
     session_id: String,
     state: State<'_, AppState>,
 ) -> Result<Value, String> {
+    load_codex_session_for_workspace(&state.workspaces, workspace_id, session_id).await
+}
+
+pub(crate) async fn load_codex_session_for_workspace(
+    workspaces: &Mutex<HashMap<String, WorkspaceEntry>>,
+    workspace_id: String,
+    session_id: String,
+) -> Result<Value, String> {
     let workspace_id = workspace_id.trim().to_string();
     let session_id = session_id.trim().to_string();
     if workspace_id.is_empty() {
@@ -301,7 +309,7 @@ pub(crate) async fn load_codex_session(
     }
 
     let (workspace_path, sessions_roots) = {
-        let workspaces = state.workspaces.lock().await;
+        let workspaces = workspaces.lock().await;
         let entry = workspaces
             .get(&workspace_id)
             .ok_or_else(|| "workspace not found".to_string())?;

--- a/src-tauri/src/runtime/ledger.rs
+++ b/src-tauri/src/runtime/ledger.rs
@@ -187,6 +187,13 @@ impl RuntimeManager {
         if let Ok(serialized) = serde_json::to_string_pretty(&payload) {
             let _ = write_json_atomically(&self.ledger_path, &serialized);
         }
-        *self.diagnostics.blocking_lock() = diagnostics;
+        // This runs during startup before any concurrent access, so the lock is
+        // always immediately available. Use `try_lock` instead of `blocking_lock`
+        // because this method is invoked from within a Tokio runtime in the daemon
+        // (`runtime.block_on(... DaemonState::load ...)`), and `blocking_lock`
+        // panics when called from a thread that is driving async tasks.
+        if let Ok(mut guard) = self.diagnostics.try_lock() {
+            *guard = diagnostics;
+        }
     }
 }

--- a/src-tauri/src/runtime/tests.rs
+++ b/src-tauri/src/runtime/tests.rs
@@ -1621,3 +1621,12 @@ fn write_json_atomically_replaces_existing_file() {
 
     let _ = fs::remove_dir_all(&temp_dir);
 }
+
+#[test]
+fn orphan_sweep_on_startup_must_not_block_lock_diagnostics() {
+    let ledger_source = include_str!("ledger.rs");
+    assert!(
+        !ledger_source.contains("diagnostics.blocking_lock()"),
+        "startup orphan sweep runs during daemon bootstrap and must not use blocking_lock"
+    );
+}

--- a/src-tauri/src/web_service/daemon_bootstrap.rs
+++ b/src-tauri/src/web_service/daemon_bootstrap.rs
@@ -74,14 +74,25 @@ pub(crate) async fn maybe_start_local_daemon_for_remote(
         command.arg("--insecure-no-auth");
     }
 
-    if let Ok(data_dir) = app.path().app_data_dir() {
-        command.arg("--data-dir").arg(data_dir);
+    let (data_dir, fallback_stderr) = match app.path().app_data_dir() {
+        Ok(dir) => (Some(dir), None),
+        Err(_) => (None, Some(capture_fallback_stderr_tmpdir())),
+    };
+    if let Some(ref dir) = data_dir {
+        command.arg("--data-dir").arg(dir);
     }
+
+    let daemon_stderr = data_dir
+        .as_ref()
+        .map(|dir| dir.as_path())
+        .and_then(capture_daemon_stderr)
+        .or(fallback_stderr)
+        .unwrap_or(Stdio::null());
 
     command
         .stdin(Stdio::null())
         .stdout(Stdio::null())
-        .stderr(Stdio::null());
+        .stderr(daemon_stderr);
 
     command.spawn().map_err(|error| {
         format!(
@@ -539,6 +550,30 @@ fn daemon_binary_names() -> &'static [&'static str] {
     {
         &["cc_gui_daemon", "moss_x_daemon", "moss-x-daemon"]
     }
+}
+
+/// Open a log file in the daemon's data directory to capture stderr output.
+/// Returns `Stdio::null()` if the file cannot be opened (degradation, not a crash).
+fn capture_daemon_stderr(base: &Path) -> Option<Stdio> {
+    let path = base.join("daemon_stderr.log");
+    std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .ok()
+        .map(Stdio::from)
+}
+
+/// Fallback stderr capture when `app_data_dir` is unavailable.
+fn capture_fallback_stderr_tmpdir() -> Stdio {
+    let path = std::env::temp_dir().join("cc_gui_daemon_stderr.log");
+    std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .ok()
+        .map(Stdio::from)
+        .unwrap_or(Stdio::null())
 }
 
 fn find_in_path(binary: &str) -> Option<PathBuf> {


### PR DESCRIPTION
## Summary

- Rebased the daemon fix branch onto the current PR base `chore/bump-version-0.7.0`.
- Keeps the original daemon startup fixes:
  - avoid `blocking_lock()` panic during `RuntimeManager::orphan_sweep_on_startup`
  - capture daemon stderr into a log file instead of swallowing startup failures
- Adds the remote Web Codex history fix:
  - expose `load_codex_session` through daemon JSON-RPC
  - reuse the existing local Codex session loader for daemon state
  - add regression coverage for the daemon RPC dispatch and startup lock behavior

## Verification

- `npm run build`
- `cargo test --manifest-path src-tauri/Cargo.toml orphan_sweep_on_startup -- --nocapture`
- `cargo test --manifest-path src-tauri/Cargo.toml --bin cc_gui_daemon daemon_dispatch_exposes_codex_history_loader -- --nocapture`
- `cargo build --manifest-path src-tauri/Cargo.toml --release --bin cc_gui_daemon`