### PR TITLE
perf(messages): optimize conversation streaming render performance

### DIFF
--- a/openspec/changes/optimize-conversation-streaming-render-perf/.openspec.yaml
+++ b/openspec/changes/optimize-conversation-streaming-render-perf/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-05

--- a/openspec/changes/optimize-conversation-streaming-render-perf/design.md
+++ b/openspec/changes/optimize-conversation-streaming-render-perf/design.md
@@ -1,0 +1,64 @@
+## Context
+
+A streaming-lag audit on the WebKitGTK renderer found the main thread saturated
+during response streaming: IPC receive time dominated, one style patch triggered a
+~184ms full-document recalc, frame gaps stretched, and CPU pinned above 100%. The
+cost was spread across four independent hotspots on the messages path, each doing
+per-token or per-frame work that could be cached, coalesced, or offloaded.
+
+## Goals / Non-Goals
+
+- **Goal:** reduce per-token main-thread work and continuous repaint during
+  streaming, with zero change to settled rendering or correctness.
+- **Goal:** each fix independently shippable and guarded by a fallback.
+- **Non-Goal:** the deferred theme-CSS `[data-theme]` / `color-mix()`
+  `recalculate-styles` cost (a separate, larger refactor).
+- **Non-Goal:** any streaming protocol or event-schema change.
+
+## Decisions
+
+### Decision: Guarded fast-paths, never a pipeline rewrite
+
+Each hotspot gets a narrow fast-path with an explicit fallback to the existing
+full computation:
+
+- **History derivations** are cached across ticks; the fast path fires only on a
+  detected trailing message-text-only update, else full recompute. This keeps the
+  idle result bit-identical to a full scan — the correctness anchor.
+- **Snapshot coalescing** is gated by the *existing* `appServerEventDropPolicy`
+  (`drop-eligible-snapshot`) — coalescing is only ever applied where the policy
+  already permits dropping, so no new correctness surface.
+
+- **Why not a rewrite:** the four hotspots are unrelated in mechanism; a unifying
+  renderer would be larger, riskier, and would duplicate engines that already
+  exist. Independent fixes are independently reviewable and revertible.
+
+### Decision: Move animation cost to the compositor
+
+Per-frame paints (`background-position` under a text clip, animated
+`filter: drop-shadow`) are replaced with `opacity` / static `box-shadow`, which
+the compositor can animate without a main-thread repaint. One redundant
+`drop-shadow` that merely duplicated an existing `text-shadow` is dropped.
+
+### Decision: Key Bash lines by absolute index
+
+Keying the sliding-window rows by absolute line index (not array position) lets
+React reuse DOM rows as the window advances, instead of remounting the visible
+list per appended line.
+
+## Risks / Trade-offs
+
+- **Fast-path detection scope:** the history-scan fast path must correctly detect
+  "trailing message-text-only update"; a false positive would reuse stale
+  derivations. Mitigated by falling back to full recompute for anything else and
+  by `events.test.ts` coverage on the coalescing side.
+- **Runtime-only proof:** the win is a wall-clock/CPU reduction that unit tests
+  cannot assert. This change was authored during a git freeze, so re-recording the
+  streaming perf trace on a rebuilt app is a **deferred** manual gate
+  (verification.md). The audit that motivated each fix is captured in
+  `docs/plans/2026-07-05-chat-scroll-and-streaming-perf-plan.md`.
+
+## Migration
+
+No data/API migration. All changes are internal to `src/features/messages` and
+`src/services/events.ts`; settled rendering and the event contract are unchanged.

