### PR TITLE
feat(settings): show Claude's runtime MCP servers in the MCP panel

### DIFF
--- a/openspec/changes/add-claude-runtime-mcp-servers-panel/.openspec.yaml
+++ b/openspec/changes/add-claude-runtime-mcp-servers-panel/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-08

--- a/openspec/changes/add-claude-runtime-mcp-servers-panel/proposal.md
+++ b/openspec/changes/add-claude-runtime-mcp-servers-panel/proposal.md
@@ -1,0 +1,63 @@
+## Why
+
+The MCP settings panel lists the servers declared in the user's config, but
+Claude also receives MCP servers injected at spawn via `--mcp-config` — most
+notably the app's own built-in `ccgui` AskUserQuestion bridge. Those never
+appear in the config list, so the panel could not answer the question a user
+actually asks it: *which MCP servers is Claude connected to right now?* Claude
+reports its live server set in the init event, which the app already captures in
+a per-workspace runtime snapshot; the panel just needs to surface it.
+
+## 目标与边界
+
+- When the Claude engine is selected, show a read-only "runtime servers" card
+  listing the MCP servers Claude reported at init (name + status), sourced from
+  the existing `getClaudeMcpRuntimeSnapshot(workspaceId)` snapshot.
+- Mark the app's built-in `ccgui` server with a "built-in" badge so users can
+  tell it apart from their own configured servers.
+- Show an explicit empty state when the snapshot has no servers (or none yet
+  captured for the workspace).
+
+## 非目标
+
+- Do not add, edit, remove, or otherwise mutate MCP servers from this card — it
+  is display-only.
+- Do not introduce a new IPC/Rust surface: reuse the runtime snapshot the init
+  path already records.
+- Do not change the Codex/OpenCode server cards or the config-declared list.
+
+## 技术方案对比
+
+- **Option A — read the existing runtime snapshot (chosen).** `McpSection` reads
+  `getClaudeMcpRuntimeSnapshot(workspaceId)` on load and renders the reported
+  servers. Zero backend work, accurate to what Claude actually connected to.
+- **Option B — re-probe MCP config files.** Parse the merged `--mcp-config` and
+  user config to reconstruct the injected set. Rejected: duplicates spawn logic,
+  drifts from reality, and still cannot report per-server connection status.
+
+## What Changes
+
+- `src/features/settings/components/McpSection.tsx`: add a `claudeRuntimeServers`
+  state populated from `getClaudeMcpRuntimeSnapshot(workspaceId)` during the
+  panel load sequence, and render a runtime-servers card when
+  `selectedEngine === "claude"` (server rows with name + status, a `built-in`
+  badge for `ccgui`, and an empty state).
+- `src/i18n/locales/{en,zh}.part1.ts`: add `settings.mcpPanel.runtimeServersClaudeDesc`
+  and `settings.mcpPanel.builtInBadge` (the card reuses the existing
+  `runtimeServersTitle` / `noRuntimeServers` / `statusUnknown` keys).
+
+## 验收标准
+
+- With the Claude engine selected, the panel renders one runtime-server row per
+  entry in the workspace's runtime snapshot; an empty/absent snapshot renders the
+  empty-state message.
+- The `ccgui` server row carries the built-in badge; other servers do not.
+- A server with no reported status renders the `statusUnknown` fallback.
+- Every new i18n key exists in both `en` and `zh`. `npm run typecheck` passes.
+
+## Spec deltas
+
+- `claude-runtime-mcp-servers-panel` (new capability): **ADDED** — the MCP
+  settings panel MUST surface Claude's runtime-reported MCP servers (read-only),
+  badge the built-in `ccgui` server, and show an empty state when none are
+  reported.

