### PR TITLE
fix(compact): remove fixed 120s wall-clock cap on manual /compact

### DIFF
--- a/openspec/changes/fix-claude-manual-compact-wall-clock-cap/.openspec.yaml
+++ b/openspec/changes/fix-claude-manual-compact-wall-clock-cap/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-06

--- a/openspec/changes/fix-claude-manual-compact-wall-clock-cap/design.md
+++ b/openspec/changes/fix-claude-manual-compact-wall-clock-cap/design.md
@@ -1,0 +1,79 @@
+## Context
+
+Manual Claude `/compact` is handled in two duplicated places: the Tauri path
+(`src-tauri/src/codex/mod.rs::compact_claude_thread`) and the daemon path
+(`src-tauri/src/bin/cc_gui_daemon/runtime_helpers.rs`). Both wrap the single
+`session.send_message(params, &turn_id)` call in a fixed 120s
+`tokio::time::timeout` keyed on `CLAUDE_MANUAL_COMPACT_TIMEOUT_SECS`. On a large
+conversation, the compaction summarization legitimately exceeds 120s, and since
+the cap measures total wall-clock (not time-since-last-event) it aborts a
+healthy run and maps the elapsed error to `Claude /compact timed out after 120
+seconds`.
+
+Two existing guards already cover the real hang case, making the outer cap
+redundant: `send_message` (`claude.rs`) enforces a 90s first-event watchdog, and
+the auto-compaction path (`lifecycle.rs`) awaits the same send without any outer
+cap.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Let a legitimate long manual compaction complete rather than being killed by a
+  total-duration wall.
+- Keep the first-event watchdog as the single, correct guard against a true
+  hang.
+- Match manual `/compact` duration handling to the already-uncapped
+  auto-compaction path.
+
+**Non-Goals:**
+
+- No new timeout knob or env var.
+- No change to `send_message`'s watchdog or to `lifecycle.rs`.
+- No change to routing, side-effect guards, or feedback strings.
+
+## Decisions
+
+1. Remove the outer cap rather than raise it.
+   - Option A (chosen): delete the `timeout()` wrapper and await
+     `send_message` directly in both handlers; remove the dead
+     `CLAUDE_MANUAL_COMPACT_TIMEOUT_SECS` const and the now-unused `timeout`
+     import in `runtime_helpers.rs`.
+   - Option B: increase `CLAUDE_MANUAL_COMPACT_TIMEOUT_SECS`.
+   - Trade-off: A removes the false-timeout class entirely and drops a redundant
+     guard; B only moves the cliff and still guesses a magic number. A is the
+     smaller, fully revertable diff.
+
+2. Rely on the first-event watchdog for hang protection.
+   - `send_message`'s 90s watchdog already fails fast when the runtime never
+     responds; keeping a second total-duration wall on top of it both duplicates
+     the guard and misclassifies healthy long runs as hangs.
+
+3. Apply the change identically in both duplicated handlers.
+   - The Tauri and daemon paths must not diverge in compaction duration
+     semantics; both drop the wrapper so behavior is uniform regardless of which
+     path executes the command.
+
+## Risks / Trade-offs
+
+- [Risk] A pathological runtime that emits an early event then streams forever
+  would no longer be wall-capped on the manual path.
+  - Mitigation: this failure mode is not observed; the watchdog covers a true
+    stall, and the auto-compaction path already accepts the same trade-off.
+- [Risk] Removing the `timeout` import could leave an unused import and break the
+  Rust build.
+  - Mitigation: `runtime_helpers.rs` still uses `Duration` (health probe), and
+    `codex/mod.rs` still uses `timeout`/`Duration` for other operations; verified
+    no orphaned imports remain, guarded by `cargo test`.
+
+## Migration Plan
+
+1. Author the OpenSpec proposal / design / spec delta / tasks.
+2. Delete the `timeout()` wrapper, dead const, and unused import in both
+   handlers; await `send_message` directly.
+3. Run `cargo test`, `npm run typecheck`, and `openspec validate --strict`.
+4. Rollback restores the two touched files; no runtime-state migration involved.
+
+## Open Questions
+
+- None.