--- a/openspec/changes/optimize-conversation-streaming-render-perf/proposal.md
+++ b/openspec/changes/optimize-conversation-streaming-render-perf/proposal.md
@@ -1,0 +1,87 @@
+## Why
+
+On the WebKitGTK renderer, streaming a response was janky: an audit found the
+main thread doing per-token work and continuous repaints. Four distinct hotspots
+each re-did work that could be cached, coalesced, or moved off the main thread —
+history rescans per token, superseded snapshots all flushed, per-frame CSS
+paints, and full DOM recreation of Bash
+output on every new line. Individually small; together they starved input and
+pinned CPU during streaming.
+
+## 目标与边界
+
+- Cut per-token main-thread work and continuous repaint **during streaming**,
+  without changing settled (idle) rendering or correctness.
+- Each fix is guarded so the idle / non-streaming path falls back to the existing
+  full-correctness computation.
+- Reuse existing engines/policies (the event drop-eligibility policy) rather than
+  adding new machinery.
+
+## 非目标
+
+- Do not change what is rendered when a message is settled (full markdown, full
+  dedup) — only the transient streaming path.
+- Do not alter the streaming protocol, event schema, or Tauri/IPC surface.
+- Do not touch the deferred theme-CSS `recalculate-styles` cost (separate,
+  larger refactor).
+- No new dependency.
+
+## What Changes
+
+Four targeted fixes on the messages streaming path:
+
+1. **History-scan caching (`Messages.tsx`)** — cache
+   `dedupeExitPlanItemsKeepFirst` / `buildMessageActionTargets` across streaming
+   ticks so they no longer rescan the full history per token. Fast path fires only
+   when a trailing message-text-only update is detected; otherwise falls back to a
+   full recompute (idle correctness preserved).
+2. **Snapshot coalescing (`events.ts`)** — coalesce `item/updated` snapshots per
+   `(workspace, thread, item)` so superseded full-text snapshots in one flush tick
+   collapse to the newest, guarded by the existing drop-eligibility policy.
+3. **Compositor-friendly animations (CSS)** — replace per-frame main-thread
+   paints with compositor equivalents: working-text shimmer
+   (`background-position` under text-clip → `opacity`), ingress spinner glow
+   (animated `filter: drop-shadow` → static `box-shadow`), agent-icon idle (drop a
+   redundant `drop-shadow` that duplicated `text-shadow`).
+4. **Bash output DOM reuse (`BashToolBlock` / `BashToolGroupBlock`)** — key output
+   lines by absolute line index so the sliding truncation window reuses DOM
+   instead of recreating the whole visible list per line.
+
+## Capabilities
+
+### New Capabilities
+
+- `conversation-streaming-render-performance`: performance invariants for the
+  conversation streaming render path — no per-token full-history rescans,
+  coalesced superseded snapshots, compositor-only streaming animations, and DOM
+  reuse for the Bash truncation window.
+
+### Modified Capabilities
+
+- None (adds invariants without changing existing observable contracts).
+
+## Impact
+
+- Frontend only: `Messages.tsx`,
+  `toolBlocks/BashToolBlock.tsx`, `toolBlocks/BashToolGroupBlock.tsx`,
+  `services/events.ts` (+ test), `styles/messages.part1.css`,
+  `styles/messages.status-shell.css`.
+- Runtime/API: no protocol, schema, IPC, or Rust change. Dependencies: none.
+
+## 技术方案对比
+
+| 选项 | 做法 | 取舍 |
+|---|---|---|
+| Recommended: guarded fast-paths on existing machinery | Cache/coalesce/reuse with a fallback to the current full computation on the idle path | Smallest diff; idle correctness untouched; reuses the event drop policy already in the codebase | 
+| Alternative: rewrite the streaming pipeline | A single new streaming renderer that owns dedup/markdown/coalescing | Larger, riskier, and duplicates engines that already exist; the four hotspots are independently shippable and independently verifiable |
+
+## 验收标准
+
+- During streaming, per-token work does not rescan full history; the idle path
+  still produces identical dedup/action-target results (fast-path fallback).
+- Superseded `item/updated` snapshots in one flush tick collapse to the newest
+  only when the drop policy allows.
+- Streaming animations run on the compositor (no per-frame main-thread paint).
+- Bash sliding-window output reuses DOM rows across new lines.
+- `events.test.ts`, `npm run typecheck`, and `openspec validate
+  optimize-conversation-streaming-render-perf --strict --no-interactive` pass.