--- a/openspec/changes/add-claude-runtime-mcp-servers-panel/specs/claude-runtime-mcp-servers-panel/spec.md
+++ b/openspec/changes/add-claude-runtime-mcp-servers-panel/specs/claude-runtime-mcp-servers-panel/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: The MCP Settings Panel MUST Surface Claude's Runtime MCP Servers
+
+当用户在 MCP 设置面板选择 Claude 引擎时，系统 MUST 展示 Claude 在初始化时上报的运行时 MCP 服务器（只读），因为通过 `--mcp-config` 注入的服务器（含内置 `ccgui` 服务器）不会出现在用户配置列表中。
+
+The panel sources this list from the per-workspace runtime snapshot the init
+path already records (`getClaudeMcpRuntimeSnapshot(workspaceId)`); the card is
+display-only and adds no server-mutation or backend surface.
+
+#### Scenario: Claude engine selected renders the runtime servers card
+
+- **WHEN** 用户在 MCP 设置面板选择 Claude 引擎
+- **THEN** 系统 MUST 从当前工作区的运行时快照读取 Claude 上报的 MCP 服务器
+- **AND** 每个服务器 MUST 以一行展示其名称与状态
+- **AND** 若某服务器未上报状态，则 MUST 回退显示 `statusUnknown` 文案
+
+#### Scenario: the built-in ccgui server is badged
+
+- **GIVEN** 运行时快照包含内置服务器 `ccgui`
+- **WHEN** 系统渲染运行时服务器列表
+- **THEN** `ccgui` 行 MUST 显示 "built-in / 内置" 徽标
+- **AND** 用户自有的其他服务器 MUST NOT 显示该徽标
+
+#### Scenario: empty snapshot renders an empty state
+
+- **WHEN** 当前工作区没有运行时快照，或快照未上报任何 MCP 服务器
+- **THEN** 系统 MUST 显示 `noRuntimeServers` 空状态文案
+- **AND** 系统 MUST NOT 渲染任何服务器行
+
+#### Scenario: the card is display-only
+
+- **WHEN** 用户查看运行时服务器卡片
+- **THEN** 系统 MUST NOT 提供从该卡片新增、编辑或删除 MCP 服务器的操作
+- **AND** 系统 MUST NOT 因渲染该卡片而引入新的 IPC/Rust 接口

--- a/openspec/changes/add-claude-runtime-mcp-servers-panel/tasks.md
+++ b/openspec/changes/add-claude-runtime-mcp-servers-panel/tasks.md
@@ -1,0 +1,17 @@
+## 1. OpenSpec Artifacts
+
+- [x] 1.1 Author proposal + spec delta + tasks for the Claude runtime MCP servers panel; output: `openspec/changes/add-claude-runtime-mcp-servers-panel`; validation: `openspec validate add-claude-runtime-mcp-servers-panel --strict --no-interactive`. [P0][I][O: change dir][V: openspec validate]
+
+## 2. Frontend (McpSection.tsx)
+
+- [x] 2.1 Add `claudeRuntimeServers` state populated from `getClaudeMcpRuntimeSnapshot(workspaceId)` in the panel load sequence (guarded by `canCommit()`). [P0][I][O: McpSection.tsx][V: typecheck]
+- [x] 2.2 Render the runtime-servers card when `selectedEngine === "claude"`: server rows (name + status), `built-in` badge for `ccgui`, `statusUnknown` fallback, and the `noRuntimeServers` empty state. [P0][I][O: McpSection.tsx][V: typecheck]
+
+## 3. i18n
+
+- [x] 3.1 Add `settings.mcpPanel.runtimeServersClaudeDesc` and `settings.mcpPanel.builtInBadge` to both `en.part1.ts` and `zh.part1.ts`; reuse existing `runtimeServersTitle` / `noRuntimeServers` / `statusUnknown` keys. [P0][I][O: en/zh.part1.ts][V: en↔zh parity]
+
+## 4. Gates
+
+- [x] 4.1 `npm run typecheck`. [P0][V: typecheck]
+- [ ] 4.2 Manual: select the Claude engine with an active workspace; the runtime-servers card lists the reported servers and badges `ccgui` — DEFERRED to runtime QA (no McpSection render test exists). [P1][V: manual]

--- a/src/features/settings/components/McpSection.tsx
+++ b/src/features/settings/components/McpSection.tsx
@@ -17,6 +17,7 @@ import {
 } from "../../../services/tauri";
 import { isWindowsPlatform } from "../../../utils/platform";
 import { isLikelyWindowsFsPath, normalizeFsPath } from "../../../utils/workspacePaths";