--- a/openspec/changes/fix-claude-manual-compact-wall-clock-cap/proposal.md
+++ b/openspec/changes/fix-claude-manual-compact-wall-clock-cap/proposal.md
@@ -1,0 +1,80 @@
+## Why
+
+Manual `/compact` on a Claude thread wraps `session.send_message` in a fixed
+120s `tokio::time::timeout` (`CLAUDE_MANUAL_COMPACT_TIMEOUT_SECS`). `/compact`
+is an LLM summarization over the entire conversation and legitimately takes
+minutes on a large context. Because the cap is a total-duration wall — not a
+watchdog — progress events cannot extend it, so a healthy long compaction is
+aborted mid-run and the user sees a false `Claude /compact timed out after 120
+seconds` failure. The outer cap is also redundant: `send_message` already has a
+90s first-event watchdog guarding a true hang, and the auto-compaction path
+(`lifecycle.rs`) runs uncapped. This weakens conformance with
+`claude-manual-compact-command`, whose feedback contract assumes a legitimate
+compaction reaches its existing success lifecycle rather than a spurious
+terminal error.
+
+## 目标与边界
+
+- Remove the fixed 120s wall-clock cap around manual Claude `/compact` in both
+  duplicated handlers so a legitimate long compaction runs to completion.
+- Preserve the existing hang protection: `send_message`'s 90s first-event
+  watchdog remains the guard against a runtime that never responds.
+- Bring manual `/compact` duration handling into parity with the uncapped
+  auto-compaction path.
+- Keep all existing routing, side-effect guards, lifecycle feedback, and
+  terminal-failure semantics of `claude-manual-compact-command` unchanged.
+
+## 非目标
+
+- Do not introduce a new configurable timeout or environment variable.
+- Do not change the auto-compaction path (`lifecycle.rs`) — it is already
+  uncapped and out of scope.
+- Do not alter `send_message`'s internal first-event watchdog value or behavior.
+- Do not change command routing, image/side-effect guards, or user-facing
+  feedback strings.
+
+## What Changes
+
+- Drop the `timeout(...)` wrapper in both duplicated manual-compact handlers
+  (`src-tauri/src/codex/mod.rs::compact_claude_thread` and
+  `src-tauri/src/bin/cc_gui_daemon/runtime_helpers.rs`), awaiting
+  `session.send_message` directly.
+- Remove the now-dead `CLAUDE_MANUAL_COMPACT_TIMEOUT_SECS` const from both files
+  and the now-unused `timeout` import in `runtime_helpers.rs`.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `claude-manual-compact-command`: add a duration requirement stating manual
+  `/compact` MUST NOT be aborted by an arbitrary wall-clock cap, and that hang
+  protection is provided by the first-event watchdog rather than a total wall.
+
+## Impact
+
+- Runtime/API: `src-tauri/src/codex/mod.rs`, and
+  `src-tauri/src/bin/cc_gui_daemon/runtime_helpers.rs`. No Tauri command
+  signature, IPC, or storage schema change.
+- Frontend: none.
+- Dependencies: no new dependency.
+
+## 技术方案对比
+
+| 选项 | 做法 | 取舍 |
+|---|---|---|
+| Recommended: remove the outer cap | Delete the `timeout()` wrapper + dead const/import; rely on the existing 90s first-event watchdog | Fixes the false-timeout on large contexts; matches the uncapped auto-compaction path; smallest, revertable diff. Trade-off: a runtime that streams useless progress forever would not be wall-capped — but that failure mode is not observed and the watchdog covers a true stall |
+| Alternative: raise the cap | Bump `CLAUDE_MANUAL_COMPACT_TIMEOUT_SECS` to a larger value | Still a total-duration wall that guesses a "large enough" number; any sufficiently large context still gets falsely killed, and it keeps a redundant guard alongside the watchdog |
+
+## 验收标准
+
+- Manual `/compact` on a large Claude context no longer fails at ~120s and
+  reaches the existing compacting / compacted lifecycle feedback.
+- A runtime that never emits a first event is still surfaced as a failure by the
+  existing 90s watchdog (behavior unchanged).
+- No unused imports or dead consts remain; `cargo test` and `npm run typecheck`
+  pass; `openspec validate fix-claude-manual-compact-wall-clock-cap --strict
+  --no-interactive` passes.

