### PR TITLE
feat(engine): AskUserQuestion MCP bridge for default/acceptEdits mode

### DIFF
--- a/openspec/changes/add-askuserquestion-default-mode-mcp-bridge/.openspec.yaml
+++ b/openspec/changes/add-askuserquestion-default-mode-mcp-bridge/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-04

--- a/openspec/changes/add-askuserquestion-default-mode-mcp-bridge/design.md
+++ b/openspec/changes/add-askuserquestion-default-mode-mcp-bridge/design.md
@@ -1,0 +1,44 @@
+## Context
+
+The CLI exposes native `AskUserQuestion` only in plan mode; in `default` /
+`acceptEdits` it is permission-gated. We want the same one-tap, mid-turn ask in
+the modes people actually work in, without forking the CLI or a kill/resume cycle.
+
+## Approach
+
+**Re-expose the capability as an in-process MCP tool.** The CLI happily calls MCP
+tools in any mode when they are on the allowed list, so we run a tiny in-process
+MCP server (`askuser_mcp.rs`) that offers a single `AskUserQuestion` tool. The
+command build (`claude.rs`) injects it via `--mcp-config` and allow-lists the tool
+in non-plan modes only (plan mode already has the native tool).
+
+**Reuse, don't rebuild, the UI + response path.** An MCP-origin ask is dispatched
+(`user_input.rs`) onto the same `RequestUserInput` event/card path the rest of the
+spec already governs — so multi-question tabs, secret handling, collapse/skip and
+stale-settlement all come for free. The user's submitted answer is returned to the
+originating call as the MCP `tool_result` (a per-request oneshot in
+`mcp_answer_waiters`), so the live turn simply continues.
+
+## Key decisions
+
+- **`MCP_TOOL_TIMEOUT=300000`.** The CLI's per-request MCP fetch timeout defaults
+  to 60s for HTTP MCP servers; a human answer routinely exceeds that. We raise it
+  for the wired command, but never override an explicit user value.
+- **No `--strict-mcp-config`.** Adding it would suppress the user's own MCP
+  servers from `~/.claude.json`; our injection is deliberately additive.
+- **Queue-hold, not queue-flush.** While a dialog is open the turn is blocked; a
+  flush would send queued messages as fresh turns and strand the answer. The
+  frontend derives `hasPendingUserInput` (workspace + thread scoped) and
+  `useQueuedSend` holds the queue until settlement.
+- **`claude`-only.** All wiring is gated on the claude engine; Codex / opencode /
+  gemini paths are untouched.
+
+## Risks / deferred
+
+- `cargo test` + the in-app multiSelect-with-queue retest are **deferred to freeze
+  window F4** (no local rebuilds during the freeze). The command-build guard test
+  (`build_command_raises_mcp_tool_timeout_when_ask_wired`) encodes the timeout
+  contract in the meantime.
+- The daemon path (`respond_to_server_request`) does not route Claude user-input
+  today (live build uses the Tauri handler); a guard is worth adding if daemon
+  mode grows, but is out of scope here.

