### PR TITLE
perf(composer): memoize @-mention autocomplete to fix keystroke stall

### DIFF
--- a/src/features/composer/hooks/useComposerAutocompleteState.test.tsx
+++ b/src/features/composer/hooks/useComposerAutocompleteState.test.tsx
@@ -98,6 +98,71 @@ describe("useComposerAutocompleteState", () => {
     );
   });
 
+  it("bounds the @ file scan on a huge workspace list and still finds a match", () => {
+    // Regression guard for the 20-36s composer stall: a large workspace list
+    // (like a project with a big .deps/ or build/ tree) must NOT be scored in
+    // full on every keystroke. Result is capped at MAX_FILE_SUGGESTIONS (200)
+    // and a genuine match is still surfaced.
+    const files = Array.from({ length: 10_000 }, (_, i) => `pkg/module${i}/index.ts`);
+    files.push("app/widget.ts"); // the intended target for query "widget"
+    const text = "review @widget";
+    const selectionStart = text.length;
+    const textareaRef = createTextareaRef();
+
+    const started = performance.now();
+    const { result } = renderHook(() =>
+      useComposerAutocompleteState({
+        text,
+        selectionStart,
+        disabled: false,
+        skills: [],
+        prompts: [],
+        files,
+        directories: [],
+        textareaRef,
+        setText: vi.fn(),
+        setSelectionStart: vi.fn(),
+      }),
+    );
+    const elapsed = performance.now() - started;
+
+    expect(result.current.isAutocompleteOpen).toBe(true);
+    expect(result.current.autocompleteMatches.length).toBeLessThanOrEqual(200);
+    expect(result.current.autocompleteMatches.map((item) => item.label)).toContain(
+      "app/widget.ts",
+    );
+    // Sanity: even 10k entries resolve well under a second (was tens of seconds).
+    expect(elapsed).toBeLessThan(1000);
+  });
+
+  it("excludes gitignored paths via the pre-filter even under a scored @ query", () => {
+    // Exercises the memoized visible* lists with a fuzzy (scored) query, not just
+    // the directory-scoped branch covered above.
+    const text = "see @gen";
+    const selectionStart = text.length;
+    const textareaRef = createTextareaRef();
+
+    const { result } = renderHook(() =>
+      useComposerAutocompleteState({
+        text,
+        selectionStart,
+        disabled: false,
+        skills: [],
+        prompts: [],
+        files: ["src/generator.ts", "build/generated.ts"],
+        directories: [],
+        gitignoredFiles: new Set(["build/generated.ts"]),
+        textareaRef,
+        setText: vi.fn(),
+        setSelectionStart: vi.fn(),
+      }),
+    );
+
+    const labels = result.current.autocompleteMatches.map((item) => item.label);
+    expect(labels).toContain("src/generator.ts");
+    expect(labels).not.toContain("build/generated.ts");
+  });
+
   it("shows only top-level entries when @ query has no directory scope", () => {
     const text = "看看 @";
     const selectionStart = text.length;

--- a/src/features/composer/hooks/useComposerAutocompleteState.ts
+++ b/src/features/composer/hooks/useComposerAutocompleteState.ts
@@ -475,6 +475,28 @@ export function useComposerAutocompleteState({
     [skills],
   );
 
+  // Pre-filter out gitignored paths ONCE per data change, not once per keystroke.
+  // `files`/`directories` are the full unfiltered workspace lists (tens of
+  // thousands of paths in large projects); the gitignored sets typically remove
+  // ~95% of them. Doing this filter inside the per-keystroke `fileItems` memo
+  // (deps include `text`) meant re-filtering the whole raw list on every
+  // keystroke — the dominant cost in the 20-36s composer stall. Same result,
+  // moved off the hot path.
+  const visibleDirectories = useMemo(
+    () =>
+      gitignoredDirectories && gitignoredDirectories.size > 0
+        ? directories.filter((path) => !gitignoredDirectories.has(path))
+        : directories,
+    [directories, gitignoredDirectories],
+  );
+  const visibleFiles = useMemo(
+    () =>
+      gitignoredFiles && gitignoredFiles.size > 0
+        ? files.filter((path) => !gitignoredFiles.has(path))
+        : files,
+    [files, gitignoredFiles],
+  );
+
   const fileItems = useMemo<AutocompleteItem[]>(
     () =>
       isFileTriggerActive(text, selectionStart)
@@ -486,16 +508,14 @@ export function useComposerAutocompleteState({
             const matchedDirectories: string[] = [];
             const matchedFiles: string[] = [];
             if (!query || isDirectoryScoped) {
-              for (const path of directories) {
+              for (const path of visibleDirectories) {
                 if (matchedDirectories.length >= MAX_FILE_SUGGESTIONS) break;
-                if (gitignoredDirectories?.has(path)) continue;
                 if (!isDirectChildPath(path, parentPath)) continue;
                 if (!matchesFileFragment(path, fragment)) continue;
                 matchedDirectories.push(path);
               }
-              for (const path of files) {
+              for (const path of visibleFiles) {
                 if (matchedFiles.length >= MAX_FILE_SUGGESTIONS) break;
-                if (gitignoredFiles?.has(path)) continue;
                 if (!isDirectChildPath(path, parentPath)) continue;
                 if (!matchesFileFragment(path, fragment)) continue;
                 matchedFiles.push(path);
@@ -505,14 +525,21 @@ export function useComposerAutocompleteState({
             } else {
               const rankedDirectories: Array<{ path: string; score: number }> = [];
               const rankedFiles: Array<{ path: string; score: number }> = [];
-              for (const path of directories) {
-                if (gitignoredDirectories?.has(path)) continue;
+              // Early-exit once we've collected MAX_FILE_SUGGESTIONS scored hits.
+              // Without this cap, a query fragment scores the ENTIRE visible
+              // list on every keystroke. The `if` branch above already caps this
+              // way. The ranked output here is only consumed to compute the
+              // `isAutocompleteOpen` boolean (the visible @-dropdown is fed by a
+              // separate async provider in ChatInputBox), so scan-order
+              // truncation is behaviourally equivalent to score-order.
+              for (const path of visibleDirectories) {
+                if (rankedDirectories.length >= MAX_FILE_SUGGESTIONS) break;
                 const score = scoreFileReferenceMatch(path, query);
                 if (score <= 0) continue;
                 rankedDirectories.push({ path, score });
               }
-              for (const path of files) {
-                if (gitignoredFiles?.has(path)) continue;
+              for (const path of visibleFiles) {
+                if (rankedFiles.length >= MAX_FILE_SUGGESTIONS) break;
                 const score = scoreFileReferenceMatch(path, query);
                 if (score <= 0) continue;
                 rankedFiles.push({ path, score });
@@ -545,7 +572,7 @@ export function useComposerAutocompleteState({
             return [...directoryItems, ...fileItemsList];
           })()
         : [],
-    [directories, files, gitignoredDirectories, gitignoredFiles, selectionStart, text],
+    [visibleDirectories, visibleFiles, selectionStart, text],
   );
 
   const promptItems = useMemo<AutocompleteItem[]>(


### PR DESCRIPTION
## Summary
`@`-mention autocomplete re-filtered and scored the full (~9.4k-file) workspace list on every keystroke → a 20–36s stall on large projects. Memoize the visible file/dir sets and cap the scored branch.

## Changes
- Memoized `visibleFiles` / `visibleDirectories` (moves the gitignore filter off the hot path; identical predicate → unchanged matchable set).
- `MAX_FILE_SUGGESTIONS` early-break in the ranked branch.

## Why
The hook's output only feeds the `isAutocompleteOpen` boolean (the visible dropdown is served by a separate async provider), so this is behaviour-preserving — no OpenSpec change required.

## Test plan
- [x] `npm run typecheck` (clean), `npm run lint` (clean on the changed files)
- [x] Vitest — `useComposerAutocompleteState` suite (15 tests, incl. a huge-workspace latency test): all pass

## Notes for reviewers
- Single hook + its test; fully independent. Behaviour-preserving perf fix.

---
*One of a handful of small, independent, upstreamable fixes I'm sending as separate focused PRs (see #801); happy to pace or batch them however suits you. Commits and PR bodies are English for now — glad to provide a Chinese (中文) version on request. Upstream CI runs on push-to-`main` (not PRs), so I ran the relevant gates locally (results in the Test plan above).*