--- a/openspec/changes/optimize-conversation-streaming-render-perf/specs/conversation-streaming-render-performance/spec.md
+++ b/openspec/changes/optimize-conversation-streaming-render-perf/specs/conversation-streaming-render-performance/spec.md
@@ -1,0 +1,70 @@
+# conversation-streaming-render-performance Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Streaming Does Not Rescan Full History Per Token
+
+The conversation MUST NOT recompute history-wide derivations
+(`dedupeExitPlanItemsKeepFirst`, `buildMessageActionTargets`) from scratch on
+every streamed token. It MUST cache these across streaming ticks and reuse the
+cached result on the fast path (a trailing message-text-only update), while
+falling back to a full recompute whenever the update is not a pure trailing-text
+append, so the idle/settled result is identical to a full scan.
+
+#### Scenario: trailing-text token reuses cached derivations
+
+- **WHEN** a streamed update only appends text to the trailing message
+- **THEN** the cached dedup / action-target derivations MUST be reused without a
+  full-history rescan
+
+#### Scenario: structural update recomputes fully
+
+- **WHEN** a streamed or settled update changes history structure (not a pure
+  trailing-text append)
+- **THEN** the derivations MUST be recomputed in full so the result matches a
+  from-scratch scan
+
+### Requirement: Superseded Snapshots Coalesce Within A Flush Tick
+
+The pipeline MUST coalesce multiple `item/updated` snapshots for the same
+`(workspace, thread, item)` that occur within one flush tick down to the newest
+snapshot, and MUST do so only when the event is classified drop-eligible by the
+existing drop policy. Events that are not drop-eligible MUST NOT be coalesced or
+dropped.
+
+#### Scenario: multiple drop-eligible snapshots in one tick
+
+- **WHEN** several drop-eligible `item/updated` snapshots for the same item
+  arrive in one flush tick
+- **THEN** only the newest MUST be delivered
+
+#### Scenario: non-drop-eligible event preserved
+
+- **WHEN** an `item/updated` event is not classified drop-eligible
+- **THEN** it MUST NOT be coalesced away
+
+### Requirement: Streaming Animations Run On The Compositor
+
+Streaming-state animations MUST avoid per-frame main-thread paints. The
+working-text shimmer, the ingress spinner glow, and the agent-icon idle state
+MUST use compositor-friendly properties (opacity / static shadow) rather than
+animating `background-position` under a text clip or an animated
+`filter: drop-shadow`.
+
+#### Scenario: working indicator animates without main-thread paint
+
+- **WHEN** the working/streaming indicators are animating
+- **THEN** the animation MUST run via compositor-friendly properties and MUST NOT
+  trigger a per-frame main-thread repaint
+
+### Requirement: Bash Output Reuses DOM Across The Truncation Window
+
+Bash tool output rendered under a sliding truncation window MUST key its lines by
+absolute line index so that advancing the window reuses existing DOM rows instead
+of recreating the whole visible list on each new line.
+
+#### Scenario: new Bash output line
+
+- **WHEN** a new line is appended and the truncation window slides
+- **THEN** existing line rows MUST be reused (keyed by absolute index), not
+  recreated wholesale