+import { getClaudeMcpRuntimeSnapshot } from "../../threads/utils/claudeMcpRuntimeSnapshot";
 import { Button } from "@/components/ui/button";
 import { EngineIcon } from "../../engine/components/EngineIcon";
 import {
@@ -51,6 +52,11 @@ type OpenCodeMcpServer = {
 type OpenCodeSnapshot = {
   mcpEnabled: boolean;
   mcpServers: OpenCodeMcpServer[];
+};
+
+type ClaudeRuntimeServer = {
+  name: string;
+  status: string | null;
 };
 
 type EngineDescriptor = {
@@ -200,6 +206,9 @@ export function McpSection({
   const [openCodeSnapshot, setOpenCodeSnapshot] = useState<OpenCodeSnapshot | null>(
     null,
   );
+  const [claudeRuntimeServers, setClaudeRuntimeServers] = useState<ClaudeRuntimeServer[]>(
+    [],
+  );
   const mountedRef = useRef(true);
   const loadSequenceRef = useRef(0);
 
@@ -259,6 +268,15 @@ export function McpSection({
         if (canCommit()) {
           setCodexServers([]);
         }
+      }
+
+      // Claude reports its live MCP servers (including our built-in AskUserQuestion
+      // "ccgui" server) via the init event, captured in the runtime snapshot. This
+      // is the accurate "is it connected?" signal — the config list can't show a
+      // server injected at spawn via --mcp-config.
+      if (canCommit()) {
+        const snapshot = workspaceId ? getClaudeMcpRuntimeSnapshot(workspaceId) : null;
+        setClaudeRuntimeServers(snapshot?.mcpServers ?? []);
       }
 
       if (selectedEngine === "opencode") {
@@ -705,6 +723,42 @@ export function McpSection({
                           </div>
                         );
                       })}
+                    </div>
+                  )}
+                </div>
+              ) : null}
+
+              {selectedEngine === "claude" ? (
+                <div className="settings-mcp-codex-card">
+                  <div className="settings-mcp-panel-title">
+                    <Server size={15} />
+                    {t("settings.mcpPanel.runtimeServersTitle")}
+                  </div>
+                  <div className="settings-mcp-server-meta">
+                    {t("settings.mcpPanel.runtimeServersClaudeDesc")}
+                  </div>
+                  {claudeRuntimeServers.length === 0 ? (
+                    <div className="settings-inline-muted">{t("settings.mcpPanel.noRuntimeServers")}</div>
+                  ) : (
+                    <div className="settings-mcp-list">
+                      {claudeRuntimeServers.map((server) => (
+                        <div key={`claude-runtime-${server.name}`} className="settings-mcp-server-row">
+                          <div>
+                            <div className="settings-mcp-server-name">
+                              <Server size={14} />
+                              {server.name}
+                              {server.name === "ccgui" ? (
+                                <span className="settings-mcp-auth">
+                                  {t("settings.mcpPanel.builtInBadge")}
+                                </span>
+                              ) : null}
+                            </div>
+                          </div>
+                          <span className="settings-mcp-auth">
+                            {server.status ?? t("settings.mcpPanel.statusUnknown")}
+                          </span>
+                        </div>
+                      ))}
                     </div>
                   )}
                 </div>

--- a/src/i18n/locales/en.part1.ts
+++ b/src/i18n/locales/en.part1.ts
@@ -971,6 +971,9 @@ const enPart1 = {
       environmentTitle: "Environment details",
       configServersTitle: "Config-defined servers",
       runtimeServersTitle: "Runtime servers",
+      runtimeServersClaudeDesc:
+        "Servers reported by the last Claude run in this workspace, including the built-in AskUserQuestion server (ccgui).",
+      builtInBadge: "Built-in",
       sessionOverviewTitle: "Session overview",
       noConfigServers:
         "No servers were discovered from the known config source.",

--- a/src/i18n/locales/zh.part1.ts
+++ b/src/i18n/locales/zh.part1.ts
@@ -1073,6 +1073,9 @@ const zhPart1 = {
       environmentTitle: "环境详情",
       configServersTitle: "配置文件里的服务",
       runtimeServersTitle: "运行时服务",
+      runtimeServersClaudeDesc:
+        "本工作区上次 Claude 运行时报告的服务，包含内置的 AskUserQuestion 服务（ccgui）。",
+      builtInBadge: "内置",
       sessionOverviewTitle: "当前会话概览",
       noConfigServers: "在对应配置来源里暂未发现 MCP 服务。",
       noRuntimeServers: "当前没有读到运行时服务。",


### PR DESCRIPTION
## Summary
Read-only card (Claude engine) listing the MCP servers Claude actually reports at init — the accurate "is it connected?" signal the config list can't show (servers injected at spawn via `--mcp-config`, including the app's built-in `ccgui` AskUserQuestion server, never appear in the config list).

## Changes
- `McpSection.tsx`: `claudeRuntimeServers` from the existing `getClaudeMcpRuntimeSnapshot(workspaceId)`; render rows (name + status), badge the built-in `ccgui`, empty state.
- i18n: new `settings.mcpPanel.*` strings (en + zh at parity).

## Test plan
- [x] `npm run typecheck`; en↔zh key parity confirmed.
- [ ] Manual render check (no McpSection test exists).

## Notes for reviewers
- OpenSpec: `add-claude-runtime-mcp-servers-panel` included. Display-only; reuses the runtime snapshot (no new IPC/Rust surface).
- Companion to #804 (the AskUserQuestion MCP bridge), which introduces the built-in `ccgui` server this panel badges — mergeable independently, but the `ccgui` badge only appears once that server exists.