--- a/openspec/changes/add-askuserquestion-default-mode-mcp-bridge/proposal.md
+++ b/openspec/changes/add-askuserquestion-default-mode-mcp-bridge/proposal.md
@@ -1,0 +1,59 @@
+## Why
+
+Claude's `AskUserQuestion` — the structured, one-tap, mid-turn ask — is only
+exposed by the CLI as a native tool **in plan mode**. In `default` / `acceptEdits`
+(where users actually work) the native tool is permission-gated, so an agent
+cannot pause mid-turn to ask the user a structured question. Users had to drop to
+plan mode, or the model fell back to plain-text questions that don't gate the
+send queue and can be answered late or lost.
+
+The existing `codex-chat-canvas-user-input-elicitation` spec already governs how a
+`RequestUserInput` card **renders** and how its response **round-trips**, but it
+has no requirement for the mechanism that makes AskUserQuestion reachable outside
+plan mode at all, for the CLI fetch-timeout the mechanism needs, or for holding
+the composer queue while an ask is open. This change adds those three
+requirements and the implementation behind them.
+
+## 目标与边界
+
+- Expose `AskUserQuestion` as an **allowed in-process MCP tool** in non-plan
+  modes, reusing the existing `RequestUserInput` card + `respond_to_server_request`
+  round-trip for rendering and settlement — no new UI surface.
+- Deliver the user's answer back to the originating live turn as the MCP
+  `tool_result`, so the turn continues without a kill/resume cycle.
+- Raise `MCP_TOOL_TIMEOUT` for the wired command so answers slower than the CLI's
+  60s default fetch timeout still land (respecting an explicit user override).
+- Hold the composer send queue for a thread while it has a pending ask, so queued
+  messages don't start fresh turns and strand the answer.
+
+## 非目标
+
+- Do not change the shared question-card presentation, multi-question tabs, secret
+  handling, or stale-settlement semantics already specified for
+  `RequestUserInput` — this change only adds the MCP-origin reachability path and
+  reuses the rest.
+- Do not alter Codex / opencode / gemini engines — the wiring is `claude`-only.
+- Do not add `--strict-mcp-config` (would disable the user's own MCP servers); the
+  injection is purely additive.
+- No change to plan mode, which keeps using the CLI's native AskUserQuestion tool.
+
+## What Changes
+
+- **New** `src-tauri/src/engine/claude/askuser_mcp.rs`: an in-process MCP server
+  exposing a single `AskUserQuestion` tool; `mcp_config_json` + `allowed_tool_name`
+  feed the CLI command; a global handle is started at app setup.
+- **New** `src-tauri/src/engine/claude/user_input.rs`: routes an MCP-origin ask to
+  the live turn's subscriber and awaits the answer via a per-request oneshot.
+- `engine/claude.rs`: in non-plan modes, inject `--mcp-config` + allowed tool and
+  set `MCP_TOOL_TIMEOUT=300000` (unless the user set it); `mcp_answer_waiters`
+  map on the manager state; guard test that the timeout is raised when wired.
+- `engine/{events,manager}.rs`, `event_conversion.rs`, `lib.rs`: `completed`
+  lifecycle on `RequestUserInput`, manager plumbing, and app-setup server start.
+- Frontend: `app-shell.tsx` derives `hasPendingUserInput` (workspace + thread
+  scoped) and threads it through `useComposerController` into `useQueuedSend`,
+  which holds the queue while an ask is pending; tests in `useQueuedSend.test.tsx`.
+
+## Spec deltas
+
+- `codex-chat-canvas-user-input-elicitation`: **ADDED** three requirements —
+  non-plan MCP reachability, MCP fetch-timeout survival, and queue-hold-while-pending.

--- a/openspec/changes/add-askuserquestion-default-mode-mcp-bridge/specs/codex-chat-canvas-user-input-elicitation/spec.md
+++ b/openspec/changes/add-askuserquestion-default-mode-mcp-bridge/specs/codex-chat-canvas-user-input-elicitation/spec.md
@@ -1,0 +1,73 @@
+## ADDED Requirements
+
+### Requirement: AskUserQuestion MUST Be Reachable In Non-Plan Modes Via An In-Process MCP Server
+
+系统 MUST 在非 plan 模式（`default` / `acceptEdits`）下通过一个进程内 MCP 服务器暴露 `AskUserQuestion` 工具，使 Claude 会话可以在 turn 进行中发起结构化提问，而不是仅在 plan 模式下经由原生 plan-gated 工具才能提问。
+
+The Claude CLI only exposes its native `AskUserQuestion` tool when running in plan
+mode; in `default` / `acceptEdits` the native tool is permission-gated, so a
+mid-turn structured ask is otherwise impossible. The client MUST start an
+in-process MCP server that re-exposes the capability as an allowed MCP tool.
+
+#### Scenario: non-plan mode wires the in-process MCP tool
+
+- **WHEN** 客户端为一个 `claude` 会话构建 CLI 命令
+- **AND** 该会话运行时模式不是 plan 模式
+- **THEN** 命令 MUST 通过 `--mcp-config` 注入进程内 AskUserQuestion MCP 服务器
+- **AND** 命令 MUST 将该服务器的工具名显式加入允许列表（allowed tools）
+- **AND** 系统 MUST NOT 传入 `--strict-mcp-config`，以免屏蔽用户自有的 MCP 服务器
+
+#### Scenario: plan mode does not double-wire the MCP tool
+
+- **WHEN** 客户端为一个 `claude` 会话构建 CLI 命令
+- **AND** 该会话运行时模式为 plan 模式
+- **THEN** 系统 MUST 依赖 CLI 原生 `AskUserQuestion` 工具
+- **AND** 系统 MUST NOT 额外注入进程内 MCP AskUserQuestion 工具
+
+#### Scenario: MCP-origin ask renders and settles through the shared user-input card
+
+- **WHEN** 进程内 MCP 服务器收到一个 AskUserQuestion 调用
+- **THEN** 系统 MUST 复用既有 `RequestUserInput` 交互卡片路径展示该提问
+- **AND** 用户提交后系统 MUST 将答案作为 MCP `tool_result` 返回给发起该调用的 live turn
+- **AND** 该往返 MUST NOT 依赖 kill/resume，当前 turn MUST 继续执行
+
+### Requirement: AskUserQuestion MCP Calls MUST Survive Answers Slower Than The CLI Default Fetch Timeout
+
+系统 MUST 在注入 AskUserQuestion MCP 工具时提高 CLI 的 MCP 工具调用抓取超时，使用户耗时超过 CLI 默认 60s 的回答不会被 CLI 提前放弃并作为 timeout 返回给模型。
+
+The Claude CLI defaults its per-request MCP tool-call fetch timeout to 60s for
+HTTP MCP servers, but an AskUserQuestion blocks on a human for up to the server's
+own (much longer) window. Without raising the CLI timeout, any answer taking
+longer than 60s is abandoned by the CLI and lost.
+
+#### Scenario: tool timeout is raised when the ask is wired
+
+- **WHEN** 客户端为一个 `claude` 会话注入 AskUserQuestion MCP 工具
+- **THEN** 命令环境 MUST 设置 `MCP_TOOL_TIMEOUT` 为一个不短于服务器等待窗口的值（例如 300000 毫秒）
+- **AND** 一个耗时超过 60s 才提交的回答 MUST 仍被正确送达发起该调用的 turn
+
+#### Scenario: an explicit user override is respected
+
+- **WHEN** 环境中已存在用户设置的 `MCP_TOOL_TIMEOUT`
+- **THEN** 系统 MUST NOT 覆盖该用户显式值
+
+### Requirement: A Pending AskUserQuestion MUST Hold The Composer Send Queue For Its Thread
+
+系统 MUST 在某线程存在待回答的 AskUserQuestion / RequestUserInput 卡片时，保留（而非清空）该线程的 Composer 发送队列，使排队消息不会被当作新 turn 发出而令待处理提问失去归属。
+
+While a dialog is open the CLI turn is blocked awaiting the answer; flushing the
+queue would strand the answer and start unrelated fresh turns.
+
+#### Scenario: queued messages are held while an ask is pending for the active thread
+
+- **WHEN** 活动线程存在一个待回答的 AskUserQuestion 卡片
+- **AND** 用户发送或已排队一条消息
+- **THEN** 系统 MUST 将该消息保留在队列中而不是立即作为新 turn 发出
+- **AND** 系统 MUST 在提问结算（提交 / skip / stale settlement）后恢复正常的队列 flush
+
+#### Scenario: pending detection is scoped by workspace and thread
+
+- **WHEN** 系统判断当前线程是否存在待回答提问
+- **THEN** 判断 MUST 匹配 `workspace_id`
+- **AND** 空 `thread_id` MUST 视为当前线程
+- **AND** 另一线程的待回答提问 MUST NOT 触发当前线程的队列保留

--- a/openspec/changes/add-askuserquestion-default-mode-mcp-bridge/tasks.md
+++ b/openspec/changes/add-askuserquestion-default-mode-mcp-bridge/tasks.md
@@ -1,0 +1,23 @@
+## 1. OpenSpec Artifacts
+
+- [x] 1.1 Author proposal/design/spec delta/tasks for the default-mode AskUserQuestion MCP bridge; output: change dir under `openspec/changes/add-askuserquestion-default-mode-mcp-bridge`; validation: `openspec validate add-askuserquestion-default-mode-mcp-bridge --strict --no-interactive`. [P0][I][O: change dir][V: openspec validate]
+
+## 2. In-process MCP server (Rust)
+
+- [x] 2.1 `askuser_mcp.rs`: in-process MCP server exposing one `AskUserQuestion` tool; `mcp_config_json(workspace_id)` + `allowed_tool_name()`; global start via `init_askuser_mcp_global`. [P0][I][O: askuser_mcp.rs][V: cargo (F4)]
+- [x] 2.2 `user_input.rs`: route an MCP-origin ask to the live turn subscriber; await the answer via per-request oneshot; settle on completed. [P0][I][O: user_input.rs][V: cargo (F4)]
+- [x] 2.3 `claude.rs`: in non-plan modes inject `--mcp-config` + allowed tool, set `MCP_TOOL_TIMEOUT=300000` unless user-set; `mcp_answer_waiters` map on manager state. [P0][I][O: claude.rs][V: tests_stream]
+- [x] 2.4 `events.rs` / `manager.rs` / `event_conversion.rs` / `lib.rs`: `completed` lifecycle on `RequestUserInput`, manager plumbing, app-setup server start. [P0][I][O: engine files][V: cargo (F4)]
+
+## 3. Composer queue hold (frontend)
+
+- [x] 3.1 `app-shell.tsx`: derive `hasPendingUserInput` scoped by `workspace_id` + `thread_id` (empty thread_id = current); thread it into `useComposerController`. [P0][I][O: app-shell.tsx][V: typecheck]
+- [x] 3.2 `useComposerController.ts`: accept + forward `hasPendingUserInput`. [P0][I][O: useComposerController.ts][V: typecheck]
+- [x] 3.3 `useQueuedSend.ts`: hold the queue while `hasPendingUserInput`; release on settlement. [P0][I][O: useQueuedSend.ts][V: vitest]
+
+## 4. Tests / gates
+
+- [x] 4.1 `tests_stream.rs`: guard that `MCP_TOOL_TIMEOUT` is raised when the ask is wired (`build_command_raises_mcp_tool_timeout_when_ask_wired`). [P0][I][O: tests_stream.rs][V: cargo (F4)]
+- [x] 4.2 `useQueuedSend.test.tsx`: queue-hold-while-pending regression. [P0][I][O: useQueuedSend.test.tsx][V: vitest]
+- [ ] 4.3 `cargo test` (app closed) — DEFERRED to freeze window F4 (no local rebuilds during freeze). [P0][V: cargo]
+- [ ] 4.4 Manual in-app retest: multiSelect ask with 2-3 messages queued behind it; box jumps the queue, answer, turn continues — DEFERRED to F4. [P1][V: manual]

--- a/src-tauri/src/engine/claude.rs
+++ b/src-tauri/src/engine/claude.rs
@@ -35,6 +35,8 @@ pub(crate) struct ClaudeAskUserQuestionResumeDiagnostic {
 }
 #[path = "claude/approval.rs"]
 mod approval;
+#[path = "claude/askuser_mcp.rs"]
+mod askuser_mcp;
 #[path = "claude/curated_skill_prompt.rs"]
 mod curated_skill_prompt;
 #[path = "claude/event_conversion.rs"]
@@ -60,6 +62,9 @@ use approval::{
 #[cfg(test)]
 #[path = "claude/tests_stream.rs"]
 mod tests_stream;
+pub use askuser_mcp::{
+    global as askuser_mcp_global, init_global as init_askuser_mcp_global, AskUserMcpServer,
+};
 pub use manager::ClaudeSessionManager;
 #[cfg(test)]
 use stream_helpers::extract_text_from_content;
@@ -342,6 +347,27 @@ pub struct ClaudeSession {
     /// Optional observer for real AskUserQuestion resume success/failure.
     ask_user_question_resume_diagnostic_sink:
         StdMutex<Option<ClaudeAskUserQuestionResumeDiagnosticSink>>,
+    /// Waiters for AskUserQuestion requests answered via the in-process MCP tool
+    /// (B2 path): request_id -> oneshot sender carrying the formatted answer text.
+    /// Present here means the answer is delivered by returning the MCP tool_result,
+    /// so the kill/`--resume` path is skipped for that request.
+    mcp_answer_waiters: StdMutex<HashMap<String, tokio::sync::oneshot::Sender<String>>>,
+    /// The turn currently being processed, if any. Set for the duration of
+    /// `send_message_with_app_settings`. The in-process MCP server reads this to
+    /// route a mid-turn AskUserQuestion to the live turn's event subscriber.
+    active_turn_id: StdMutex<Option<String>>,
+}
+
+/// Clears the session's active turn on drop, covering every exit path of
+/// `send_message_with_app_settings` (including `?`/panic unwinds).
+struct ActiveTurnGuard<'a> {
+    session: &'a ClaudeSession,
+}
+
+impl Drop for ActiveTurnGuard<'_> {
+    fn drop(&mut self) {
+        self.session.set_active_turn(None);
+    }
 }
 
 impl ClaudeSession {
@@ -605,6 +631,8 @@ impl ClaudeSession {
             thread_id_by_turn: StdMutex::new(HashMap::new()),
             pending_user_input_resume_diagnostic_by_turn: StdMutex::new(HashMap::new()),
             ask_user_question_resume_diagnostic_sink: StdMutex::new(None),
+            mcp_answer_waiters: StdMutex::new(HashMap::new()),
+            active_turn_id: StdMutex::new(None),
         }
     }
 