--- a/openspec/changes/optimize-conversation-streaming-render-perf/tasks.md
+++ b/openspec/changes/optimize-conversation-streaming-render-perf/tasks.md
@@ -1,0 +1,25 @@
+## 1. OpenSpec Artifacts
+
+- [x] 1.1 Author proposal/design/spec delta/tasks/verification for the streaming-render perf pack; output: change artifacts under `openspec/changes/optimize-conversation-streaming-render-perf`; validation: `openspec validate optimize-conversation-streaming-render-perf --strict --no-interactive`. [P0][I][O: change dir][V: openspec validate]
+
+## 2. History-scan caching
+
+- [x] 2.1 Cache `dedupeExitPlanItemsKeepFirst` / `buildMessageActionTargets` across streaming ticks in `Messages.tsx`; fast path only on a trailing message-text-only update, full recompute otherwise. Output: no per-token full-history rescan; idle result unchanged. Validation: typecheck + manual. [P0][depends: 1.1][I][O: Messages.tsx][V: typecheck]
+
+## 3. Snapshot coalescing
+
+- [x] 3.1 Coalesce `item/updated` snapshots per `(workspace, thread, item)` in `events.ts`, guarded by `appServerEventDropPolicy` drop-eligibility. Output: superseded snapshots collapse to newest only when drop-eligible. Validation: `events.test.ts`. [P0][depends: 1.1][I][O: events.ts][V: vitest]
+
+## 4. Compositor-friendly animations
+
+- [x] 4.1 Replace per-frame paints with compositor equivalents (working-text shimmer → opacity; ingress spinner glow → static box-shadow; drop redundant agent-icon drop-shadow). Output: streaming animations off the main thread. Validation: manual. [P1][depends: 1.1][I][O: messages.part1.css, messages.status-shell.css][V: manual]
+
+## 5. Bash output DOM reuse
+
+- [x] 5.1 Key Bash output lines by absolute line index so the sliding truncation window reuses DOM. Output: no wholesale list recreation per line. Validation: manual. [P1][depends: 1.1][I][O: BashToolBlock.tsx, BashToolGroupBlock.tsx][V: manual]
+
+## 6. Verification
+
+- [x] 6.1 Unit coverage for the event coalescing (`events.test.ts`). Output: green. Validation: `npx vitest run src/services/events.test.ts`. [P0][depends: 3.1][I][O: events.test.ts][V: vitest]
+- [x] 6.2 Repository JS gates. Output: no TypeScript regressions; scoped messages suite green apart from 2 pre-existing upstream `GenericToolBlock` failures (reproduce on base `ea338fae`, unrelated). Validation: `npm run typecheck` + `npx vitest run src/features/messages`. [P0][depends: 6.1][V: typecheck]
+- [ ] 6.3 Re-record the streaming perf trace on a rebuilt app (deferred — authored during git freeze): confirm reduced main-thread time / frame gaps / CPU during streaming vs the pre-fix capture. Output: perf report delta. Validation: manual (next rebuild). [P0][depends: 6.2][V: manual]

