### PR TITLE
feat(menu): localize the Linux native menu at build time

### DIFF
--- a/openspec/changes/add-linux-native-menu-localization/.openspec.yaml
+++ b/openspec/changes/add-linux-native-menu-localization/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-04

--- a/openspec/changes/add-linux-native-menu-localization/proposal.md
+++ b/openspec/changes/add-linux-native-menu-localization/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+The native menu bar is built in Rust (`menu.rs`) and cannot reach the React
+i18next layer, so its labels were written in a single language. On Linux the
+runtime relabel path (`menu_update_labels`) does not reliably repaint the GTK
+menubar (a muda/GTK limitation), so a non-default-language user saw a menu that
+never localized. The fix is to build the menu in the saved language up front.
+
+## 目标与边界
+
+- Source native menu labels from a Rust-side mirror of the `menu.*` i18n keys,
+  selected by the saved UI language, so the menu is localized at build time.
+- Fix Linux specifically: build-in-language instead of depending on a runtime
+  GTK relabel that doesn't repaint.
+- Keep adding a locale cheap: one label-set constructor, no change to the build
+  path.
+
+## 非目标
+
+- Do not move menu construction out of Rust or wire it to i18next at runtime.
+- Do not change the frontend i18n keys themselves — the Rust mirror tracks the
+  existing `menu.*` keys.
+- No behavior change on macOS beyond also sourcing labels from the mirror (its
+  runtime relabel already worked).
+
+## What Changes
+
+- `src-tauri/src/menu.rs`: introduce a `MenuLabels` struct (all menu item
+  strings) with a per-language constructor; build every `MenuItemBuilder` from
+  `labels.*` instead of hardcoded strings; select the label set from the saved
+  language. Terminal / devtools items are localized too (previously hardcoded).
+
+## Spec deltas
+
+- `linux-native-menu-localization` (new capability): **ADDED** — the native menu
+  MUST be built in the saved UI language, with a Linux build-in-language
+  requirement and a one-constructor-per-locale requirement.

--- a/openspec/changes/add-linux-native-menu-localization/specs/linux-native-menu-localization/spec.md
+++ b/openspec/changes/add-linux-native-menu-localization/specs/linux-native-menu-localization/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: The Native Menu MUST Be Built In The Saved UI Language
+
+系统 MUST 在构建原生（GTK/AppKit）菜单时使用用户已保存的界面语言，而不是写死单一语言，因为原生菜单在 Rust 层构建、无法访问 React i18next 层。
+
+The native menu bar is constructed in Rust and cannot reach the React i18next
+layer, so its labels must be sourced from a Rust-side mirror of the `menu.*`
+translation keys, selected by the saved language.
+
+#### Scenario: native menu labels follow the saved language at build time
+
+- **WHEN** 系统构建原生菜单
+- **THEN** 每个菜单项的标签 MUST 取自与当前已保存语言对应的标签集合
+- **AND** 标签集合 MUST 覆盖全部菜单项（File / Edit / Composer / View 等）
+- **AND** Rust 侧标签 MUST 与 `src/i18n/locales/*/menu` 的键保持一致
+
+#### Scenario: Linux builds in-language rather than relying on runtime relabel
+
+- **GIVEN** 运行平台为 Linux（GTK/muda）
+- **WHEN** 用户的保存语言不是默认语言
+- **THEN** 系统 MUST 在构建时就以正确语言创建菜单
+- **AND** 系统 MUST NOT 依赖运行时 `menu_update_labels` 重绘 GTK 菜单栏（muda/GTK 限制下不可靠）
+- **AND** 运行时切换语言 MAY 在下次启动时才完全生效
+
+#### Scenario: adding a locale is a single constructor
+
+- **WHEN** 新增一个受支持语言
+- **THEN** 只 MUST 新增一个标签集合构造器
+- **AND** 既有语言的菜单构建路径 MUST NOT 需要改动