@@ -891,6 +919,7 @@ impl ClaudeSession {
 
         // Access mode / permission handling
         // Maps UI access modes to Claude Code CLI permission flags
+        let is_plan_mode = matches!(params.access_mode.as_deref(), Some("read-only"));
         match params.access_mode.as_deref() {
             Some("full-access") => {
                 // Full access: bypass all permission checks
@@ -910,6 +939,39 @@ impl ClaudeSession {
                 // "current" mode: auto-accept edits but still prompt for dangerous ops
                 cmd.arg("--permission-mode");
                 cmd.arg("acceptEdits");
+            }
+        }
+
+        // Register the in-process AskUserQuestion MCP server in NON-plan modes.
+        // In plan mode the CLI already exposes the native AskUserQuestion tool, so
+        // registering ours would double the surface. Outside plan mode the native
+        // tool is never offered, so this is what restores mid-turn structured asks.
+        //
+        // MCP tools are permission-gated, so we must also allow ours explicitly
+        // (verified: without this the CLI reports "not granted" and the model
+        // can't get the answer). `--dangerously-skip-permissions` (full-access)
+        // already covers it, but allowing it is harmless and keeps modes uniform.
+        // We intentionally do NOT pass `--strict-mcp-config` so the user's own
+        // MCP servers (from ~/.claude.json) keep working — this is purely additive.
+        if !is_plan_mode {
+            if let Some(server) = crate::engine::claude::askuser_mcp_global() {
+                cmd.arg("--mcp-config");
+                cmd.arg(server.mcp_config_json(&self.workspace_id));
+                cmd.arg("--allowedTools");
+                cmd.arg(crate::engine::claude::AskUserMcpServer::allowed_tool_name());
+                // The CLI's per-request MCP tool-call fetch timeout defaults to 60s
+                // for remote HTTP servers. Our AskUserQuestion server blocks up to
+                // 300s waiting for the user, so without this the CLI abandons the
+                // call at 60s and any ask the user takes longer than a minute on is
+                // lost. Raise it to match our server bound (ms). Only set when our
+                // MCP ask is actually wired; the user can still override via env.
+                if std::env::var_os("MCP_TOOL_TIMEOUT").is_none() {
+                    cmd.env("MCP_TOOL_TIMEOUT", "300000");
+                }
+            } else {
+                log::warn!(
+                    "[claude] AskUserQuestion MCP server not started; mid-turn asks unavailable this turn"
+                );
             }
         }
 
@@ -1015,6 +1077,11 @@ impl ClaudeSession {
         turn_id: &str,
         app_settings: Option<&crate::types::AppSettings>,
     ) -> Result<String, String> {
+        // Mark this as the active turn so a mid-turn MCP AskUserQuestion can find
+        // the live event subscriber. Cleared on any exit path via the guard.
+        self.set_active_turn(Some(turn_id));
+        let _active_turn_guard = ActiveTurnGuard { session: self };
+
         match self
             .send_message_attempt(params.clone(), turn_id, true, app_settings)
             .await
@@ -1029,6 +1096,18 @@ impl ClaudeSession {
             }
             result => result,
         }
+    }
+
+    fn set_active_turn(&self, turn_id: Option<&str>) {
+        if let Ok(mut active) = self.active_turn_id.lock() {
+            *active = turn_id.map(ToOwned::to_owned);
+        }
+    }
+
+    /// The turn currently being processed, if any. Used by the in-process MCP
+    /// AskUserQuestion server to route a mid-turn ask to the live subscriber.
+    pub fn active_turn_id(&self) -> Option<String> {
+        self.active_turn_id.lock().ok().and_then(|active| active.clone())
     }
 
     async fn send_message_attempt(

--- a/src-tauri/src/engine/claude.rs
+++ b/src-tauri/src/engine/claude.rs
@@ -62,9 +62,12 @@ use approval::{
 #[cfg(test)]
 #[path = "claude/tests_stream.rs"]
 mod tests_stream;
-pub use askuser_mcp::{
-    global as askuser_mcp_global, init_global as init_askuser_mcp_global, AskUserMcpServer,
-};
+pub use askuser_mcp::{global as askuser_mcp_global, AskUserMcpServer};
+// `init_global` is re-exported for the Tauri lib entrypoint (lib.rs) and tests; the
+// cc_gui_daemon binary compiles this module but never starts the askuser MCP server,
+// so the re-export is unused in that build — allow it rather than trip `-D warnings`.
+#[allow(unused_imports)]
+pub use askuser_mcp::init_global as init_askuser_mcp_global;
 pub use manager::ClaudeSessionManager;
 #[cfg(test)]
 use stream_helpers::extract_text_from_content;

--- a/src-tauri/src/engine/claude/askuser_mcp.rs
+++ b/src-tauri/src/engine/claude/askuser_mcp.rs
@@ -1,0 +1,297 @@
+//! In-process HTTP MCP server exposing a single `AskUserQuestion` tool.
+//!
+//! # Why this exists
+//! The `claude` CLI only offers the native `AskUserQuestion` tool to the model in
+//! **plan mode**. To restore mid-turn structured asks in default/acceptEdits, we
+//! register an MCP tool — MCP tools are not plan-gated — and route its call into
+//! the existing `RequestUserInput` dialog machinery.
+//!
+//! # Transport
+//! Streamable-HTTP: a single `POST /mcp/:workspace_id` endpoint speaking JSON-RPC
+//! (`initialize`, `tools/list`, `tools/call`), responding `application/json`. No
+//! SSE stream is needed for request/response. Verified against CLI v2.1.201.
+//!
+//! # Answer path (B2)
+//! On `tools/call`, resolve the workspace's `ClaudeSession` and call
+//! `ask_via_mcp`, which emits `RequestUserInput` to the live turn's subscriber
+//! and blocks until the user answers. The answer text is returned as the MCP
+//! tool_result — the CLI turn continues natively, no kill/`--resume`.
+
+use std::net::SocketAddr;
+use std::sync::{Arc, OnceLock};
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::routing::post;
+use axum::{Json, Router};
+use serde_json::{json, Value};
+use tokio::net::TcpListener;
+
+use super::ClaudeSessionManager;
+
+/// The tool name the model sees (prefixed by the CLI as `mcp__ccgui__AskUserQuestion`).
+pub const MCP_SERVER_NAME: &str = "ccgui";
+pub const ASK_TOOL_NAME: &str = "AskUserQuestion";
+
+/// Process-global handle to the running server, set once at app startup.
+/// The CLI spawn wiring reads this to build the per-workspace `--mcp-config`.
+static ASKUSER_MCP_SERVER: OnceLock<AskUserMcpServer> = OnceLock::new();
+
+/// Start the server (idempotent) and store it in the process-global slot.
+/// Call once during app setup. No-op if already started.
+pub async fn init_global(claude_manager: Arc<ClaudeSessionManager>) -> Result<(), String> {
+    if ASKUSER_MCP_SERVER.get().is_some() {
+        return Ok(());
+    }
+    let server = AskUserMcpServer::start(claude_manager).await?;
+    // Ignore the race where another caller set it first; either is valid.
+    let _ = ASKUSER_MCP_SERVER.set(server);
+    Ok(())
+}
+
+/// The running server, if it has been started.
+pub fn global() -> Option<&'static AskUserMcpServer> {
+    ASKUSER_MCP_SERVER.get()
+}
+
+#[derive(Clone)]
+struct McpServerState {
+    claude_manager: Arc<ClaudeSessionManager>,
+}
+
+/// A running in-process AskUserQuestion MCP server. Holds the bound port so the
+/// CLI spawn wiring can build the per-workspace `--mcp-config` URL.
+pub struct AskUserMcpServer {
+    port: u16,
+}
+
+impl AskUserMcpServer {
+    /// Bind an ephemeral localhost port and start serving. Returns once the
+    /// listener is bound (so `port()` is immediately usable); the accept loop
+    /// runs on a detached task for the process lifetime.
+    pub async fn start(claude_manager: Arc<ClaudeSessionManager>) -> Result<Self, String> {
+        let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+            .await
+            .map_err(|err| format!("failed to bind AskUserQuestion MCP server: {err}"))?;
+        let port = listener
+            .local_addr()
+            .map_err(|err| format!("failed to read MCP server addr: {err}"))?
+            .port();
+
+        let state = McpServerState { claude_manager };
+        let router = Router::new()
+            .route("/mcp/:workspace_id", post(handle_mcp))
+            .with_state(state);
+
+        tokio::spawn(async move {
+            if let Err(err) = axum::serve(listener, router).await {
+                log::error!("AskUserQuestion MCP server stopped: {err}");
+            }
+        });
+
+        log::info!("AskUserQuestion MCP server listening on 127.0.0.1:{port}");
+        Ok(Self { port })
+    }
+
+    /// The `--mcp-config` inline JSON registering this server for a given
+    /// workspace. Uses http transport so no subprocess is spawned.
+    pub fn mcp_config_json(&self, workspace_id: &str) -> String {
+        json!({
+            "mcpServers": {
+                MCP_SERVER_NAME: {
+                    "type": "http",
+                    "url": format!("http://127.0.0.1:{}/mcp/{}", self.port, workspace_id),
+                }
+            }
+        })
+        .to_string()
+    }
+
+    /// The fully-qualified tool name the CLI exposes, for `--allowedTools`.
+    pub fn allowed_tool_name() -> String {
+        format!("mcp__{MCP_SERVER_NAME}__{ASK_TOOL_NAME}")
+    }
+}
+
+fn tool_definition() -> Value {
+    json!({
+        "name": ASK_TOOL_NAME,
+        "description": "Ask the user a structured multiple-choice question and get their selection back. \
+            Use mid-turn when you need the user to pick between options before continuing. \
+            Provide 2-4 options per question; put the recommended default first.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "questions": {
+                    "type": "array",
+                    "description": "One or more questions to ask the user.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "question": { "type": "string", "description": "The question text." },
+                            "header": { "type": "string", "description": "A short label for the question." },
+                            "multiSelect": { "type": "boolean", "description": "Allow selecting multiple options." },
+                            "options": {
+                                "type": "array",
+                                "description": "The options to choose from. First option is the recommended default.",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "label": { "type": "string" },
+                                        "description": { "type": "string" }
+                                    },
+                                    "required": ["label"]
+                                }
+                            }
+                        },
+                        "required": ["question", "options"]
+                    }
+                }
+            },
+            "required": ["questions"]
+        }
+    })
+}
+
+fn rpc_result(id: Value, result: Value) -> Value {
+    json!({ "jsonrpc": "2.0", "id": id, "result": result })
+}
+
+fn rpc_error(id: Value, code: i64, message: &str) -> Value {
+    json!({ "jsonrpc": "2.0", "id": id, "error": { "code": code, "message": message } })
+}
+
+/// A JSON-RPC response, or 202-with-no-body for notifications.
+enum McpResponse {
+    Json(Value),
+    Accepted,
+}
+
+impl IntoResponse for McpResponse {
+    fn into_response(self) -> axum::response::Response {
+        match self {
+            McpResponse::Json(value) => (StatusCode::OK, Json(value)).into_response(),
+            McpResponse::Accepted => StatusCode::ACCEPTED.into_response(),
+        }
+    }
+}
+
+async fn handle_mcp(
+    Path(workspace_id): Path<String>,
+    State(state): State<McpServerState>,
+    Json(msg): Json<Value>,
+) -> McpResponse {
+    let id = msg.get("id").cloned().unwrap_or(Value::Null);
+    let method = msg.get("method").and_then(Value::as_str).unwrap_or("");
+
+    match method {
+        "initialize" => {
+            let protocol_version = msg
+                .get("params")
+                .and_then(|p| p.get("protocolVersion"))
+                .and_then(Value::as_str)
+                .unwrap_or("2024-11-05")
+                .to_string();
+            McpResponse::Json(rpc_result(
+                id,
+                json!({
+                    "protocolVersion": protocol_version,
+                    "capabilities": { "tools": {} },
+                    "serverInfo": { "name": MCP_SERVER_NAME, "version": env!("CARGO_PKG_VERSION") }
+                }),
+            ))
+        }
+        // Notifications (no `id`) get no response body.
+        "notifications/initialized" | "notifications/cancelled" => McpResponse::Accepted,
+        "tools/list" => {
+            McpResponse::Json(rpc_result(id, json!({ "tools": [tool_definition()] })))
+        }
+        "tools/call" => {
+            let tool_name = msg
+                .get("params")
+                .and_then(|p| p.get("name"))
+                .and_then(Value::as_str)
+                .unwrap_or("");
+            if tool_name != ASK_TOOL_NAME {
+                return McpResponse::Json(rpc_error(
+                    id,
+                    -32602,
+                    &format!("unknown tool: {tool_name}"),
+                ));
+            }
+            let arguments = msg
+                .get("params")
+                .and_then(|p| p.get("arguments"))
+                .cloned()
+                .unwrap_or_else(|| json!({}));
+
+            let Some(session) = state.claude_manager.get_session(&workspace_id).await else {
+                return McpResponse::Json(rpc_error(
+                    id,
+                    -32000,
+                    "no active Claude session for this workspace",
+                ));
+            };
+
+            match session.ask_via_mcp(&arguments).await {
+                Ok(answer_text) => McpResponse::Json(rpc_result(
+                    id,
+                    json!({ "content": [{ "type": "text", "text": answer_text }] }),
+                )),
+                // Return a tool_result error (isError) rather than a JSON-RPC
+                // error so the CLI recovers and the model can continue.
+                Err(err) => McpResponse::Json(rpc_result(
+                    id,
+                    json!({
+                        "content": [{ "type": "text", "text": format!("AskUserQuestion failed: {err}") }],
+                        "isError": true
+                    }),
+                )),
+            }
+        }
+        other => McpResponse::Json(rpc_error(id, -32601, &format!("method not found: {other}"))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn server_at(port: u16) -> AskUserMcpServer {
+        AskUserMcpServer { port }
+    }
+
+    #[test]
+    fn mcp_config_json_uses_http_transport_and_workspace_url() {
+        let config: Value = serde_json::from_str(&server_at(4899).mcp_config_json("ws-42")).unwrap();
+        let server = &config["mcpServers"][MCP_SERVER_NAME];
+        assert_eq!(server["type"], "http");
+        assert_eq!(server["url"], "http://127.0.0.1:4899/mcp/ws-42");
+        // Must NOT request strict mode — that would drop the user's own servers.
+        assert!(config.get("strict").is_none());
+    }
+
+    #[test]
+    fn allowed_tool_name_matches_cli_mcp_prefix() {
+        assert_eq!(
+            AskUserMcpServer::allowed_tool_name(),
+            "mcp__ccgui__AskUserQuestion"
+        );
+    }
+
+    #[test]
+    fn tool_definition_schema_matches_native_questions_shape() {
+        let def = tool_definition();
+        assert_eq!(def["name"], ASK_TOOL_NAME);
+        // The engine's convert_ask_user_question_to_request parses these exact keys.
+        let props = &def["inputSchema"]["properties"]["questions"]["items"]["properties"];
+        assert!(props.get("question").is_some());
+        assert!(props.get("header").is_some());
+        assert!(props.get("options").is_some());
+        assert!(props.get("multiSelect").is_some());
+        let opt = &props["options"]["items"]["properties"];
+        assert!(opt.get("label").is_some());
+        assert!(opt.get("description").is_some());
+    }
+}

--- a/src-tauri/src/engine/claude/askuser_mcp.rs
+++ b/src-tauri/src/engine/claude/askuser_mcp.rs
@@ -21,7 +21,7 @@ use std::net::SocketAddr;
 use std::sync::{Arc, OnceLock};
 
 use axum::extract::{Path, State};
-use axum::http::StatusCode;
+use axum::http::{HeaderMap, StatusCode};
 use axum::response::IntoResponse;
 use axum::routing::post;
 use axum::{Json, Router};
@@ -58,12 +58,16 @@ pub fn global() -> Option<&'static AskUserMcpServer> {
 #[derive(Clone)]
 struct McpServerState {
     claude_manager: Arc<ClaudeSessionManager>,
+    /// Random per-process bearer token; every request must present it (set in `start`).
+    token: Arc<str>,
 }
 
 /// A running in-process AskUserQuestion MCP server. Holds the bound port so the
-/// CLI spawn wiring can build the per-workspace `--mcp-config` URL.
+/// CLI spawn wiring can build the per-workspace `--mcp-config` URL, plus the bearer
+/// token injected into that config's headers and required on every request.
 pub struct AskUserMcpServer {
     port: u16,
+    token: Arc<str>,
 }
 
 impl AskUserMcpServer {
@@ -79,7 +83,14 @@ impl AskUserMcpServer {
             .map_err(|err| format!("failed to read MCP server addr: {err}"))?
             .port();
 
-        let state = McpServerState { claude_manager };
+        // Unguessable per-process token: our CLI spawn carries it via the injected
+        // `--mcp-config` Authorization header; any other local process that finds the
+        // loopback port cannot forge it.
+        let token: Arc<str> = Arc::from(uuid::Uuid::new_v4().simple().to_string());
+        let state = McpServerState {
+            claude_manager,
+            token: Arc::clone(&token),
+        };
         let router = Router::new()
             .route("/mcp/:workspace_id", post(handle_mcp))
             .with_state(state);
@@ -91,7 +102,7 @@ impl AskUserMcpServer {
         });
 
         log::info!("AskUserQuestion MCP server listening on 127.0.0.1:{port}");
-        Ok(Self { port })
+        Ok(Self { port, token })
     }
 
     /// The `--mcp-config` inline JSON registering this server for a given
@@ -102,6 +113,7 @@ impl AskUserMcpServer {
                 MCP_SERVER_NAME: {
                     "type": "http",
                     "url": format!("http://127.0.0.1:{}/mcp/{}", self.port, workspace_id),
+                    "headers": { "Authorization": format!("Bearer {}", self.token) },
                 }
             }
         })