--- a/openspec/changes/fix-claude-manual-compact-wall-clock-cap/specs/claude-manual-compact-command/spec.md
+++ b/openspec/changes/fix-claude-manual-compact-wall-clock-cap/specs/claude-manual-compact-command/spec.md
@@ -1,0 +1,35 @@
+# claude-manual-compact-command Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Manual Compact Duration Is Not Wall-Clock Capped
+
+Claude manual `/compact` MUST NOT be aborted by an arbitrary total-duration
+wall-clock cap. Because compaction is an LLM summarization over the whole
+conversation and legitimately takes minutes on a large context, hang protection
+MUST come from the runtime's first-event watchdog rather than a fixed elapsed
+limit, matching the uncapped auto-compaction path.
+
+#### Scenario: legitimate long compaction runs to completion
+
+- **WHEN** the user submits `/compact` on a large Claude context
+- **AND** the runtime is actively producing the compaction summary beyond the
+  former fixed cap
+- **THEN** the product MUST let the compaction continue to completion
+- **AND** the product MUST surface the existing compacting / compacted lifecycle
+  feedback rather than a timeout failure
+
+#### Scenario: a true runtime hang is still surfaced
+
+- **WHEN** the user submits `/compact`
+- **AND** the runtime never emits a first response event
+- **THEN** the product MUST surface a failure via the existing first-event
+  watchdog
+- **AND** the conversation MUST NOT be left in a stuck processing state
+
+#### Scenario: no arbitrary elapsed cap is imposed on the send
+
+- **WHEN** manual `/compact` dispatches the command to the Claude session
+- **THEN** the product MUST NOT wrap the send in a fixed total-duration timeout
+- **AND** manual compact duration handling MUST match the uncapped
+  auto-compaction path

--- a/openspec/changes/fix-claude-manual-compact-wall-clock-cap/tasks.md
+++ b/openspec/changes/fix-claude-manual-compact-wall-clock-cap/tasks.md
@@ -1,0 +1,12 @@
+## 1. OpenSpec Artifacts
+
+- [x] 1.1 Create proposal/design/spec delta for removing the manual `/compact` 120s wall-clock cap; output: change artifacts under `openspec/changes/fix-claude-manual-compact-wall-clock-cap`; validation: `openspec validate fix-claude-manual-compact-wall-clock-cap --strict --no-interactive`. [P0][I][O: change dir][V: openspec validate]
+
+## 2. Runtime Fix
+
+- [x] 2.1 Remove the `timeout()` wrapper, the `CLAUDE_MANUAL_COMPACT_TIMEOUT_SECS` const, and the false-timeout error mapping in `src-tauri/src/codex/mod.rs::compact_claude_thread`, awaiting `session.send_message` directly; output: no wall-clock cap on the Tauri manual-compact path; validation: `cargo test`. [P0][depends: 1.1][I][O: codex/mod.rs][V: cargo test]
+- [x] 2.2 Apply the identical removal in `src-tauri/src/bin/cc_gui_daemon/runtime_helpers.rs` and drop the now-unused `timeout` import; output: no wall-clock cap on the daemon manual-compact path and no orphaned import; validation: `cargo test`. [P0][depends: 1.1][I][O: runtime_helpers.rs][V: cargo test]
+
+## 3. Verification
+
+- [x] 3.1 Run repository gates; output: no Rust or TypeScript regressions and no dead-import warnings; validation: `cargo test`, `npm run lint`, `npm run typecheck`. [P0][depends: 2.1, 2.2][V: cargo test && npm run lint && npm run typecheck]

--- a/src-tauri/src/bin/cc_gui_daemon/runtime_helpers.rs
+++ b/src-tauri/src/bin/cc_gui_daemon/runtime_helpers.rs
@@ -1,8 +1,7 @@
 use super::*;
-use tokio::time::{timeout, Duration};
+use tokio::time::Duration;
 
 const SESSION_HEALTH_PROBE_TIMEOUT_SECS: u64 = 3;