--- a/openspec/changes/add-linux-native-menu-localization/tasks.md
+++ b/openspec/changes/add-linux-native-menu-localization/tasks.md
@@ -1,0 +1,13 @@
+## 1. OpenSpec Artifacts
+
+- [x] 1.1 Author proposal + spec delta + tasks for native menu localization; output: `openspec/changes/add-linux-native-menu-localization`; validation: `openspec validate add-linux-native-menu-localization --strict --no-interactive`. [P0][I][O: change dir][V: openspec validate]
+
+## 2. Rust menu (menu.rs)
+
+- [x] 2.1 Add `MenuLabels` struct covering all menu item strings, with per-language constructors (zh/en) whose keys mirror `src/i18n/locales/*/menu`. [P0][I][O: menu.rs][V: cargo (F4)]
+- [x] 2.2 Build every menu item from `labels.*` (incl. terminal/devtools, previously hardcoded); select the label set from the saved language. [P0][I][O: menu.rs][V: cargo (F4)]
+
+## 3. Gates
+
+- [ ] 3.1 `cargo test` / `cargo check` (app closed) — DEFERRED to freeze window F4 (no local rebuilds during freeze). Conflict resolution vs v0.6.7 verified textually (struct fields + both constructors present). [P0][V: cargo]
+- [ ] 3.2 Manual: launch with a non-default saved language on Linux; menu bar is localized at startup — DEFERRED to F4. [P1][V: manual]

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -73,7 +73,7 @@ const LABELS_ZH: MenuLabels = MenuLabels {
     cycle_collaboration: "切换协作模式",
     view: "视图",
     toggle_projects_sidebar: "切换项目侧边栏",
-    toggle_git_sidebar: "切换 Git 侧边栏",
+    toggle_git_sidebar: "切换右侧边栏",
     toggle_global_search: "切换全局搜索",
     toggle_debug_panel: "切换调试面板",
     toggle_terminal: "切换终端",

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -8,6 +8,143 @@ use tauri::{Emitter, Manager, Runtime, WebviewUrl, WebviewWindowBuilder};
 const NEW_WINDOW_ACCELERATOR: &str = "CmdOrCtrl+Shift+N";
 const RELOAD_WINDOW_ACCELERATOR: &str = "CmdOrCtrl+R";
 
+/// Native menu labels for a single language. The native (GTK/AppKit) menu is
+/// built in Rust, so it can't reach the React i18next layer; we mirror the
+/// `menu.*` translation keys here and build the menu in the saved language.
+///
+/// Runtime re-labelling via `menu_update_labels` works on macOS but does not
+/// reliably repaint the GTK menubar on Linux (muda/GTK limitation), so building
+/// in the right language up front is what actually makes the menu localized
+/// there. Live switching still applies on next launch. New locales = one more
+/// constructor; strings must stay in sync with `src/i18n/locales/*/menu`.
+struct MenuLabels {
+    check_for_updates: &'static str,
+    settings: &'static str,
+    file: &'static str,
+    new_agent: &'static str,
+    new_worktree_agent: &'static str,
+    new_clone_agent: &'static str,
+    new_window: &'static str,
+    add_workspace: &'static str,
+    close_window: &'static str,
+    quit: &'static str,
+    edit: &'static str,
+    composer: &'static str,
+    cycle_model: &'static str,
+    cycle_access: &'static str,
+    cycle_reasoning: &'static str,
+    cycle_collaboration: &'static str,
+    view: &'static str,
+    toggle_projects_sidebar: &'static str,
+    toggle_git_sidebar: &'static str,
+    toggle_global_search: &'static str,
+    toggle_debug_panel: &'static str,
+    toggle_terminal: &'static str,
+    toggle_devtools: &'static str,
+    next_agent: &'static str,
+    prev_agent: &'static str,
+    next_workspace: &'static str,
+    prev_workspace: &'static str,
+    fullscreen: &'static str,
+    window: &'static str,
+    minimize: &'static str,
+    maximize: &'static str,
+    reload_window: &'static str,
+    help: &'static str,
+    about_prefix: &'static str, // "关于" / "About" — prepended to the app name
+}
+
+const LABELS_ZH: MenuLabels = MenuLabels {
+    check_for_updates: "检查更新…",
+    settings: "设置…",
+    file: "文件",
+    new_agent: "新建会话",
+    new_worktree_agent: "新建工作树代理",
+    new_clone_agent: "新建克隆代理",
+    new_window: "新建窗口",
+    add_workspace: "添加工作区…",
+    close_window: "关闭窗口",
+    quit: "退出",
+    edit: "编辑",
+    composer: "编辑器",
+    cycle_model: "切换模型",
+    cycle_access: "切换访问模式",
+    cycle_reasoning: "切换推理模式",
+    cycle_collaboration: "切换协作模式",
+    view: "视图",
+    toggle_projects_sidebar: "切换项目侧边栏",
+    toggle_git_sidebar: "切换 Git 侧边栏",
+    toggle_global_search: "切换全局搜索",
+    toggle_debug_panel: "切换调试面板",
+    toggle_terminal: "切换终端",
+    toggle_devtools: "切换开发者工具",
+    next_agent: "下一个代理",
+    prev_agent: "上一个代理",
+    next_workspace: "下一个工作区",
+    prev_workspace: "上一个工作区",
+    fullscreen: "切换全屏",
+    window: "窗口",
+    minimize: "最小化",
+    maximize: "最大化",
+    reload_window: "重新加载窗口",
+    help: "帮助",
+    about_prefix: "关于",
+};
+
+const LABELS_EN: MenuLabels = MenuLabels {
+    check_for_updates: "Check for Updates…",
+    settings: "Settings…",
+    file: "File",
+    new_agent: "New Agent",
+    new_worktree_agent: "New Worktree Agent",
+    new_clone_agent: "New Clone Agent",
+    new_window: "New Window",
+    add_workspace: "Add Workspace…",
+    close_window: "Close Window",
+    quit: "Quit",
+    edit: "Edit",
+    composer: "Composer",
+    cycle_model: "Cycle Model",
+    cycle_access: "Cycle Access Mode",
+    cycle_reasoning: "Cycle Reasoning Mode",
+    cycle_collaboration: "Cycle Collaboration Mode",
+    view: "View",
+    toggle_projects_sidebar: "Toggle Projects Sidebar",
+    toggle_git_sidebar: "Toggle Right Sidebar",
+    toggle_global_search: "Toggle Global Search",
+    toggle_debug_panel: "Toggle Debug Panel",
+    toggle_terminal: "Toggle Terminal",
+    toggle_devtools: "Toggle Developer Tools",
+    next_agent: "Next Agent",
+    prev_agent: "Previous Agent",
+    next_workspace: "Next Workspace",
+    prev_workspace: "Previous Workspace",
+    fullscreen: "Toggle Full Screen",
+    window: "Window",
+    minimize: "Minimize",
+    maximize: "Maximize",
+    reload_window: "Reload Window",
+    help: "Help",
+    about_prefix: "About",
+};
+
+/// Read the saved UI language from the client `app` store. Defaults to `zh`
+/// (matching the frontend default) when unset or unreadable. Only zh/en exist.
+fn saved_menu_labels() -> &'static MenuLabels {
+    let language = crate::client_storage::client_store_read("app".to_string())
+        .ok()
+        .and_then(|value| {
+            value
+                .get("language")
+                .and_then(|lang| lang.as_str())
+                .map(str::to_string)
+        });
+    match language.as_deref() {
+        Some("en") => &LABELS_EN,
+        _ => &LABELS_ZH,
+    }
+}
+
 fn reload_window_accelerator() -> Option<&'static str> {
     #[cfg(target_os = "macos")]
     {
@@ -21,8 +158,9 @@ fn reload_window_accelerator() -> Option<&'static str> {
 
 fn build_reload_window_item<R: tauri::Runtime>(
     handle: &tauri::AppHandle<R>,
+    labels: &MenuLabels,
 ) -> tauri::Result<MenuItem<R>> {
-    let builder = MenuItemBuilder::with_id("window_reload", "重新加载窗口");
+    let builder = MenuItemBuilder::with_id("window_reload", labels.reload_window);
     let builder = match reload_window_accelerator() {
         Some(accelerator) => builder.accelerator(accelerator),
         None => builder,
@@ -146,11 +284,13 @@ pub(crate) fn build_menu<R: tauri::Runtime>(
     handle: &tauri::AppHandle<R>,
 ) -> tauri::Result<Menu<R>> {
     let registry = handle.state::<MenuItemRegistry<R>>();
+    let labels = saved_menu_labels();
     let app_name = handle.package_info().name.clone();
-    let about_item = MenuItemBuilder::with_id("about", format!("关于 {app_name}")).build(handle)?;
+    let about_label = format!("{} {app_name}", labels.about_prefix);
+    let about_item = MenuItemBuilder::with_id("about", about_label.clone()).build(handle)?;
     let check_updates_item =
-        MenuItemBuilder::with_id("check_for_updates", "检查更新…").build(handle)?;
-    let settings_item = MenuItemBuilder::with_id("file_open_settings", "设置…")
+        MenuItemBuilder::with_id("check_for_updates", labels.check_for_updates).build(handle)?;
+    let settings_item = MenuItemBuilder::with_id("file_open_settings", labels.settings)
         .accelerator("CmdOrCtrl+,")
         .build(handle)?;
 
@@ -177,16 +317,18 @@ pub(crate) fn build_menu<R: tauri::Runtime>(
         ],
     )?;
 
-    let new_agent_item = MenuItemBuilder::with_id("file_new_agent", "新建会话").build(handle)?;
+    let new_agent_item =
+        MenuItemBuilder::with_id("file_new_agent", labels.new_agent).build(handle)?;
     let new_worktree_agent_item =
-        MenuItemBuilder::with_id("file_new_worktree_agent", "新建工作树代理").build(handle)?;
+        MenuItemBuilder::with_id("file_new_worktree_agent", labels.new_worktree_agent)
+            .build(handle)?;
     let new_clone_agent_item =
-        MenuItemBuilder::with_id("file_new_clone_agent", "新建克隆代理").build(handle)?;
-    let new_window_item = MenuItemBuilder::with_id("file_new_window", "新建窗口")
+        MenuItemBuilder::with_id("file_new_clone_agent", labels.new_clone_agent).build(handle)?;
+    let new_window_item = MenuItemBuilder::with_id("file_new_window", labels.new_window)
         .accelerator(NEW_WINDOW_ACCELERATOR)
         .build(handle)?;
     let add_workspace_item =
-        MenuItemBuilder::with_id("file_add_workspace", "添加工作区…").build(handle)?;
+        MenuItemBuilder::with_id("file_add_workspace", labels.add_workspace).build(handle)?;
 
     registry.register("file_new_agent", &new_agent_item);
     registry.register("file_new_worktree_agent", &new_worktree_agent_item);
@@ -197,11 +339,11 @@ pub(crate) fn build_menu<R: tauri::Runtime>(
     #[cfg(target_os = "linux")]
     let file_menu = {
         let close_window_item =
-            MenuItemBuilder::with_id("file_close_window", "关闭窗口").build(handle)?;
-        let quit_item = MenuItemBuilder::with_id("file_quit", "退出").build(handle)?;
+            MenuItemBuilder::with_id("file_close_window", labels.close_window).build(handle)?;
+        let quit_item = MenuItemBuilder::with_id("file_quit", labels.quit).build(handle)?;
         registry.register("file_close_window", &close_window_item);
         registry.register("file_quit", &quit_item);
-        let submenu = SubmenuBuilder::with_id(handle, "file_menu", "文件")
+        let submenu = SubmenuBuilder::with_id(handle, "file_menu", labels.file)
             .items(&[
                 &new_agent_item,
                 &new_worktree_agent_item,
@@ -219,7 +361,7 @@ pub(crate) fn build_menu<R: tauri::Runtime>(
     };
     #[cfg(not(target_os = "linux"))]
     let file_menu = {
-        let submenu = SubmenuBuilder::with_id(handle, "file_menu", "文件")
+        let submenu = SubmenuBuilder::with_id(handle, "file_menu", labels.file)
             .items(&[
                 &new_agent_item,
                 &new_worktree_agent_item,
@@ -238,7 +380,7 @@ pub(crate) fn build_menu<R: tauri::Runtime>(
     };
 
     let edit_menu = {
-        let submenu = SubmenuBuilder::with_id(handle, "edit_menu", "编辑")
+        let submenu = SubmenuBuilder::with_id(handle, "edit_menu", labels.edit)
             .items(&[
                 &PredefinedMenuItem::undo(handle, None)?,
                 &PredefinedMenuItem::redo(handle, None)?,
@@ -253,17 +395,18 @@ pub(crate) fn build_menu<R: tauri::Runtime>(
         submenu
     };
 
-    let cycle_model_item = MenuItemBuilder::with_id("composer_cycle_model", "切换模型")
+    let cycle_model_item = MenuItemBuilder::with_id("composer_cycle_model", labels.cycle_model)
         .accelerator("CmdOrCtrl+Shift+M")
         .build(handle)?;
-    let cycle_access_item = MenuItemBuilder::with_id("composer_cycle_access", "切换访问模式")
+    let cycle_access_item = MenuItemBuilder::with_id("composer_cycle_access", labels.cycle_access)
         .accelerator("CmdOrCtrl+Shift+A")
         .build(handle)?;
-    let cycle_reasoning_item = MenuItemBuilder::with_id("composer_cycle_reasoning", "切换推理模式")
-        .accelerator("CmdOrCtrl+Shift+R")
-        .build(handle)?;
+    let cycle_reasoning_item =
+        MenuItemBuilder::with_id("composer_cycle_reasoning", labels.cycle_reasoning)
+            .accelerator("CmdOrCtrl+Shift+R")
+            .build(handle)?;
     let cycle_collaboration_item =
-        MenuItemBuilder::with_id("composer_cycle_collaboration", "切换协作模式")
+        MenuItemBuilder::with_id("composer_cycle_collaboration", labels.cycle_collaboration)
             .accelerator("Shift+Tab")
             .build(handle)?;
     registry.register("composer_cycle_model", &cycle_model_item);
@@ -272,7 +415,7 @@ pub(crate) fn build_menu<R: tauri::Runtime>(
     registry.register("composer_cycle_collaboration", &cycle_collaboration_item);
 
     let composer_menu = {
-        let submenu = SubmenuBuilder::with_id(handle, "composer_menu", "编辑器")
+        let submenu = SubmenuBuilder::with_id(handle, "composer_menu", labels.composer)
             .items(&[
                 &cycle_model_item,
                 &cycle_access_item,
@@ -285,31 +428,35 @@ pub(crate) fn build_menu<R: tauri::Runtime>(
     };
 
     let toggle_projects_sidebar_item =
-        MenuItemBuilder::with_id("view_toggle_projects_sidebar", "切换项目侧边栏").build(handle)?;
+        MenuItemBuilder::with_id("view_toggle_projects_sidebar", labels.toggle_projects_sidebar)
+            .build(handle)?;
     let toggle_git_sidebar_item =
-        MenuItemBuilder::with_id("view_toggle_git_sidebar", "切换 Git 侧边栏").build(handle)?;
+        MenuItemBuilder::with_id("view_toggle_git_sidebar", labels.toggle_git_sidebar)
+            .build(handle)?;
     let toggle_global_search_item =
-        MenuItemBuilder::with_id("view_toggle_global_search", "切换全局搜索")
+        MenuItemBuilder::with_id("view_toggle_global_search", labels.toggle_global_search)
             .accelerator("CmdOrCtrl+O")
             .build(handle)?;
     let toggle_debug_panel_item =
-        MenuItemBuilder::with_id("view_toggle_debug_panel", "切换调试面板")
+        MenuItemBuilder::with_id("view_toggle_debug_panel", labels.toggle_debug_panel)
             .accelerator("CmdOrCtrl+Shift+D")
             .build(handle)?;
-    let toggle_terminal_item = MenuItemBuilder::with_id("view_toggle_terminal", "切换终端")
-        .accelerator("CmdOrCtrl+Shift+T")
-        .build(handle)?;
-    let toggle_devtools_item = MenuItemBuilder::with_id("view_toggle_devtools", "切换开发者工具")
-        .accelerator("CmdOrCtrl+Alt+I")
-        .build(handle)?;
+    let toggle_terminal_item =
+        MenuItemBuilder::with_id("view_toggle_terminal", labels.toggle_terminal)
+            .accelerator("CmdOrCtrl+Shift+T")
+            .build(handle)?;
+    let toggle_devtools_item =
+        MenuItemBuilder::with_id("view_toggle_devtools", labels.toggle_devtools)
+            .accelerator("CmdOrCtrl+Alt+I")
+            .build(handle)?;
     let next_agent_item =
-        MenuItemBuilder::with_id("view_next_agent", "下一个代理").build(handle)?;
+        MenuItemBuilder::with_id("view_next_agent", labels.next_agent).build(handle)?;
     let prev_agent_item =
-        MenuItemBuilder::with_id("view_prev_agent", "上一个代理").build(handle)?;
+        MenuItemBuilder::with_id("view_prev_agent", labels.prev_agent).build(handle)?;
     let next_workspace_item =
-        MenuItemBuilder::with_id("view_next_workspace", "下一个工作区").build(handle)?;
+        MenuItemBuilder::with_id("view_next_workspace", labels.next_workspace).build(handle)?;
     let prev_workspace_item =
-        MenuItemBuilder::with_id("view_prev_workspace", "上一个工作区").build(handle)?;
+        MenuItemBuilder::with_id("view_prev_workspace", labels.prev_workspace).build(handle)?;
     registry.register(
         "view_toggle_projects_sidebar",
         &toggle_projects_sidebar_item,
@@ -327,9 +474,9 @@ pub(crate) fn build_menu<R: tauri::Runtime>(
     #[cfg(target_os = "linux")]
     let view_menu = {
         let fullscreen_item =
-            MenuItemBuilder::with_id("view_fullscreen", "切换全屏").build(handle)?;
+            MenuItemBuilder::with_id("view_fullscreen", labels.fullscreen).build(handle)?;
         registry.register("view_fullscreen", &fullscreen_item);
-        let submenu = SubmenuBuilder::with_id(handle, "view_menu", "视图")
+        let submenu = SubmenuBuilder::with_id(handle, "view_menu", labels.view)
             .items(&[
                 &toggle_projects_sidebar_item,
                 &toggle_git_sidebar_item,
@@ -352,7 +499,7 @@ pub(crate) fn build_menu<R: tauri::Runtime>(
     };
     #[cfg(not(target_os = "linux"))]
     let view_menu = {
-        let submenu = SubmenuBuilder::with_id(handle, "view_menu", "视图")
+        let submenu = SubmenuBuilder::with_id(handle, "view_menu", labels.view)
             .items(&[
                 &toggle_projects_sidebar_item,
                 &toggle_git_sidebar_item,
@@ -376,15 +523,18 @@ pub(crate) fn build_menu<R: tauri::Runtime>(
 
     #[cfg(target_os = "linux")]
     let window_menu = {
-        let minimize_item = MenuItemBuilder::with_id("window_minimize", "最小化").build(handle)?;
-        let maximize_item = MenuItemBuilder::with_id("window_maximize", "最大化").build(handle)?;
-        let reload_item = build_reload_window_item(handle)?;
-        let close_item = MenuItemBuilder::with_id("window_close", "关闭窗口").build(handle)?;
+        let minimize_item =
+            MenuItemBuilder::with_id("window_minimize", labels.minimize).build(handle)?;
+        let maximize_item =
+            MenuItemBuilder::with_id("window_maximize", labels.maximize).build(handle)?;
+        let reload_item = build_reload_window_item(handle, labels)?;
+        let close_item =
+            MenuItemBuilder::with_id("window_close", labels.close_window).build(handle)?;
         registry.register("window_minimize", &minimize_item);
         registry.register("window_maximize", &maximize_item);
         registry.register("window_reload", &reload_item);
         registry.register("window_close", &close_item);
-        let submenu = SubmenuBuilder::with_id(handle, "window_menu", "窗口")
+        let submenu = SubmenuBuilder::with_id(handle, "window_menu", labels.window)
             .items(&[
                 &minimize_item,
                 &maximize_item,
@@ -398,9 +548,9 @@ pub(crate) fn build_menu<R: tauri::Runtime>(
     };
     #[cfg(not(target_os = "linux"))]
     let window_menu = {
-        let reload_item = build_reload_window_item(handle)?;
+        let reload_item = build_reload_window_item(handle, labels)?;
         registry.register("window_reload", &reload_item);
-        let submenu = SubmenuBuilder::with_id(handle, "window_menu", "窗口")
+        let submenu = SubmenuBuilder::with_id(handle, "window_menu", labels.window)
             .items(&[
                 &PredefinedMenuItem::minimize(handle, None)?,
                 &PredefinedMenuItem::maximize(handle, None)?,
@@ -416,9 +566,9 @@ pub(crate) fn build_menu<R: tauri::Runtime>(
     #[cfg(target_os = "linux")]
     let help_menu = {
         let about_item =
-            MenuItemBuilder::with_id("help_about", format!("关于 {app_name}")).build(handle)?;
+            MenuItemBuilder::with_id("help_about", about_label.clone()).build(handle)?;
         registry.register("help_about", &about_item);
-        let submenu = SubmenuBuilder::with_id(handle, "help_menu", "帮助")
+        let submenu = SubmenuBuilder::with_id(handle, "help_menu", labels.help)
             .items(&[&about_item])
             .build()?;
         registry.register_submenu("help_menu", &submenu);
@@ -426,7 +576,7 @@ pub(crate) fn build_menu<R: tauri::Runtime>(
     };
     #[cfg(not(target_os = "linux"))]
     let help_menu = {
-        let submenu = SubmenuBuilder::with_id(handle, "help_menu", "帮助").build()?;
+        let submenu = SubmenuBuilder::with_id(handle, "help_menu", labels.help).build()?;
         registry.register_submenu("help_menu", &submenu);
         submenu
     };
@@ -456,8 +606,9 @@ pub(crate) fn handle_menu_event<R: tauri::Runtime>(
                 let _ = window.set_focus();
                 return;
             }
+            let about_title = format!("{} ccgui", saved_menu_labels().about_prefix);
             let _ = WebviewWindowBuilder::new(app, "about", WebviewUrl::App("index.html".into()))
-                .title("关于 ccgui")
+                .title(about_title)
                 .resizable(false)
                 .inner_size(360.0, 240.0)
                 .center()


### PR DESCRIPTION
## Summary
Build the native menu in the saved UI language up front (a Rust-side mirror of the `menu.*` i18n keys), fixing un-localized menus for non-default-language Linux users. The native menu is built in Rust and can't reach the React i18next layer, and the Linux runtime relabel path (`menu_update_labels`) doesn't reliably repaint the GTK menubar (a muda/GTK limitation), so localizing at build time is the reliable fix.

## Changes
- `menu.rs`: add a `MenuLabels` struct + per-language constructors; build every item from `labels.*` (terminal/devtools included); pick the label set from the saved UI language.

## Test plan
- [x] `cargo test` — full suite passes (1348 lib + 845 daemon + 2 config). No new compiler warnings introduced.
- [x] Verified both `MenuLabels` constructors carry all 34 fields (compiler-enforced) and every base menu item is preserved.

## Notes for reviewers
- OpenSpec: `add-linux-native-menu-localization` included. Independent (touches `menu.rs` only; the `menu.*` i18n keys already existed).

---
*One of a handful of small, independent, upstreamable fixes I'm sending as separate focused PRs (see #801, #802); happy to pace or batch them however suits you. This change originates from an OpenSpec change under `openspec/changes/`. Commits and PR bodies are English for now — glad to provide a Chinese (中文) version on request. Upstream CI runs on push-to-`main` (not PRs), so I ran the relevant gates locally (results in the Test plan above).*