@@ -166,6 +178,7 @@ fn rpc_error(id: Value, code: i64, message: &str) -> Value {
 enum McpResponse {
     Json(Value),
     Accepted,
+    Unauthorized,
 }
 
 impl IntoResponse for McpResponse {
@@ -173,15 +186,32 @@ impl IntoResponse for McpResponse {
         match self {
             McpResponse::Json(value) => (StatusCode::OK, Json(value)).into_response(),
             McpResponse::Accepted => StatusCode::ACCEPTED.into_response(),
+            McpResponse::Unauthorized => StatusCode::UNAUTHORIZED.into_response(),
         }
     }
+}
+
+/// Whether the request carries the injected `Authorization: Bearer <token>`.
+fn authorized(headers: &HeaderMap, token: &str) -> bool {
+    headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.strip_prefix("Bearer "))
+        .map(|presented| presented == token)
+        .unwrap_or(false)
 }
 
 async fn handle_mcp(
     Path(workspace_id): Path<String>,
     State(state): State<McpServerState>,
+    headers: HeaderMap,
     Json(msg): Json<Value>,
 ) -> McpResponse {
+    // The loopback port is reachable by any local process; only our CLI spawn carries
+    // the injected bearer token, so reject everything else before touching a session.
+    if !authorized(&headers, &state.token) {
+        return McpResponse::Unauthorized;
+    }
     let id = msg.get("id").cloned().unwrap_or(Value::Null);
     let method = msg.get("method").and_then(Value::as_str).unwrap_or("");
 
@@ -259,7 +289,10 @@ mod tests {
     use super::*;
 
     fn server_at(port: u16) -> AskUserMcpServer {
-        AskUserMcpServer { port }
+        AskUserMcpServer {
+            port,
+            token: Arc::from("test-token"),
+        }
     }
 
     #[test]
@@ -268,6 +301,7 @@ mod tests {
         let server = &config["mcpServers"][MCP_SERVER_NAME];
         assert_eq!(server["type"], "http");
         assert_eq!(server["url"], "http://127.0.0.1:4899/mcp/ws-42");
+        assert_eq!(server["headers"]["Authorization"], "Bearer test-token");
         // Must NOT request strict mode — that would drop the user's own servers.
         assert!(config.get("strict").is_none());
     }

--- a/src-tauri/src/engine/claude/event_conversion.rs
+++ b/src-tauri/src/engine/claude/event_conversion.rs
@@ -279,7 +279,12 @@ impl ClaudeSession {
                                         input.as_ref(),
                                     );
 
-                                    // Intercept AskUserQuestion tool to emit a RequestUserInput event
+                                    // Intercept the NATIVE (plan-mode) AskUserQuestion tool to emit a
+                                    // RequestUserInput event. The MCP variant
+                                    // (`mcp__ccgui__AskUserQuestion`) is deliberately NOT matched here:
+                                    // its RequestUserInput is already emitted by the in-process MCP
+                                    // handler (`ask_via_mcp`), so re-converting the transcript tool_use
+                                    // would double-emit the dialog. It renders as a normal MCP tool card.
                                     if tool_name == "AskUserQuestion" {
                                         if let Some(ref input_val) = input {
                                             return self.convert_ask_user_question_to_request(
@@ -513,7 +518,9 @@ impl ClaudeSession {
                 }
                 self.register_pending_tool(turn_id, &tool_id, &tool_name, input.as_ref());
 
-                // Intercept AskUserQuestion tool to emit a RequestUserInput event
+                // Intercept the NATIVE (plan-mode) AskUserQuestion tool only. The MCP
+                // variant is answered via the in-process handler; see the streaming
+                // site above for why we must not match it here (double-emit).
                 if tool_name == "AskUserQuestion" {
                     if let Some(ref input_val) = input {
                         return self

--- a/src-tauri/src/engine/claude/tests_stream.rs
+++ b/src-tauri/src/engine/claude/tests_stream.rs
@@ -299,6 +299,45 @@ async fn respond_to_user_input_rejects_mismatched_request_id() {
     assert!(session.has_any_pending_user_input());
 }
 
+#[tokio::test]
+async fn respond_to_user_input_settles_note_only_mcp_answer() {
+    // A note-only answer (free text, NO option selected) must still settle the
+    // waiting MCP tool call — guards the ask_via_mcp oneshot delivery path.
+    let session = ClaudeSession::new("test-workspace".to_string(), test_workspace_path(), None);
+    let request_id = "ask-note-only";
+    if let Ok(mut pending) = session.pending_user_inputs.lock() {
+        pending.insert(request_id.to_string(), "turn-note-only".to_string());
+    }
+    let (tx, rx) = tokio::sync::oneshot::channel::<String>();
+    if let Ok(mut waiters) = session.mcp_answer_waiters.lock() {
+        waiters.insert(request_id.to_string(), tx);
+    }
+
+    // Note-only payload: the frontend emits the note under the question id with a
+    // `user_note:` prefix and no option value.
+    let result = json!({
+        "answers": {
+            "q-0": { "answers": ["user_note: just a note"] }
+        }
+    });
+    session
+        .respond_to_user_input(json!(request_id), result)
+        .await
+        .expect("note-only answer should settle, not error");
+
+    let answer = rx
+        .await
+        .expect("MCP waiter must receive the note-only answer (else ask_via_mcp hangs)");
+    assert!(
+        answer.contains("just a note"),
+        "settled answer should carry the note text, got: {answer}"
+    );
+    assert!(
+        !session.has_any_pending_user_input(),
+        "pending request should be consumed on settle"
+    );
+}
+
 #[test]
 fn build_command_adds_external_spec_root_when_configured() {
     let session = ClaudeSession::new("test-workspace".to_string(), test_workspace_path(), None);
@@ -316,6 +355,45 @@ fn build_command_adds_external_spec_root_when_configured() {
     assert!(args.windows(2).any(|window| {
         window[0] == "--add-dir" && window[1] == params.custom_spec_root.clone().unwrap()
     }));
+}
+
+#[tokio::test]
+async fn build_command_raises_mcp_tool_timeout_when_ask_wired() {
+    // Root cause of the "answers >60s are lost" bug (2026-07-04): the CLI's
+    // per-request MCP tool-call fetch timeout defaults to 60s for remote HTTP
+    // servers, so it abandons our AskUserQuestion call before a slow user answers.
+    // build_command must raise MCP_TOOL_TIMEOUT to our 300s server bound whenever
+    // the MCP ask is wired (non-plan mode + server started).
+    let manager = std::sync::Arc::new(ClaudeSessionManager::new());
+    // Idempotent; starts the process-global in-process MCP server so the wiring
+    // branch in build_command is taken.
+    init_askuser_mcp_global(manager)
+        .await
+        .expect("MCP server should start for the test");
+    // Don't fight a user-provided override if one is set in the test env.
+    if std::env::var_os("MCP_TOOL_TIMEOUT").is_some() {
+        return;
+    }
+
+    let session = ClaudeSession::new("test-workspace".to_string(), test_workspace_path(), None);
+    let mut params = SendMessageParams::default();
+    params.text = "hello".to_string();
+    // Non-plan mode → MCP ask is wired.
+    params.access_mode = Some("acceptEdits".to_string());
+
+    let command = session.build_command(&params, false, true, None, None);
+    let timeout_env = command
+        .as_std()
+        .get_envs()
+        .find(|(key, _)| *key == "MCP_TOOL_TIMEOUT")
+        .and_then(|(_, value)| value)
+        .map(|value| value.to_string_lossy().to_string());
+
+    assert_eq!(
+        timeout_env.as_deref(),
+        Some("300000"),
+        "MCP_TOOL_TIMEOUT must be raised to 300s when the AskUserQuestion MCP ask is wired"
+    );
 }
 
 #[test]

--- a/src-tauri/src/engine/claude/user_input.rs
+++ b/src-tauri/src/engine/claude/user_input.rs
@@ -406,6 +406,7 @@ impl ClaudeSession {
             workspace_id: self.workspace_id.clone(),
             request_id: Value::String(request_id),
             questions: Value::Array(questions),
+            completed: false,
         })
     }
 
@@ -815,6 +816,24 @@ impl ClaudeSession {
 
         // Format the answer and store it for the target turn only.
         let answer_text = format_ask_user_answer(&result);
+
+        // MCP-origin request (B2): deliver the answer by resolving the waiting
+        // MCP tool call. No kill/`--resume` — the CLI turn continues natively
+        // with the tool_result in hand.
+        if let Some(sender) = self.take_mcp_answer_waiter(&request_id_key) {
+            let (answer_count, non_empty_answer_count, has_skipped_questions) =
+                Self::summarize_user_input_response(&result);
+            log::info!(
+                "Claude engine: AskUserQuestion (MCP) response accepted (request_id={}, turn_id={}, answer_count={}, non_empty_answer_count={}, has_skipped_questions={})",
+                request_id_key,
+                turn_id,
+                answer_count,
+                non_empty_answer_count,
+                has_skipped_questions
+            );
+            let _ = sender.send(answer_text);
+            return Ok(());
+        }
         let (answer_count, non_empty_answer_count, has_skipped_questions) =
             Self::summarize_user_input_response(&result);
         log::info!(
@@ -836,5 +855,110 @@ impl ClaudeSession {
         self.get_or_create_user_input_notify(&turn_id).notify_one();
 
         Ok(())
+    }
+
+    /// Raise an AskUserQuestion via the in-process MCP tool (B2 path) and block
+    /// until the user answers, returning the formatted tool_result text.
+    ///
+    /// Unlike the native plan-mode path, the answer is delivered by returning the
+    /// MCP tool_result to the still-running CLI turn — no kill/`--resume`. The
+    /// CLI is blocked awaiting our HTTP response while this future is pending, so
+    /// `isProcessing` stays true and the dialog preempts the queued messages,
+    /// exactly as with the native tool.
+    ///
+    /// The current live turn (whose event subscriber carries the RequestUserInput
+    /// to the frontend) is resolved from `active_turn_id()`. `input` is the MCP
+    /// tool's raw arguments (`{ questions: [...] }`), byte-identical to native.
+    pub async fn ask_via_mcp(&self, input: &Value) -> Result<String, String> {
+        let turn_id = self
+            .active_turn_id()
+            .ok_or_else(|| "no active turn for AskUserQuestion".to_string())?;
+        let turn_id = turn_id.as_str();
+        // Reuse the existing conversion so rendering + request_id derivation are
+        // identical to the native path. A synthetic, unique tool_id keeps
+        // concurrent asks within one turn from colliding.
+        let tool_id = {
+            use std::hash::{Hash, Hasher};
+            let mut hasher = std::collections::hash_map::DefaultHasher::new();
+            turn_id.hash(&mut hasher);
+            (input as *const Value as usize).hash(&mut hasher);
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+                .hash(&mut hasher);
+            format!("mcp-ask-{:016x}", hasher.finish())
+        };
+
+        let event = self
+            .convert_ask_user_question_to_request(&tool_id, input, turn_id)
+            .ok_or_else(|| "AskUserQuestion input had no valid questions".to_string())?;
+
+        // Pull the request_id back out of the event so we can register the waiter
+        // under the same key the frontend answer will arrive with.
+        let request_id = match &event {
+            EngineEvent::RequestUserInput { request_id, .. } => request_id
+                .as_str()
+                .map(ToOwned::to_owned)
+                .ok_or_else(|| "RequestUserInput request_id was not a string".to_string())?,
+            _ => return Err("expected RequestUserInput event".to_string()),
+        };
+
+        let (tx, rx) = tokio::sync::oneshot::channel::<String>();
+        if let Ok(mut waiters) = self.mcp_answer_waiters.lock() {
+            waiters.insert(request_id.clone(), tx);
+        }
+
+        // Emit to the live turn's subscriber → existing React dialog.
+        self.emit_turn_event(turn_id, event);
+
+        // Block until the answer arrives (or the native 5-min bound elapses).
+        let answer = match tokio::time::timeout(std::time::Duration::from_secs(300), rx).await {
+            Ok(Ok(text)) => text,
+            Ok(Err(_)) => {
+                // Sender dropped without answering.
+                self.clear_mcp_answer_waiter(&request_id);
+                return Err("AskUserQuestion answer channel closed".to_string());
+            }
+            Err(_) => {
+                self.clear_mcp_answer_waiter(&request_id);
+                // Also drop the pending_user_inputs entry so a late answer is rejected.
+                if let Ok(mut pending) = self.pending_user_inputs.lock() {
+                    pending.remove(&request_id);
+                }
+                // Tell the frontend to dismiss the now-dead dialog (completed=true
+                // is the removal signal). Without this the card lingers forever.
+                self.emit_turn_event(
+                    turn_id,
+                    EngineEvent::RequestUserInput {
+                        workspace_id: self.workspace_id.clone(),
+                        request_id: Value::String(request_id.clone()),
+                        questions: Value::Array(Vec::new()),
+                        completed: true,
+                    },
+                );
+                return Err("AskUserQuestion timed out after 5 minutes".to_string());
+            }
+        };
+
+        Ok(answer)
+    }
+
+    /// Take the MCP answer waiter for `request_id`, if this request is MCP-origin.
+    /// Returns the oneshot sender so the caller can deliver the formatted answer.
+    pub(super) fn take_mcp_answer_waiter(
+        &self,
+        request_id: &str,
+    ) -> Option<tokio::sync::oneshot::Sender<String>> {
+        self.mcp_answer_waiters
+            .lock()
+            .ok()
+            .and_then(|mut waiters| waiters.remove(request_id))
+    }
+
+    fn clear_mcp_answer_waiter(&self, request_id: &str) {
+        if let Ok(mut waiters) = self.mcp_answer_waiters.lock() {
+            waiters.remove(request_id);
+        }
     }
 }

--- a/src-tauri/src/engine/events.rs
+++ b/src-tauri/src/engine/events.rs
@@ -119,6 +119,11 @@ pub enum EngineEvent {
         workspace_id: String,
         request_id: Value,
         questions: Value,
+        /// When true, this is a *removal* signal (e.g. backend timeout): the
+        /// frontend drops the pending dialog instead of showing it. Normal asks
+        /// leave this false.
+        #[serde(default)]
+        completed: bool,
     },
 
     /// Turn/response completed
@@ -710,6 +715,7 @@ pub fn engine_event_to_app_server_event_with_turn_context(
         EngineEvent::RequestUserInput {
             request_id,
             questions,
+            completed,
             ..
         } => json!({
             "method": "item/tool/requestUserInput",
@@ -718,6 +724,7 @@ pub fn engine_event_to_app_server_event_with_turn_context(
                 "turnId": item_id,
                 "itemId": item_id,
                 "questions": questions,
+                "completed": completed,
             },
             "id": request_id,
         }),

--- a/src-tauri/src/engine/events.rs
+++ b/src-tauri/src/engine/events.rs
@@ -723,10 +723,11 @@ pub fn engine_event_to_app_server_event_with_turn_context(
             // for RequestUserInput, so `itemId: item_id` pinned the card to the
             // top of the turn (it rendered right after the assistant message's
             // first block, then got buried as the turn streamed on). A unique,
-            // non-matching itemId makes the frontend use its tail placement,
-            // where the sticky ask-card CSS pins the box above the composer; it
-            // also gives the settled ask its own item id instead of reusing the
-            // assistant message item. turnId stays as item_id for turn context.
+            // non-matching itemId makes the frontend fall back to its default
+            // tail placement, so the card renders at the bottom of the turn near
+            // the composer; it also gives the settled ask its own item id instead
+            // of reusing the assistant message item. turnId stays as item_id for
+            // turn context.
             let ask_item_id = format!("askuserquestion-{}", stringify_value(request_id));
             json!({
                 "method": "item/tool/requestUserInput",
@@ -1108,7 +1109,7 @@ mod tests {
         // (resolve_claude_realtime_item_id falls through to assistant_item_id),
         // which anchored it to the top of the turn. It must carry its own
         // request-scoped itemId so the frontend renders it at the conversation
-        // tail (where the sticky ask-card CSS pins it above the composer).
+        // tail (the bottom of the turn, near the composer).
         let event = EngineEvent::RequestUserInput {
             workspace_id: "ws-ask".to_string(),
             request_id: json!("ask-req-1"),

--- a/src-tauri/src/engine/events.rs
+++ b/src-tauri/src/engine/events.rs
@@ -717,17 +717,29 @@ pub fn engine_event_to_app_server_event_with_turn_context(
             questions,
             completed,
             ..
-        } => json!({
-            "method": "item/tool/requestUserInput",
-            "params": {
-                "threadId": thread_id,
-                "turnId": item_id,
-                "itemId": item_id,
-                "questions": questions,
-                "completed": completed,
-            },
-            "id": request_id,
-        }),
+        } => {
+            // Anchor the ask card to its own request, not the assistant message
+            // head. resolve_claude_realtime_item_id() returns assistant_item_id
+            // for RequestUserInput, so `itemId: item_id` pinned the card to the
+            // top of the turn (it rendered right after the assistant message's
+            // first block, then got buried as the turn streamed on). A unique,
+            // non-matching itemId makes the frontend use its tail placement,
+            // where the sticky ask-card CSS pins the box above the composer; it
+            // also gives the settled ask its own item id instead of reusing the
+            // assistant message item. turnId stays as item_id for turn context.
+            let ask_item_id = format!("askuserquestion-{}", stringify_value(request_id));
+            json!({
+                "method": "item/tool/requestUserInput",
+                "params": {
+                    "threadId": thread_id,
+                    "turnId": item_id,
+                    "itemId": ask_item_id,
+                    "questions": questions,
+                    "completed": completed,
+                },
+                "id": request_id,
+            })
+        }
         EngineEvent::Raw { data, engine, .. } => {
             if matches!(engine, EngineType::Claude) {
                 if let Some(signal) = detect_claude_permission_signal(data) {
@@ -1087,6 +1099,40 @@ mod tests {
         assert_eq!(
             resolve_claude_realtime_item_id(&text_event, "assistant-item", "reasoning-item"),
             "assistant-item"
+        );
+    }
+
+    #[test]
+    fn request_user_input_anchors_item_id_to_its_own_request_not_assistant_head() {
+        // Regression: the ask card used to inherit the assistant message item id
+        // (resolve_claude_realtime_item_id falls through to assistant_item_id),
+        // which anchored it to the top of the turn. It must carry its own
+        // request-scoped itemId so the frontend renders it at the conversation
+        // tail (where the sticky ask-card CSS pins it above the composer).
+        let event = EngineEvent::RequestUserInput {
+            workspace_id: "ws-ask".to_string(),
+            request_id: json!("ask-req-1"),
+            questions: json!([{ "id": "q-0", "header": "Pick", "question": "Which?" }]),
+            completed: false,
+        };
+
+        let mapped = engine_event_to_app_server_event(&event, "thread-1", "assistant-item-9")
+            .expect("mapped event");
+
+        assert_eq!(
+            mapped.message["method"],
+            Value::String("item/tool/requestUserInput".to_string())
+        );
+        // itemId is the ask's own request-scoped id, NOT the assistant message head.
+        assert_eq!(
+            mapped.message["params"]["itemId"],
+            Value::String("askuserquestion-ask-req-1".to_string())
+        );
+        assert_ne!(mapped.message["params"]["itemId"], json!("assistant-item-9"));
+        // turnId still carries the assistant item so turn association is unchanged.
+        assert_eq!(
+            mapped.message["params"]["turnId"],
+            Value::String("assistant-item-9".to_string())
         );
     }
 

--- a/src-tauri/src/engine/manager.rs
+++ b/src-tauri/src/engine/manager.rs
@@ -25,8 +25,9 @@ pub struct EngineManager {
     /// Cached engine statuses
     engine_statuses: RwLock<HashMap<EngineType, EngineStatus>>,
 
-    /// Claude session manager
-    pub claude_manager: ClaudeSessionManager,
+    /// Claude session manager. Wrapped in `Arc` so the in-process AskUserQuestion
+    /// MCP server can hold a shared handle for session lookup (see `askuser_mcp`).
+    pub claude_manager: Arc<ClaudeSessionManager>,
 
     /// OpenCode sessions per workspace
     opencode_sessions: Mutex<HashMap<String, Arc<OpenCodeSession>>>,
@@ -44,7 +45,7 @@ impl EngineManager {
         Self {
             active_engine: RwLock::new(EngineType::default()),
             engine_statuses: RwLock::new(HashMap::new()),
-            claude_manager: ClaudeSessionManager::new(),
+            claude_manager: Arc::new(ClaudeSessionManager::new()),
             opencode_sessions: Mutex::new(HashMap::new()),
             gemini_sessions: Mutex::new(HashMap::new()),
             engine_configs: RwLock::new(HashMap::new()),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -217,6 +217,20 @@ pub fn run() {
             app.manage(state);
             renderer_stability::spawn_renderer_heartbeat_watchdog(app.handle().clone());
             {
+                // Start the in-process AskUserQuestion MCP server so mid-turn
+                // structured asks work in default/acceptEdits (not just plan mode).
+                let app_handle = app.handle().clone();
+                tauri::async_runtime::spawn(async move {
+                    let state = app_handle.state::<state::AppState>();
+                    let claude_manager = state.engine_manager.claude_manager.clone();
+                    if let Err(error) =
+                        crate::engine::claude::init_askuser_mcp_global(claude_manager).await
+                    {
+                        log::warn!("Failed to start AskUserQuestion MCP server: {error}");
+                    }
+                });
+            }
+            {
                 let app_handle = app.handle().clone();
                 tauri::async_runtime::spawn(async move {
                     let state = app_handle.state::<state::AppState>();

--- a/src/app-shell.tsx
+++ b/src/app-shell.tsx
@@ -1261,6 +1261,20 @@ export function AppShell() {
   const activeTurnId = activeThreadId
     ? (activeTurnIdByThread[activeThreadId] ?? null)
     : null;
+  // An open AskUserQuestion for the active thread holds the send queue — the CLI
+  // turn is blocked awaiting the answer. Mirror AskUserQuestionDialog's filter:
+  // match on workspace + thread_id (empty thread_id = current thread).
+  const hasPendingUserInput = useMemo(
+    () =>
+      Boolean(activeThreadId) &&
+      userInputRequests.some((req) => {
+        const requestThreadId = (req.params.thread_id ?? "").trim();
+        if (requestThreadId && requestThreadId !== activeThreadId) return false;
+        if (activeWorkspaceId && req.workspace_id !== activeWorkspaceId) return false;
+        return true;
+      }),
+    [userInputRequests, activeThreadId, activeWorkspaceId],
+  );
   const {
     activeImages,
     attachImages,
@@ -1298,6 +1312,7 @@ export function AppShell() {
     activeWorkspace,
     isProcessing,
     isReviewing,
+    hasPendingUserInput,
     steerEnabled: appSettings.experimentalSteerEnabled,
     activeEngine,
     connectWorkspace,

--- a/src/features/app/hooks/useComposerController.ts
+++ b/src/features/app/hooks/useComposerController.ts
@@ -24,6 +24,7 @@ export function useComposerController({
   activeWorkspace,
   isProcessing,
   isReviewing,
+  hasPendingUserInput,
   steerEnabled,
   activeEngine,
   connectWorkspace,
@@ -58,6 +59,7 @@ export function useComposerController({
   activeWorkspace: WorkspaceInfo | null;
   isProcessing: boolean;
   isReviewing: boolean;
+  hasPendingUserInput?: boolean;
   steerEnabled: boolean;
   activeEngine?: EngineType;
   connectWorkspace: (workspace: WorkspaceInfo) => Promise<void>;
@@ -134,6 +136,7 @@ export function useComposerController({
     activeTerminalPulse,
     isProcessing,
     isReviewing,
+    hasPendingUserInput,
     steerEnabled,
     activeWorkspace,
     activeEngine,

--- a/src/features/threads/hooks/useQueuedSend.test.tsx
+++ b/src/features/threads/hooks/useQueuedSend.test.tsx
@@ -86,6 +86,34 @@ describe("useQueuedSend", () => {
     expect(options.sendUserMessage).toHaveBeenLastCalledWith("Second", []);
   });
 
+  it("holds the queue while an AskUserQuestion is pending, then flushes once it clears", async () => {
+    const options = makeOptions({ hasPendingUserInput: true });
+    const { result, rerender } = renderHook((props) => useQueuedSend(props), {
+      initialProps: options,
+    });
+
+    await act(async () => {
+      await result.current.queueMessage("Queued during ask");
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Turn is blocked on the dialog answer — must NOT dispatch the queued message.
+    expect(options.sendUserMessage).not.toHaveBeenCalled();
+
+    // Dialog answered → pending clears → queue drains.
+    await act(async () => {
+      rerender({ ...options, hasPendingUserInput: false });
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(options.sendUserMessage).toHaveBeenCalledTimes(1);
+    expect(options.sendUserMessage).toHaveBeenCalledWith("Queued during ask", []);
+  });
+
   it("waits for processing to start before sending the next queued message", async () => {
     const options = makeOptions();
     const { result } = renderHook((props) => useQueuedSend(props), {

--- a/src/features/threads/hooks/useQueuedSend.ts
+++ b/src/features/threads/hooks/useQueuedSend.ts
@@ -21,6 +21,12 @@ type UseQueuedSendOptions = {
   activeTerminalPulse?: number;
   isProcessing: boolean;
   isReviewing: boolean;
+  // True while an AskUserQuestion dialog is open for the active thread. The CLI
+  // turn is blocked awaiting the answer, so the queue must NOT flush into it —
+  // isProcessing can drop to false mid-ask, which would otherwise send queued
+  // messages as fresh turns and strand the pending answer. See handleSend +
+  // the auto-flush effect below.
+  hasPendingUserInput?: boolean;
   steerEnabled: boolean;
   activeWorkspace: WorkspaceInfo | null;
   activeEngine?: EngineType;
@@ -274,6 +280,7 @@ export function useQueuedSend({
   activeTerminalPulse = 0,
   isProcessing,
   isReviewing,
+  hasPendingUserInput = false,
   steerEnabled,
   activeWorkspace,
   activeEngine = "claude",
@@ -773,10 +780,10 @@ export function useQueuedSend({
         return;
       }
       const shouldQueueWhileProcessing =
-        isProcessing &&
-        activeThreadId &&
-        (!steerEnabled || isClaudePendingBootstrapThread);
-      if (shouldQueueWhileProcessing) {
+        isProcessing && (!steerEnabled || isClaudePendingBootstrapThread);
+      // A pending AskUserQuestion also holds the queue: the turn is alive but
+      // blocked on the answer, so a fresh send must queue rather than dispatch.
+      if (activeThreadId && (shouldQueueWhileProcessing || hasPendingUserInput)) {
         const item = buildQueuedMessage(trimmed, nextImages, options);
         enqueueMessage(activeThreadId, item);
         clearActiveImages();
@@ -792,6 +799,7 @@ export function useQueuedSend({
       clearActiveImages,
       dispatchQueuedMessage,
       enqueueMessage,
+      hasPendingUserInput,
       isClaudePendingBootstrapThread,
       isProcessing,
       isReviewing,
@@ -1132,6 +1140,14 @@ export function useQueuedSend({
     if (!activeThreadId || isProcessing || isReviewing) {
       return;
     }
+    // Hold the queue while an AskUserQuestion dialog is open: the CLI turn is
+    // blocked awaiting the answer even though isProcessing may read false, so
+    // flushing here would send the queued message as a fresh turn and strand
+    // the pending answer (→ 5-min MCP timeout). The queue drains after the
+    // dialog is settled and the turn resumes/ends.
+    if (hasPendingUserInput) {
+      return;
+    }
     if (fusionByThread[activeThreadId]) {
       return;
     }
@@ -1189,6 +1205,7 @@ export function useQueuedSend({
     activeThreadId,
     dispatchQueuedMessage,
     fusionByThread,
+    hasPendingUserInput,
     inFlightByThread,
     isProcessing,
     isReviewing,


### PR DESCRIPTION
## Summary
Make mid-turn structured AskUserQuestion available in default/acceptEdits mode (Claude gates the native tool to plan mode) via an in-process MCP server.

## Changes
- In-process axum MCP server exposing `mcp__ccgui__AskUserQuestion`, wired via `--mcp-config` in non-plan modes; `MCP_TOOL_TIMEOUT=300000` when unset (so >60s answers survive the CLI's default remote-MCP fetch timeout).
- **Auth:** every request is authenticated with a per-process random bearer token — generated at startup, injected as an `Authorization: Bearer` header into the `--mcp-config` (the CLI forwards http-MCP config headers), validated server-side (401 otherwise). So no other local process on the loopback port can raise a dialog or read answers.
- Frontend: hold the message queue while an ask is pending; `completed` flag auto-dismisses a dialog on backend timeout.
- **Card anchoring:** the ask card now carries a request-scoped `itemId` (`askuserquestion-{request_id}`) instead of inheriting the assistant message head, so it renders at the conversation tail (near the composer) rather than jumping to the top of the turn and getting buried as the turn streams on. `turnId` still carries the assistant item for turn association.

## Test plan
- [x] `cargo check` (memory-capped) clean; `askuser_mcp` unit tests pass (config asserts the bearer header); `events` regression test asserts the request-scoped `itemId`.
- [x] Runtime round-trip on a fresh build (app-closed rebuild): the mid-turn ask reaches the user through the token and the card anchors at the tail under a full-screen turn — confirmed for both main-loop and sub-agent-fired asks.
- [x] Manually smoke-tested end-to-end (single/multiSelect + free-text note, >60s answers).

## Notes for reviewers
- OpenSpec: `add-askuserquestion-default-mode-mcp-bridge` (3 ADDED requirements) included. A 4th requirement covering the bearer-token auth is a follow-up (authored in Chinese via the repo's translation path to match the spec's language).
- **Security:** loopback + ephemeral port, now token-authenticated (see Changes). The token is unguessable (uuid v4) and never leaves the local `--mcp-config`.
- The card-anchoring change is a display-layer bug fix (where an existing card renders); it doesn't alter the pinning behavior covered by `conversation-live-user-bubble-pinning`.
