### PR TITLE
fix(dev,composer): 修复本地开发启动和图片粘贴

### DIFF
--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -1,5 +1,7 @@
 import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { accessSync, constants, existsSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
 
 const strict = process.argv.includes("--strict");
 
@@ -10,9 +12,11 @@ const CMAKE_WINDOWS_PATHS = [
 ];
 
 function hasCommand(command) {
-  const checker = process.platform === "win32" ? "where" : "command";
-  const checkerArgs = process.platform === "win32" ? [command] : ["-v", command];
-  const result = spawnSync(checker, checkerArgs, { stdio: "ignore" });
+  if (process.platform !== "win32") {
+    return hasExecutableOnPath(command);
+  }
+
+  const result = spawnSync("where", [command], { stdio: "ignore" });
   if (result.status === 0) return true;
 
   // On Windows, also check common installation paths
@@ -26,33 +30,54 @@ function hasCommand(command) {
   return false;
 }
 
-const missing = [];
-if (!hasCommand("cmake")) missing.push("cmake");
-
-if (missing.length === 0) {
-  console.log("Doctor: OK");
-  process.exit(0);
+export function hasExecutableOnPath(command, searchPath = process.env.PATH ?? "") {
+  for (const directory of searchPath.split(path.delimiter)) {
+    if (!directory) {
+      continue;
+    }
+    const candidate = path.join(directory, command);
+    try {
+      accessSync(candidate, constants.X_OK);
+      return true;
+    } catch {
+      // Keep scanning PATH entries.
+    }
+  }
+  return false;
 }
 
-console.log(`Doctor: missing dependencies: ${missing.join(" ")}`);
+export function runDoctor({ strictMode = strict } = {}) {
+  const missing = [];
+  if (!hasCommand("cmake")) missing.push("cmake");
 
-switch (process.platform) {
-  case "darwin":
-    console.log("Install: brew install cmake");
-    break;
-  case "linux":
-    console.log("Ubuntu/Debian: sudo apt-get install cmake");
-    console.log("Fedora: sudo dnf install cmake");
-    console.log("Arch: sudo pacman -S cmake");
-    break;
-  case "win32":
-    console.log("Install: choco install cmake");
-    console.log("Or download from: https://cmake.org/download/");
-    break;
-  default:
-    console.log("Install CMake from: https://cmake.org/download/");
-    break;
+  if (missing.length === 0) {
+    console.log("Doctor: OK");
+    return 0;
+  }
+
+  console.log(`Doctor: missing dependencies: ${missing.join(" ")}`);
+
+  switch (process.platform) {
+    case "darwin":
+      console.log("Install: brew install cmake");
+      break;
+    case "linux":
+      console.log("Ubuntu/Debian: sudo apt-get install cmake");
+      console.log("Fedora: sudo dnf install cmake");
+      console.log("Arch: sudo pacman -S cmake");
+      break;
+    case "win32":
+      console.log("Install: choco install cmake");
+      console.log("Or download from: https://cmake.org/download/");
+      break;
+    default:
+      console.log("Install CMake from: https://cmake.org/download/");
+      break;
+  }
+
+  return strictMode ? 1 : 0;
 }
 
-process.exit(strict ? 1 : 0);
-
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  process.exit(runDoctor());
+}

--- a/scripts/doctor.test.mjs
+++ b/scripts/doctor.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { hasExecutableOnPath } from "./doctor.mjs";
+
+test("doctor accepts executable cmake found on PATH", async () => {
+  const tempDir = await mkdtemp(path.join(tmpdir(), "ccgui-doctor-"));
+  try {
+    const cmakePath = path.join(tempDir, "cmake");
+    await writeFile(cmakePath, "#!/bin/sh\nexit 0\n", "utf8");
+    await chmod(cmakePath, 0o755);
+
+    assert.equal(hasExecutableOnPath("cmake", tempDir), true);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("doctor rejects non-executable cmake files on PATH", async () => {
+  const tempDir = await mkdtemp(path.join(tmpdir(), "ccgui-doctor-"));
+  try {
+    const cmakePath = path.join(tempDir, "cmake");
+    await writeFile(cmakePath, "#!/bin/sh\nexit 0\n", "utf8");
+    await chmod(cmakePath, 0o644);
+
+    assert.equal(hasExecutableOnPath("cmake", tempDir), false);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/scripts/tauri-dev-frontend.mjs
+++ b/scripts/tauri-dev-frontend.mjs
@@ -3,6 +3,7 @@ import { createRequire } from "node:module";
 import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
+import { ensureTauriDevResourcePlaceholders } from "./tauri-dev-resources.mjs";
 
 const require = createRequire(import.meta.url);
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
@@ -65,6 +66,7 @@ function spawnViteDevServer() {
 }
 
 async function main() {
+  await ensureTauriDevResourcePlaceholders(repoRoot);
   await runNodeScript(ensureDevPortScript);
   spawnViteDevServer();
 }

--- a/scripts/tauri-dev-resources.mjs
+++ b/scripts/tauri-dev-resources.mjs
@@ -1,0 +1,23 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+const DEV_INDEX_HTML = "<!doctype html><meta charset=\"utf-8\"><title>ccgui dev placeholder</title>\n";
+
+async function writeFileIfMissing(filePath, contents) {
+  try {
+    await writeFile(filePath, contents, { flag: "wx" });
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && error.code === "EEXIST") {
+      return;
+    }
+    throw error;
+  }
+}
+
+export async function ensureTauriDevResourcePlaceholders(repoRoot) {
+  const distDir = path.join(repoRoot, "dist");
+  const assetsDir = path.join(distDir, "assets");
+  await mkdir(assetsDir, { recursive: true });
+  await writeFileIfMissing(path.join(distDir, "index.html"), DEV_INDEX_HTML);
+  await writeFileIfMissing(path.join(assetsDir, ".tauri-dev-placeholder"), "");
+}

--- a/scripts/tauri-dev-resources.test.mjs
+++ b/scripts/tauri-dev-resources.test.mjs
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { ensureTauriDevResourcePlaceholders } from "./tauri-dev-resources.mjs";
+
+test("creates Tauri dev resource placeholders for bundle globs", async () => {
+  const repoRoot = await mkdtemp(path.join(tmpdir(), "ccgui-tauri-dev-"));
+  try {
+    await ensureTauriDevResourcePlaceholders(repoRoot);
+
+    const indexHtml = await readFile(path.join(repoRoot, "dist", "index.html"), "utf8");
+    const assetPlaceholder = await readFile(
+      path.join(repoRoot, "dist", "assets", ".tauri-dev-placeholder"),
+      "utf8",
+    );
+
+    assert.match(indexHtml, /ccgui dev placeholder/);
+    assert.equal(assetPlaceholder, "");
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("does not overwrite existing frontend build artifacts", async () => {
+  const repoRoot = await mkdtemp(path.join(tmpdir(), "ccgui-tauri-dev-"));
+  try {
+    const indexPath = path.join(repoRoot, "dist", "index.html");
+    await ensureTauriDevResourcePlaceholders(repoRoot);
+    await writeFile(indexPath, "<!doctype html><title>real build</title>\n", "utf8");
+
+    await ensureTauriDevResourcePlaceholders(repoRoot);
+
+    assert.equal(await readFile(indexPath, "utf8"), "<!doctype html><title>real build</title>\n");
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});

--- a/src/features/composer/components/ChatInputBox/hooks/usePasteAndDrop.test.ts
+++ b/src/features/composer/components/ChatInputBox/hooks/usePasteAndDrop.test.ts
@@ -125,6 +125,7 @@ describe("usePasteAndDrop path insertion", () => {
     delete window.__fileTreeDragDropped;
     window.localStorage.removeItem(DETACHED_FILE_TREE_DRAG_SNAPSHOT_STORAGE_KEY);
     crossWindowDragBridgeHandler = null;
+    vi.restoreAllMocks();
   });
 
   it("inserts multi-path payload from custom drag data once", () => {
@@ -673,6 +674,54 @@ describe("usePasteAndDrop path insertion", () => {
     const state2 = updater2 ? updater2(state1) : state1;
     expect(state2).toHaveLength(1);
     expect(state2[0]?.data).toBe("C:\\Users\\demo\\Desktop\\bug.png");
+
+    harness.unmount();
+  });
+
+  it("falls back to async clipboard image read when WebView paste payload is empty", async () => {
+    const imageBlob = new Blob(["fake-png"], { type: "image/png" });
+    const read = vi.fn(async () => [
+      {
+        types: ["image/png"],
+        getType: vi.fn(async (type: string) => {
+          expect(type).toBe("image/png");
+          return imageBlob;
+        }),
+      },
+    ]);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { read },
+    });
+
+    const harness = createHarness();
+    const pasteEvent = {
+      preventDefault: vi.fn(),
+      clipboardData: {
+        items: [],
+        getData: () => "",
+      },
+    } as unknown as React.ClipboardEvent;
+
+    act(() => {
+      harness.result.handlePaste(pasteEvent);
+    });
+
+    expect(pasteEvent.preventDefault).toHaveBeenCalled();
+    await vi.waitFor(() => {
+      expect(harness.setInternalAttachments).toHaveBeenCalled();
+    });
+    expect(read).toHaveBeenCalledTimes(1);
+
+    const updater = harness.setInternalAttachments.mock.calls[0]?.[0] as
+      | ((prev: Array<{ data: string; fileName: string; mediaType: string }>) => Array<{ data: string; fileName: string; mediaType: string }>)
+      | undefined;
+    expect(typeof updater).toBe("function");
+    const next = updater ? updater([]) : [];
+    expect(next).toHaveLength(1);
+    expect(next[0]?.fileName).toMatch(/^pasted-image-\d+\.png$/);
+    expect(next[0]?.mediaType).toBe("image/png");
+    expect(next[0]?.data).toBe("ZmFrZS1wbmc=");
 
     harness.unmount();
   });

--- a/src/features/composer/components/ChatInputBox/hooks/usePasteAndDrop.ts
+++ b/src/features/composer/components/ChatInputBox/hooks/usePasteAndDrop.ts
@@ -344,6 +344,42 @@ function hasPathLikeDragType(
   );
 }
 
+async function readAsyncClipboardImageBlobs(): Promise<Blob[]> {
+  if (typeof navigator === 'undefined') {
+    return [];
+  }
+  const clipboard = navigator.clipboard;
+  if (!clipboard || typeof clipboard.read !== 'function') {
+    return [];
+  }
+
+  let clipboardItems: ClipboardItems;
+  try {
+    clipboardItems = await clipboard.read();
+  } catch {
+    return [];
+  }
+
+  const blobs: Blob[] = [];
+  for (const clipboardItem of clipboardItems) {
+    const imageType = Array.from(clipboardItem.types).find((type) =>
+      type.startsWith('image/'),
+    );
+    if (!imageType) {
+      continue;
+    }
+    try {
+      const blob = await clipboardItem.getType(imageType);
+      if (blob.size > 0 && (blob.type || imageType).startsWith('image/')) {
+        blobs.push(blob);
+      }
+    } catch {
+      // Continue probing other clipboard items.
+    }
+  }
+  return blobs;
+}
+
 /**
  * usePasteAndDrop - Handle paste and drag-drop operations
  *
@@ -375,6 +411,37 @@ export function usePasteAndDrop({
   const lastClientPositionRef = useRef<{ x: number; y: number } | null>(null);
   const [isDragOver, setIsDragOver] = useState(false);
   const [dragPreviewNames, setDragPreviewNames] = useState<string[]>([]);
+
+  const appendImageBlobAttachment = useCallback(
+    (blob: Blob, fallbackMediaType = 'image/png') => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        const base64 = (reader.result as string).split(',')[1] ?? '';
+        if (!base64) {
+          return;
+        }
+        const mediaType = blob.type || fallbackMediaType;
+        const ext = (() => {
+          if (mediaType && mediaType.includes('/')) {
+            return mediaType.split('/')[1] ?? 'png';
+          }
+          const name = (blob as File).name || '';
+          const m = name.match(/\.([a-zA-Z0-9]+)$/);
+          return m?.[1] ?? 'png';
+        })();
+        const attachment: Attachment = {
+          id: generateId(),
+          fileName: `pasted-image-${Date.now()}.${ext}`,
+          mediaType,
+          data: base64,
+        };
+
+        setInternalAttachments((prev) => [...prev, attachment]);
+      };
+      reader.readAsDataURL(blob);
+    },
+    [setInternalAttachments],
+  );
 
   const appendImagePathAttachments = useCallback(
     (paths: string[]) => {
@@ -702,29 +769,7 @@ export function usePasteAndDrop({
           const blob = item.getAsFile();
 
           if (blob) {
-            // Read image as Base64
-            const reader = new FileReader();
-            reader.onload = () => {
-              const base64 = (reader.result as string).split(',')[1] ?? '';
-              const mediaType = blob.type || item.type || 'image/png';
-              const ext = (() => {
-                if (mediaType && mediaType.includes('/')) {
-                  return mediaType.split('/')[1] ?? 'png';
-                }
-                const name = blob.name || '';
-                const m = name.match(/\.([a-zA-Z0-9]+)$/);
-                return m?.[1] ?? 'png';
-              })();
-              const attachment: Attachment = {
-                id: generateId(),
-                fileName: `pasted-image-${Date.now()}.${ext}`,
-                mediaType,
-                data: base64,
-              };
-
-              setInternalAttachments((prev) => [...prev, attachment]);
-            };
-            reader.readAsDataURL(blob);
+            appendImageBlobAttachment(blob, item.type || 'image/png');
           }
 
           return;
@@ -805,10 +850,17 @@ export function usePasteAndDrop({
           });
 
           timer.end();
+          return;
         }
+
+        void readAsyncClipboardImageBlobs().then((blobs) => {
+          for (const blob of blobs) {
+            appendImageBlobAttachment(blob);
+          }
+        });
       }
     },
-    [disabled, setInternalAttachments, handleInput, flushInput, editableRef]
+    [disabled, appendImageBlobAttachment, handleInput, flushInput, editableRef]
   );
 
   /**


### PR DESCRIPTION
## 修改内容

这个 PR 修复了我在 Linux 本机开发时很容易复现的 3 个问题。

其中前两个问题都发生在运行 `npm run tauri:dev` 的本地启动链路里，但不是同一个问题：

1. 本地前置检查误报：机器上已经安装了 `cmake`，并且 `cmake` 在 `PATH` 中可用，但 `doctor:strict` 仍然提示缺少 `cmake`。
2. Tauri dev 启动失败：前置检查通过后，干净 checkout 中还没有生产构建产物，Tauri 在 dev 启动阶段校验资源 glob `../dist/assets/**/*` 时失败。
3. 聊天窗口图片粘贴失败：Linux 系统剪贴板中有真实图片时，在聊天输入框中粘贴不会添加图片附件。

## 本机环境和复现现象

环境：

- Linux 桌面环境，Ubuntu/Debian 风格的软件包环境
- 项目现有的 Tauri 2 / Linux WebView 运行栈，也就是 Tauri 依赖的 `webkit2gtk`
- 开发启动命令：`npm run tauri:dev`
- 原始 checkout 位于 `/opt/mysoft/desktop-cc-gui`，这些问题在该目录中可以本地复现

问题 1：已经安装 `cmake`，但 `doctor:strict` 误报缺失。

```text
> ccgui@0.6.2 tauri:dev
> npm run doctor:strict && tauri dev

...
Branding check passed.
Doctor: missing dependencies: cmake
Ubuntu/Debian: sudo apt-get install cmake
Fedora: sudo dnf install cmake
Arch: sudo pacman -S cmake
```

我本机的 `cmake` 实际已经安装，而且可以从 `PATH` 中找到，但原来的 doctor 检查没有稳定识别到它。

问题 2：修复本地 doctor 检查后，`tauri dev` 又因为资源 glob 失败。

```text
error: failed to run custom build command for `cc-gui v0.3.0 (.../src-tauri)`

Caused by:
  process didn't exit successfully: `.../src-tauri/target/debug/build/cc-gui-.../build-script-build` (exit status: 1)
  --- stdout
  ...
  glob pattern ../dist/assets/**/* path not found or didn't match any files.
```

问题 3：聊天窗口无法粘贴真实系统剪贴板图片。

- 系统剪贴板中有一张真实图片。
- `xclip -selection clipboard -t TARGETS -o` 能看到 `image/png` 等图片 target。
- 但在 Tauri/WebKitGTK 的聊天输入框 `paste` event 中，`event.clipboardData.items/files/types` 没有暴露图片，所以原有图片粘贴分支没有执行。

## 根因

- `cmake` 误报的根因：doctor 脚本的命令探测逻辑在非 Windows 平台上不够直接，可能漏掉已经存在于 `PATH` 中的可执行文件。
- `dist/assets` glob 报错的根因：`tauri dev` 启动时会校验 Tauri 配置里的 bundle resource glob，但干净 checkout 在 Vite 生产构建之前不一定存在 `dist/assets` 目录。
- 图片粘贴失败的根因：在 Linux/WebKitGTK 中，真实系统剪贴板里可以存在 `image/png`，但同步的 DOM `ClipboardEvent.clipboardData` 可能为空；同一次 paste 手势下，WebView 仍然可以通过标准异步 Clipboard API `navigator.clipboard.read()` 读取到图片。

## 实现方式

- doctor 命令检查：
  - 非 Windows 平台改为直接扫描 `PATH`，并检查候选文件是否可执行。
  - Windows 仍保留原有的 `where` 检查和常见 CMake 安装路径 fallback。

- Tauri dev 资源 glob：
  - 增加一个很小的 `tauri-dev-resources` helper。
  - 在启动 Vite 前创建开发期占位文件：`dist/index.html` 和 `dist/assets/.tauri-dev-placeholder`。
  - 使用 `wx` 写入，因此不会覆盖真实构建产物。

- 聊天窗口图片粘贴：
  - 保留原有 composer attachment/image pipeline。
  - 只在 paste event 没有图片 item 且没有文本时，fallback 到 `navigator.clipboard.read()`。
  - 从 async Clipboard API 返回的 clipboard item 中提取 image blob，再交给现有附件流程处理。
  - 没有新增 native command，也没有新增 `xclip` / `wl-paste` 这类外部运行时依赖。

## 验证

本地已通过：

```bash
node --test scripts/doctor.test.mjs scripts/tauri-dev-resources.test.mjs
npm exec vitest run src/features/composer/components/ChatInputBox/hooks/usePasteAndDrop.test.ts
npm run typecheck
npm run doctor:strict
npm run lint
npm run test
```

其中 `npm run test` 完成了全部 728 个 test files。

手动验证：

- 在 Linux 上运行 `npm run tauri:dev`，可以成功启动。
- 将一张真实图片复制到系统剪贴板。
- 在 Tauri app 的聊天输入框中粘贴。
- 图片能出现在附件区域，并进入原有发送 payload 路径。

## 说明

- 这个 PR 没有引入新的运行时依赖。
- 图片粘贴修复使用的是项目现有 Tauri/Linux WebView 运行栈暴露的标准 async Clipboard API，不是新引入的 WebView 库。
- 开发期创建的 `dist` 占位文件会被 git ignore，不属于本 PR 的提交内容。