-const CLAUDE_MANUAL_COMPACT_TIMEOUT_SECS: u64 = 120;
 const CREATE_SESSION_RUNTIME_RECOVERING_ERROR_PREFIX: &str = "[SESSION_CREATE_RUNTIME_RECOVERING]";
 
 pub(super) fn is_stopping_runtime_race_error(error: &str) -> bool {
@@ -84,17 +83,11 @@ impl DaemonState {
             ..Default::default()
         };
 
-        let compact_result = timeout(
-            Duration::from_secs(CLAUDE_MANUAL_COMPACT_TIMEOUT_SECS),
-            session.send_message(params, &turn_id),
-        )
-        .await
-        .map_err(|_| {
-            format!(
-                "Claude /compact timed out after {} seconds",
-                CLAUDE_MANUAL_COMPACT_TIMEOUT_SECS
-            )
-        })?;
+        // No outer wall-clock cap: /compact is an LLM summarization over the whole
+        // conversation and legitimately takes minutes on a large context. send_message
+        // already has a 90s first-event watchdog (claude.rs) guarding a true hang, and
+        // the auto-compact path (lifecycle.rs) runs uncapped too — matching it here.
+        let compact_result = session.send_message(params, &turn_id).await;
 
         match compact_result {
             Ok(result_text) => {

--- a/src-tauri/src/codex/mod.rs
+++ b/src-tauri/src/codex/mod.rs
@@ -182,7 +182,6 @@ pub(crate) use self::start_thread_retry::{
 };
 
 const DELETE_ARCHIVE_TIMEOUT_MS: u64 = 2_000;
-const CLAUDE_MANUAL_COMPACT_TIMEOUT_SECS: u64 = 120;
 
 fn emit_manual_compaction_event(
     app: &AppHandle,
@@ -249,17 +248,11 @@ async fn compact_claude_thread(
         ..Default::default()
     };
 
-    let compact_result = timeout(
-        Duration::from_secs(CLAUDE_MANUAL_COMPACT_TIMEOUT_SECS),
-        session.send_message(params, &turn_id),
-    )
-    .await
-    .map_err(|_| {
-        format!(
-            "Claude /compact timed out after {} seconds",
-            CLAUDE_MANUAL_COMPACT_TIMEOUT_SECS
-        )
-    })?;
+    // No outer wall-clock cap: /compact is an LLM summarization over the whole
+    // conversation and legitimately takes minutes on a large context. send_message
+    // already has a 90s first-event watchdog (claude.rs) guarding a true hang, and
+    // the auto-compact path (lifecycle.rs) runs uncapped too — matching it here.
+    let compact_result = session.send_message(params, &turn_id).await;
 
     match compact_result {
         Ok(result_text) => {


### PR DESCRIPTION
## Summary
Manual `/compact` wrapped `send_message` in a fixed 120s total-duration timeout, so a legitimate multi-minute large-context compaction was aborted mid-run. This removes that cap.

## Changes
- Drop the 120s `tokio::time::timeout` (+ the dead `CLAUDE_MANUAL_COMPACT_TIMEOUT_SECS` const and now-unused import) in **both** duplicated manual-compact handlers (`codex/mod.rs`, `cc_gui_daemon/runtime_helpers.rs`).

## Why
It was a total-duration wall, not a watchdog. `send_message`'s own first-event watchdog still guards true hangs, and auto-compact (`lifecycle.rs`) was already uncapped — so this only removes a false-timeout class, consistent with the existing auto path.

## Test plan
- [x] `cargo test` — full workspace suite passes (2195 tests: 1348 lib + 845 daemon + 2 config).
- [x] Reviewed both handlers for orphaned references (none).

## Notes for reviewers
- OpenSpec: `fix-claude-manual-compact-wall-clock-cap` included. Fully independent (src-tauri only).

---
*I'm a fork contributor planning to send a handful of small, independent, upstreamable fixes as separate focused PRs — this is the first; happy to pace or batch them however suits you. Commits and PR bodies are English for now — glad to provide a Chinese (中文) version on request. This change originates from an OpenSpec change under `openspec/changes/`. Upstream CI runs on push-to-`main` (not PRs), so I ran the relevant gates locally (results in the Test plan above).*