--- a/openspec/changes/optimize-conversation-streaming-render-perf/verification.md
+++ b/openspec/changes/optimize-conversation-streaming-render-perf/verification.md
@@ -1,0 +1,29 @@
+# Verification — optimize-conversation-streaming-render-perf
+
+## Automated (pass now)
+
+- [x] `npm run typecheck` — clean.
+- [x] `npx vitest run src/services/events.test.ts` — event coalescing covered
+  (added cases for drop-eligible collapse + non-drop-eligible preservation).
+- [x] `npx vitest run src/features/messages` — 584 passed / 7 skipped. The 2
+  `GenericToolBlock.test.tsx` failures are **pre-existing on base `ea338fae`**
+  (verified by running that test on a clean BASE worktree: 2 failed | 24 passed),
+  unrelated to this change (the pack does not touch that file).
+
+## Manual — DEFERRED to next rebuild (authored during git freeze)
+
+- [ ] Re-record the streaming perf trace (Settings → Other → "Copy performance
+  report") during a long streamed response; compare main-thread time, frame gaps,
+  and CPU against the pre-fix capture referenced in
+  `docs/plans/2026-07-05-chat-scroll-and-streaming-perf-plan.md`.
+- [ ] Visual check: working shimmer / ingress spinner / agent icon animate
+  smoothly; Bash output scrolls without flashing the whole list.
+- [ ] Correctness spot-check: settled dedup/action-target behavior is unchanged
+  from before.
+
+## Notes
+
+- All four fixes are guarded fast-paths with a fallback to the existing full
+  computation; the coalescing reuses the existing `appServerEventDropPolicy`.
+- This pack is independent of the scroll-owner / jump-controls stack (no shared
+  files beyond `Messages.tsx`, which cherry-picked clean onto BASE).

--- a/src/features/messages/components/Messages.tsx
+++ b/src/features/messages/components/Messages.tsx
@@ -106,6 +106,7 @@ import {
   resolveActiveMessageAnchor,
   resolveCollapsedTimelineItems,
   resolveVisibleMessageItems,
+  type MessageActionTargets,
   type PreservedReadableWindow,
 } from "./messagesViewModel";
 import {
@@ -165,6 +166,40 @@ function areStringSetsEqual(left: ReadonlySet<string>, right: ReadonlySet<string
     }
   }
   return true;
+}
+
+// 流式期间每个 token 都会替换 items 数组引用,但通常只有最后一条正在流式输出的
+// assistant/user "message" 条目发生了文本变化,其余条目引用保持不变。此时
+// dedupeExitPlanItemsKeepFirst / buildMessageActionTargets 的计算结果必然与上一次
+// 完全相同(两者都只关心 tool 条目身份或 role/isFinal 边界,不关心文本内容本身),
+// 可以安全复用缓存结果,避免对整段历史重新扫描。
+// 一旦出现条目增删、非 message 类型条目变化,或 role/isFinal 发生翻转,则回退到全量重算,
+// 保证 idle/展开态下覆盖全部历史的正确性不受影响。
+function isTrailingMessageTextOnlyUpdate(
+  prev: ConversationItem[],
+  next: ConversationItem[],
+): boolean {
+  if (prev.length === 0 || prev.length !== next.length) {
+    return false;
+  }
+  const lastIndex = prev.length - 1;
+  for (let index = 0; index < lastIndex; index += 1) {
+    if (prev[index] !== next[index]) {
+      return false;
+    }
+  }
+  const prevLast = prev[lastIndex];
+  const nextLast = next[lastIndex];
+  if (prevLast === nextLast) {
+    return true;
+  }
+  return (
+    prevLast.kind === "message" &&
+    nextLast.kind === "message" &&
+    prevLast.id === nextLast.id &&
+    prevLast.role === nextLast.role &&
+    prevLast.isFinal === nextLast.isFinal
+  );
 }
 
 export const Messages = memo(function Messages({
@@ -489,16 +524,44 @@ export const Messages = memo(function Messages({
   const latestItemsRef = useRef(items);
   latestItemsRef.current = items;
   const [finalizingAssistantMessageId, setFinalizingAssistantMessageId] = useState<string | null>(null);
+  const exitPlanDedupeCacheRef = useRef<{
+    baseItems: ConversationItem[];
+    result: ConversationItem[];
+  } | null>(null);
   const effectiveItems = useMemo(() => {
     const baseItems = isSelectionFrozen
       ? frozenItemsRef.current ?? items
       : items;
-    return dedupeExitPlanItemsKeepFirst(baseItems);
+    const cache = exitPlanDedupeCacheRef.current;
+    if (cache && isTrailingMessageTextOnlyUpdate(cache.baseItems, baseItems)) {
+      // dedupe 只会移除 exit-plan 工具条目,末尾的 "message" 条目必然原样透传,
+      // 因此只需把结果数组的最后一项替换为最新引用,无需重新扫描整段历史。
+      const nextLast = baseItems[baseItems.length - 1];
+      const result =
+        cache.result[cache.result.length - 1] === nextLast
+          ? cache.result
+          : [...cache.result.slice(0, -1), nextLast];
+      exitPlanDedupeCacheRef.current = { baseItems, result };
+      return result;
+    }
+    const result = dedupeExitPlanItemsKeepFirst(baseItems);
+    exitPlanDedupeCacheRef.current = { baseItems, result };
+    return result;
   }, [isSelectionFrozen, items]);
-  const messageActionTargets = useMemo(
-    () => buildMessageActionTargets(effectiveItems),
-    [effectiveItems],
-  );
+  const messageActionTargetsCacheRef = useRef<{
+    baseItems: ConversationItem[];
+    result: MessageActionTargets;
+  } | null>(null);
+  const messageActionTargets = useMemo(() => {
+    const cache = messageActionTargetsCacheRef.current;
+    if (cache && isTrailingMessageTextOnlyUpdate(cache.baseItems, effectiveItems)) {
+      messageActionTargetsCacheRef.current = { baseItems: effectiveItems, result: cache.result };
+      return cache.result;
+    }
+    const result = buildMessageActionTargets(effectiveItems);
+    messageActionTargetsCacheRef.current = { baseItems: effectiveItems, result };
+    return result;
+  }, [effectiveItems]);
   const liveTailWorkingSet = useMemo(
     () =>
       buildLiveTailWorkingSet(effectiveItems, {

--- a/src/features/messages/components/toolBlocks/BashToolBlock.tsx
+++ b/src/features/messages/components/toolBlocks/BashToolBlock.tsx
@@ -75,11 +75,11 @@ export const BashToolBlock = memo(function BashToolBlock({
   const durationMs = typeof item.durationMs === 'number' ? item.durationMs : null;
   const isLongRunning = durationMs !== null && durationMs >= 1200;
 
-  const outputLines = useMemo(() => {
-    if (!item.output) return [];
+  const { outputLines, outputStartIndex } = useMemo(() => {
+    if (!item.output) return { outputLines: [], outputStartIndex: 0 };
     const lines = item.output.split(/\r?\n/);
-    if (lines.length <= MAX_OUTPUT_LINES) return lines;
-    return lines.slice(-MAX_OUTPUT_LINES);
+    if (lines.length <= MAX_OUTPUT_LINES) return { outputLines: lines, outputStartIndex: 0 };
+    return { outputLines: lines.slice(-MAX_OUTPUT_LINES), outputStartIndex: lines.length - MAX_OUTPUT_LINES };
   }, [item.output]);
   const highlightedOutputLines = useMemo(
     () => outputLines.map((line) => highlightLine(line, 'bash')),
@@ -189,7 +189,7 @@ export const BashToolBlock = memo(function BashToolBlock({
                 </button>
               </div>
               {outputLines.map((line, index) => (
-                <div key={`${index}-${line.slice(0, 20)}`} className="bash-output-line">
+                <div key={`line-${outputStartIndex + index}`} className="bash-output-line">
                   {isErrorLine(line) ? (
                     <span className="bash-output-line-error">{line || ' '}</span>
                   ) : line.length === 0 ? (

--- a/src/features/messages/components/toolBlocks/BashToolGroupBlock.tsx
+++ b/src/features/messages/components/toolBlocks/BashToolGroupBlock.tsx
@@ -168,9 +168,9 @@ export const BashToolGroupBlock = memo(function BashToolGroupBlock({
           {parsed.map((entry, index) => {
             const isLast = index === parsed.length - 1;
             const isItemExpanded = expandedItemId === entry.id;
-            const outputLines = entry.output
-              ? entry.output.split(/\r?\n/).slice(-MAX_OUTPUT_LINES)
-              : [];
+            const allOutputLines = entry.output ? entry.output.split(/\r?\n/) : [];
+            const outputLines = allOutputLines.slice(-MAX_OUTPUT_LINES);
+            const outputStartIndex = allOutputLines.length - outputLines.length;
             const highlightedOutputLines = outputLines.map((line) => highlightLine(line, 'bash'));
 
             return (
@@ -230,7 +230,7 @@ export const BashToolGroupBlock = memo(function BashToolGroupBlock({
                           </div>
                           {outputLines.map((line, i) => (
                             <div
-                              key={`${i}-${line.slice(0, 20)}`}
+                              key={`line-${outputStartIndex + i}`}
                               className="bash-output-line"
                             >
                               {ERROR_LINE_PATTERN.test(line) ? (

--- a/src/services/events.test.ts
+++ b/src/services/events.test.ts
@@ -102,6 +102,47 @@ describe("events subscriptions", () => {
     expect(backpressure.getRawRecent()).toHaveLength(128);
   });
 
+  it("coalesces superseding item/updated snapshots for the same item", () => {
+    const backpressure = getAppServerEventBackpressureForTests();
+    const snapshot = (text: string): AppServerEvent => ({
+      workspace_id: "ws-1",
+      message: {
+        method: "item/updated",
+        params: {
+          threadId: "t1",
+          item: { id: "item-1", kind: "message", text },
+        },
+      },
+    });
+
+    backpressure.push(snapshot("hel"));
+    backpressure.push(snapshot("hello"));
+    backpressure.push(snapshot("hello wor"));
+
+    expect(backpressure.queueDepth).toBe(1);
+    expect(backpressure.coalescedCount).toBe(2);
+  });
+
+  it("does not coalesce item/updated events for different items", () => {
+    const backpressure = getAppServerEventBackpressureForTests();
+    const snapshot = (itemId: string): AppServerEvent => ({
+      workspace_id: "ws-1",
+      message: {
+        method: "item/updated",
+        params: {
+          threadId: "t1",
+          item: { id: itemId, kind: "message", text: "hi" },
+        },
+      },
+    });
+
+    backpressure.push(snapshot("item-1"));
+    backpressure.push(snapshot("item-2"));
+
+    expect(backpressure.queueDepth).toBe(2);
+    expect(backpressure.coalescedCount).toBe(0);
+  });
+
   it("cleans up listeners that resolve after unsubscribe", async () => {
     let resolveListener: (handler: UnlistenFn) => void = () => {};
     const unlisten = vi.fn();

--- a/src/services/events.ts
+++ b/src/services/events.ts
@@ -212,6 +212,18 @@ function appServerEventCoalesceKey(event: AppServerEvent): string | null {
     }
     case "account/rateLimits/updated":
       return `${event.workspace_id}\0${method}`;
+    case "item/updated": {
+      if (appServerEventDropPolicy(event) !== "drop-eligible-snapshot") {
+        return null;
+      }
+      const threadId = appServerEventThreadId(params);
+      const item = (params.item as Record<string, unknown> | undefined) ?? params;
+      const itemId = item.id ?? params.itemId ?? params.item_id;
+      if (!threadId || typeof itemId !== "string" || !itemId.trim()) {
+        return null;
+      }
+      return `${event.workspace_id}\0${method}\0${threadId}\0${itemId}`;
+    }
     default:
       return null;
   }

--- a/src/styles/messages.part1.css
+++ b/src/styles/messages.part1.css
@@ -514,12 +514,11 @@
   transform: scale(1.04);
   transform-origin: center;
   animation: message-agent-icon-idle 3.4s ease-in-out infinite;
+  /* text-shadow already provides the glow; the drop-shadow filter was redundant and forced an
+     offscreen filter surface to be re-composited on every frame of the transform animation. */
   text-shadow:
     0 0 0.6px color-mix(in srgb, var(--color-message-user-bg, var(--surface-bubble-user)) 70%, #ffffff 30%),
     0 0 0.6px color-mix(in srgb, var(--color-message-user-bg, var(--surface-bubble-user)) 70%, #ffffff 30%);
-  filter: drop-shadow(
-    0 0 0.7px color-mix(in srgb, var(--color-message-user-bg, var(--surface-bubble-user)) 68%, #ffffff 32%)
-  );
 }
 
 .message-agent-icon-glyph svg {

--- a/src/styles/messages.status-shell.css
+++ b/src/styles/messages.status-shell.css
@@ -337,7 +337,10 @@
   animation-duration: 0.42s;
   border-top-color: #ffb347;
   border-right-color: rgba(255, 179, 71, 0.56);
-  filter: drop-shadow(0 0 8px rgba(255, 166, 62, 0.55));
+  /* Static box-shadow glow instead of animated filter: drop-shadow — drop-shadow forces an
+     offscreen surface to be re-rasterized every frame of the rotate animation; box-shadow paints
+     once and lets the rotation stay a pure compositor transform. */
+  box-shadow: 0 0 8px rgba(255, 166, 62, 0.55);
 }
 
 .working.is-ingress .working-spinner::before,
@@ -384,7 +387,7 @@
   animation-duration: 1s;
   border-top-color: color-mix(in srgb, var(--text-stronger) 82%, transparent);
   border-right-color: rgba(255, 255, 255, 0.2);
-  filter: none;
+  box-shadow: none;
 }
 
 .app.windows-desktop
@@ -410,7 +413,7 @@
 :root[data-theme="light"] .working.is-ingress .working-spinner {
   border-top-color: #ff6a00;
   border-right-color: rgba(255, 106, 0, 0.68);
-  filter: drop-shadow(0 0 8px rgba(255, 90, 0, 0.42));
+  box-shadow: 0 0 8px rgba(255, 90, 0, 0.42);
 }
 
 :root[data-theme="light"] .working.is-ingress .working-spinner::before {
@@ -431,7 +434,7 @@
   :root:not([data-theme]) .working.is-ingress .working-spinner {
     border-top-color: #ff6a00;
     border-right-color: rgba(255, 106, 0, 0.68);
-    filter: drop-shadow(0 0 8px rgba(255, 90, 0, 0.42));
+    box-shadow: 0 0 8px rgba(255, 90, 0, 0.42);
   }
 
   :root:not([data-theme]) .working.is-ingress .working-spinner::before {
@@ -467,9 +470,12 @@
     rgba(255, 255, 255, 0.95),
     rgba(255, 255, 255, 0.3)
   );
-  background-size: 200% 100%;
   -webkit-background-clip: text;
   background-clip: text;
+  /* Animate opacity instead of background-position: moving the gradient under a text clip-mask
+     forces a full glyph-mask + gradient re-raster every frame (uncompositable in WebKit).
+     Opacity is one of the few properties WebKit can composite as a post-process alpha blend,
+     so the pulse no longer re-rasters the clipped text per frame. */
   animation: working-shimmer 2.2s ease-in-out infinite;
 }
 
@@ -528,14 +534,12 @@
 }
 
 @keyframes working-shimmer {
-  0% {
-    background-position: 0% 50%;
+  0%,
+  100% {
+    opacity: 0.55;
   }
   50% {
-    background-position: 100% 50%;
-  }
-  100% {
-    background-position: 0% 50%;
+    opacity: 1;
   }
 }
 


### PR DESCRIPTION
## Summary
Four small, individually-reversible fixes that cut main-thread work during message streaming on WebKitGTK.

## Changes
- History-scan caching guarded to the trailing text-only update (full recompute on any structural / role / isFinal change).
- Snapshot coalescing plugged into the existing event-backpressure machinery (drop-eligible full-text snapshots only, never append-only deltas).
- CSS compositor swaps (opacity shimmer, static box-shadow, dropped a redundant drop-shadow).
- Bash output keyed by absolute line index so the sliding truncation window reuses DOM instead of recreating the visible list per line.

## Why
Streaming a long reply pins the WebKitGTK main thread; these reuse existing engines/policies rather than adding a new render path.

## Test plan
- [x] `npm run typecheck` clean.
- [x] Vitest — `MessagesRows.stream-mitigation` + `events` suites, 33/33 pass.
- [x] Merges cleanly against current main (v0.6.9), no conflicts.

## Notes for reviewers
- OpenSpec: `optimize-conversation-streaming-render-perf` (proposal/design/spec-delta/tasks) included — four requirements.
- A fifth reasoning-row progressive-markdown optimization was intentionally omitted: v0.6.9 already ships an equivalent (unconditional lightweight `liveRenderMode` + `useDeferredValue` on the reasoning render), so it would be redundant and conflict here.
- This PR owns the `Messages.tsx` streaming caching (`isTrailingMessageTextOnlyUpdate` + action-target caches).
