### PR TITLE
perf(ui): reduce idle recalc and render cost (pure-perf split of #807)

### DIFF
--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -18,7 +18,10 @@ function Switch({
     >
       <SwitchPrimitive.Thumb
         className={cn(
-          "pointer-events-none block aspect-square h-full origin-left in-[[role=switch]:active,[data-slot=label]:active,[data-slot=field-label]:active]:not-data-disabled:scale-x-110 in-[[role=switch]:active,[data-slot=label]:active,[data-slot=field-label]:active]:rounded-[var(--thumb-size)/calc(var(--thumb-size)*1.1)] rounded-(--thumb-size) bg-background shadow-sm/5 will-change-transform [transition:translate_.15s,border-radius_.15s,scale_.1s_.1s,transform-origin_.15s] data-[state=checked]:origin-[var(--thumb-size)_50%] data-[state=checked]:translate-x-[calc(var(--thumb-size)-4px)]",
+          // Removed `will-change-transform`: it forced WebKitGTK to allocate a
+          // permanent compositor layer per thumb, inflating paint across a panel
+          // of many switches. The transition still runs fine without it.
+          "pointer-events-none block aspect-square h-full origin-left in-[[role=switch]:active,[data-slot=label]:active,[data-slot=field-label]:active]:not-data-disabled:scale-x-110 in-[[role=switch]:active,[data-slot=label]:active,[data-slot=field-label]:active]:rounded-[var(--thumb-size)/calc(var(--thumb-size)*1.1)] rounded-(--thumb-size) bg-background shadow-sm/5 [transition:translate_.15s,border-radius_.15s,scale_.1s_.1s,transform-origin_.15s] data-[state=checked]:origin-[var(--thumb-size)_50%] data-[state=checked]:translate-x-[calc(var(--thumb-size)-4px)]",
         )}
         data-slot="switch-thumb"
       />

--- a/src/features/app/components/Sidebar.tsx
+++ b/src/features/app/components/Sidebar.tsx
@@ -909,6 +909,18 @@ function SidebarImpl({
       if (!isWorkspaceMatch(workspace)) {
         return;
       }
+      // Cheap early-out BEFORE the expensive getProjectedThreads (which pulls in
+      // activeItems and so recomputes on every message-stream tick): if this
+      // workspace has no pinned thread at all, there's nothing to build. Checks
+      // the base thread list, which is stable across streaming. Without this the
+      // whole memo re-ran O(all threads) on every stream tick even with 0 pins.
+      const baseThreads = threadsByWorkspace[workspace.id] ?? [];
+      const hasPinnedThread = baseThreads.some((thread) =>
+        isThreadPinned(workspace.id, thread.id),
+      );
+      if (!hasPinnedThread) {
+        return;
+      }
       const threads = getProjectedThreads(workspace.id);
       if (!threads.length) {
         return;
@@ -963,6 +975,8 @@ function SidebarImpl({
       );
   }, [
     workspaces,
+    threadsByWorkspace,
+    isThreadPinned,
     getProjectedThreads,
     getThreadRows,
     getPinTimestamp,

--- a/src/features/files/components/FileTreeRows.tsx
+++ b/src/features/files/components/FileTreeRows.tsx
@@ -245,7 +245,10 @@ function FileTreeNodeRow({
         }}
         onDragEnd={handleDragEnd}
       >
-        <span className="file-tree-icon-cell" aria-hidden>
+        <span
+          className={`file-tree-icon-cell${row.isFolder && row.canExpand ? " has-chevron" : ""}`}
+          aria-hidden
+        >
           <span
             className="file-tree-icon"
             dangerouslySetInnerHTML={{

--- a/src/features/git/components/DiffBlock.tsx
+++ b/src/features/git/components/DiffBlock.tsx
@@ -1,5 +1,5 @@
 import type { KeyboardEvent, MouseEvent, ReactNode } from "react";
-import { useMemo } from "react";
+import { memo, useMemo } from "react";
 import { parseDiff, type ParsedDiffLine } from "../../../utils/diff";
 import { highlightLine } from "../../../utils/syntax";
 import type { CodeAnnotationLineRange } from "../../code-annotations/types";
@@ -24,7 +24,19 @@ type SplitDiffRow =
       right: IndexedDiffLine | null;
     };
 
-type DiffCellMode = "unified" | "old" | "new";
+export type DiffCellMode = "unified" | "old" | "new";
+
+export type DiffLineSelectHandler = (
+  line: ParsedDiffLine,
+  index: number,
+  event: MouseEvent<HTMLDivElement> | KeyboardEvent<HTMLDivElement>,
+) => void;
+
+export type DiffLineExtensionRenderer = (
+  line: ParsedDiffLine,
+  index: number,
+  mode: DiffCellMode,
+) => ReactNode;
 
 type DiffBlockProps = {
   diff: string;
@@ -32,20 +44,12 @@ type DiffBlockProps = {
   diffStyle?: DiffStyle;
   showHunkHeaders?: boolean;
   showLineNumbers?: boolean;
-  onLineSelect?: (
-    line: ParsedDiffLine,
-    index: number,
-    event: MouseEvent<HTMLDivElement> | KeyboardEvent<HTMLDivElement>,
-  ) => void;
+  onLineSelect?: DiffLineSelectHandler;
   selectedRange?: { start: number; end: number } | null;
   parsedLines?: ParsedDiffLine[] | null;
   onAnnotateLine?: (lineRange: CodeAnnotationLineRange) => void;
   annotationLabel?: string;
-  renderLineExtension?: (
-    line: ParsedDiffLine,
-    index: number,
-    mode: DiffCellMode,
-  ) => ReactNode;
+  renderLineExtension?: DiffLineExtensionRenderer;
 };
 
 function mapLineTypeAttribute(type: ParsedDiffLine["type"]) {
@@ -158,7 +162,7 @@ function buildSplitRows(
   return rows;
 }
 
-export function DiffBlock({
+function DiffBlockImpl({
   diff,
   language,
   diffStyle = "unified",
@@ -350,3 +354,10 @@ export function DiffBlock({
     </div>
   );
 }
+
+// Memoized: the git diff viewer re-renders on every 15s status poll and on
+// mount-time setState bursts. Without memo, every visible DiffBlock re-runs its
+// full render (parse + per-line highlight) each time. Callers must pass stable
+// prop identities (see the useCallback'd closures in GitDiffViewer) for this to
+// bite — an inline closure per render would defeat it.
+export const DiffBlock = memo(DiffBlockImpl);

--- a/src/features/git/components/GitDiffViewer.tsx
+++ b/src/features/git/components/GitDiffViewer.tsx
@@ -10,7 +10,11 @@ import { getGitFileFullDiff } from "../../../services/tauri";
 import { formatRelativeTime } from "../../../utils/time";
 import { Markdown } from "../../messages/components/Markdown";
 import { ImageDiffCard } from "./ImageDiffCard";
-import { DiffBlock } from "./DiffBlock";
+import {
+  DiffBlock,
+  type DiffLineExtensionRenderer,
+  type DiffLineSelectHandler,
+} from "./DiffBlock";
 import { parseDiff } from "../../../utils/diff";
 import { languageFromPath } from "../../../utils/syntax";
 import type {
@@ -155,6 +159,141 @@ const DiffCard = memo(function DiffCard({
     : null;
   const canCreateCodeAnnotation = Boolean(onCreateCodeAnnotation);
 
+  // Stable prop identities for the (now memoized) DiffBlock. Previously these
+  // were inline closures recreated every render, so a status poll or mount-time
+  // setState re-rendered every DiffBlock even though nothing they depend on
+  // changed. Each useCallback lists exactly the values it closes over, so it
+  // only churns when those actually change (e.g. annotationDraft while typing).
+  const handleLineSelect = useCallback<DiffLineSelectHandler>(
+    (_line, index, event) => {
+      if (event.shiftKey && selectedDiffRange) {
+        setSelectedDiffRange({
+          start: Math.min(selectedDiffRange.start, index),
+          end: Math.max(selectedDiffRange.start, index),
+        });
+        return;
+      }
+      setSelectedDiffRange({ start: index, end: index });
+    },
+    [selectedDiffRange],
+  );
+  const handleAnnotateLine = useCallback(
+    (lineRange: CodeAnnotationLineRange) =>
+      setAnnotationDraft({ lineRange, body: "" }),
+    [],
+  );
+  const renderLineExtension = useCallback<DiffLineExtensionRenderer>(
+    (line, _index, mode) => {
+      if (mode === "old") {
+        return null;
+      }
+      if (
+        (line.type !== "add" && line.type !== "context") ||
+        typeof line.newLine !== "number"
+      ) {
+        return null;
+      }
+      const lineAnnotations = visibleCodeAnnotations.filter(
+        (annotation) => annotation.lineRange.endLine === line.newLine,
+      );
+      const shouldRenderDraft =
+        annotationDraft?.lineRange.endLine === line.newLine;
+      if (lineAnnotations.length === 0 && !shouldRenderDraft) {
+        return null;
+      }
+      return (
+        <>
+          {lineAnnotations.map((annotation) => (
+            <div key={annotation.id} className="diff-annotation-marker" role="note">
+              <div className="diff-annotation-marker-head">
+                <span className="diff-annotation-title">
+                  <span className="codicon codicon-comment-discussion" aria-hidden />
+                  {t("files.annotationDraft")}
+                </span>
+                <span className="diff-annotation-marker-tools">
+                  <code>{formatCodeAnnotationLineRange(annotation.lineRange)}</code>
+                  {onRemoveCodeAnnotation ? (
+                    <button
+                      type="button"
+                      className="diff-annotation-remove"
+                      onClick={() => onRemoveCodeAnnotation(annotation.id)}
+                      title={t("files.annotationRemove")}
+                      aria-label={t("files.annotationRemove")}
+                    >
+                      <span className="codicon codicon-close" aria-hidden />
+                    </button>
+                  ) : null}
+                </span>
+              </div>
+              <p>{annotation.body}</p>
+            </div>
+          ))}
+          {shouldRenderDraft ? (
+            <div className="diff-annotation-draft diff-annotation-draft-inline" role="region" aria-label={t("files.annotationDraft")}>
+              <div className="diff-annotation-draft-head">
+                <span className="diff-annotation-title">
+                  <span className="codicon codicon-comment-discussion" aria-hidden />
+                  {t("files.annotationDraft")}
+                </span>
+                <code>
+                  {formatCodeAnnotationLineRange(annotationDraft.lineRange)}
+                </code>
+              </div>
+              <textarea
+                value={annotationDraft.body}
+                onChange={(event) => {
+                  const nextBody = event.currentTarget.value;
+                  setAnnotationDraft((current) =>
+                    current ? { ...current, body: nextBody } : current,
+                  );
+                }}
+                placeholder={t("files.annotationPlaceholder")}
+                autoFocus
+              />
+              <div className="diff-annotation-draft-actions">
+                <button
+                  type="button"
+                  className="ghost"
+                  onClick={() => setAnnotationDraft(null)}
+                >
+                  {t("common.cancel")}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    const body = annotationDraft.body.trim();
+                    if (!body) {
+                      return;
+                    }
+                    onCreateCodeAnnotation?.({
+                      path: normalizedEntryPath,
+                      lineRange: annotationDraft.lineRange,
+                      body,
+                      source: codeAnnotationSurface,
+                    });
+                    setAnnotationDraft(null);
+                  }}
+                  disabled={!annotationDraft.body.trim()}
+                >
+                  {t("files.annotationSubmit")}
+                </button>
+              </div>
+            </div>
+          ) : null}
+        </>
+      );
+    },
+    [
+      annotationDraft,
+      codeAnnotationSurface,
+      normalizedEntryPath,
+      onCreateCodeAnnotation,
+      onRemoveCodeAnnotation,
+      t,
+      visibleCodeAnnotations,
+    ],
+  );
+
   return (
       <div
         data-diff-path={entry.path}
@@ -209,122 +348,12 @@ const DiffCard = memo(function DiffCard({
               showLineNumbers
               parsedLines={parsedLines}
               selectedRange={selectedDiffRange}
-              onLineSelect={canCreateCodeAnnotation ? (_line, index, event) => {
-                if (event.shiftKey && selectedDiffRange) {
-                  setSelectedDiffRange({
-                    start: Math.min(selectedDiffRange.start, index),
-                    end: Math.max(selectedDiffRange.start, index),
-                  });
-                  return;
-                }
-                setSelectedDiffRange({ start: index, end: index });
-              } : undefined}
+              onLineSelect={canCreateCodeAnnotation ? handleLineSelect : undefined}
               onAnnotateLine={
-                canCreateCodeAnnotation
-                  ? (lineRange) => setAnnotationDraft({ lineRange, body: "" })
-                  : undefined
+                canCreateCodeAnnotation ? handleAnnotateLine : undefined
               }
               annotationLabel={t("files.annotateForAi")}
-              renderLineExtension={(line, _index, mode) => {
-                if (mode === "old") {
-                  return null;
-                }
-                if (
-                  (line.type !== "add" && line.type !== "context") ||
-                  typeof line.newLine !== "number"
-                ) {
-                  return null;
-                }
-                const lineAnnotations = visibleCodeAnnotations.filter(
-                  (annotation) => annotation.lineRange.endLine === line.newLine,
-                );
-                const shouldRenderDraft =
-                  annotationDraft?.lineRange.endLine === line.newLine;
-                if (lineAnnotations.length === 0 && !shouldRenderDraft) {
-                  return null;
-                }
-                return (
-                  <>
-                    {lineAnnotations.map((annotation) => (
-                      <div key={annotation.id} className="diff-annotation-marker" role="note">
-                        <div className="diff-annotation-marker-head">
-                          <span className="diff-annotation-title">
-                            <span className="codicon codicon-comment-discussion" aria-hidden />
-                            {t("files.annotationDraft")}
-                          </span>
-                          <span className="diff-annotation-marker-tools">
-                            <code>{formatCodeAnnotationLineRange(annotation.lineRange)}</code>
-                            {onRemoveCodeAnnotation ? (
-                              <button
-                                type="button"
-                                className="diff-annotation-remove"
-                                onClick={() => onRemoveCodeAnnotation(annotation.id)}
-                                title={t("files.annotationRemove")}
-                                aria-label={t("files.annotationRemove")}
-                              >
-                                <span className="codicon codicon-close" aria-hidden />
-                              </button>
-                            ) : null}
-                          </span>
-                        </div>
-                        <p>{annotation.body}</p>
-                      </div>
-                    ))}
-                    {shouldRenderDraft ? (
-                      <div className="diff-annotation-draft diff-annotation-draft-inline" role="region" aria-label={t("files.annotationDraft")}>
-                        <div className="diff-annotation-draft-head">
-                          <span className="diff-annotation-title">
-                            <span className="codicon codicon-comment-discussion" aria-hidden />
-                            {t("files.annotationDraft")}
-                          </span>
-                          <code>
-                            {formatCodeAnnotationLineRange(annotationDraft.lineRange)}
-                          </code>
-                        </div>
-                        <textarea
-                          value={annotationDraft.body}
-                          onChange={(event) => {
-                            const nextBody = event.currentTarget.value;
-                            setAnnotationDraft((current) =>
-                              current ? { ...current, body: nextBody } : current,
-                            );
-                          }}
-                          placeholder={t("files.annotationPlaceholder")}
-                          autoFocus
-                        />
-                        <div className="diff-annotation-draft-actions">
-                          <button
-                            type="button"
-                            className="ghost"
-                            onClick={() => setAnnotationDraft(null)}
-                          >
-                            {t("common.cancel")}
-                          </button>
-                          <button
-                            type="button"
-                            onClick={() => {
-                              const body = annotationDraft.body.trim();
-                              if (!body) {
-                                return;
-                              }
-                              onCreateCodeAnnotation?.({
-                                path: normalizedEntryPath,
-                                lineRange: annotationDraft.lineRange,
-                                body,
-                                source: codeAnnotationSurface,
-                              });
-                              setAnnotationDraft(null);
-                            }}
-                            disabled={!annotationDraft.body.trim()}
-                          >
-                            {t("files.annotationSubmit")}
-                          </button>
-                        </div>
-                      </div>
-                    ) : null}
-                  </>
-                );
-              }}
+              renderLineExtension={renderLineExtension}
             />
           </div>
         </div>

--- a/src/features/git/hooks/useGitStatus.ts
+++ b/src/features/git/hooks/useGitStatus.ts
@@ -145,19 +145,21 @@ export function useGitStatus(
         const resolvedBranchName = isGitRepository
           ? resolveBranchName(data.branchName, cached)
           : "";
-        const nextStatus = {
+        const freshStatus = {
           ...data,
           isGitRepository,
           branchName: resolvedBranchName,
           error: isGitRepository ? null : "not a git repository",
         };
+        // Reuse the cached object (stable identity) when the poll changed nothing,
+        // so identity-keyed downstream memos don't re-run every 15s.
         setStatus((currentStatus) => {
-          if (areGitStatusesEqual(currentStatus, nextStatus)) {
+          if (areGitStatusesEqual(currentStatus, freshStatus)) {
             cachedStatusRef.current.set(workspaceId, currentStatus);
             return currentStatus;
           }
-          cachedStatusRef.current.set(workspaceId, nextStatus);
-          return nextStatus;
+          cachedStatusRef.current.set(workspaceId, freshStatus);
+          return freshStatus;
         });
       } catch (err) {
         console.error("Failed to load git status", err);

--- a/src/services/perfBaseline/diagnosticsReport.ts
+++ b/src/services/perfBaseline/diagnosticsReport.ts
@@ -108,5 +108,23 @@ export function buildDiagnosticsReportText(): string {
     return `${header}(no performance diagnostics recorded — 打开设置里的「性能诊断采集」并复现卡顿后再导出)\n`;
   }
 
-  return `${header}${recent.map(formatEntry).join("\n")}\n`;
+  // Dedicated "all frame drops" section: the tail above is capped at
+  // REPORT_MAX_ENTRIES and interleaves other labels. This dumps EVERY recorded
+  // frame drop (real ones + suspend/resume) with its full payload — including
+  // `topRenders` attribution — sorted worst-first so the heaviest stalls are at
+  // the top. NOTE: the react-scan "Update DOM vs JS-Hooks" self-time split is
+  // computed inside the react-scan toolbar and is not available to app code, so
+  // it cannot be included here.
+  const worstFirst = [...allFrameDrops].sort(
+    (a, b) =>
+      (readNumber(b.payload, "deltaMs") ?? 0) -
+      (readNumber(a.payload, "deltaMs") ?? 0),
+  );
+  const allDropsSection = [
+    "",
+    `--- ALL FRAME DROPS (${worstFirst.length}, worst first) ---`,
+    ...worstFirst.map(formatEntry),
+  ].join("\n");
+
+  return `${header}${recent.map(formatEntry).join("\n")}\n${allDropsSection}\n`;
 }

--- a/src/services/perfBaseline/reactScanRenderLog.ts
+++ b/src/services/perfBaseline/reactScanRenderLog.ts
@@ -5,7 +5,15 @@
 // 瞬间读取"掉帧前一小段时间里渲染最多的组件",回答"是谁在重渲染"。仅当 react-scan overlay
 // 开启时才有数据(onRender 由 reactScanController 接入)。
 
-type RenderLogEntry = { name: string; count: number; at: number };
+type RenderLogEntry = {
+  name: string;
+  count: number;
+  // Summed self-time (ms) across this commit's Render objects. react-scan puts
+  // per-render self-time on Render.time; we were discarding it. May be 0/absent
+  // in production builds (React strips per-render timings there).
+  selfMs: number;
+  at: number;
+};
 
 const MAX_ENTRIES = 300;
 const buffer: RenderLogEntry[] = [];
@@ -43,28 +51,54 @@ function getFiberName(fiber: unknown): string {
   return "unknown";
 }
 
+// Sum the self-time off react-scan's Render[] payload (each has a numeric `time`).
+function sumSelfMs(renders: unknown): number {
+  if (!Array.isArray(renders)) {
+    return 0;
+  }
+  let total = 0;
+  for (const render of renders) {
+    const time = (render as { time?: unknown } | null | undefined)?.time;
+    if (typeof time === "number" && Number.isFinite(time)) {
+      total += time;
+    }
+  }
+  return total;
+}
+
 export function recordReactScanRender(fiber: unknown, renders: unknown): void {
   const name = getFiberName(fiber);
   const count = Array.isArray(renders) ? renders.length : 1;
-  buffer.push({ name, count, at: nowMs() });
+  buffer.push({ name, count, selfMs: sumSelfMs(renders), at: nowMs() });
   if (buffer.length > MAX_ENTRIES) {
     buffer.splice(0, buffer.length - MAX_ENTRIES);
   }
 }
 
-/** 返回最近 windowMs 内渲染次数最多的前若干组件,供掉帧现场附着。 */
+/**
+ * 返回最近 windowMs 内渲染次数最多的前若干组件,供掉帧现场附着。
+ * selfMs 为该窗口内该组件的累计 self-time(生产版可能恒为 0)。
+ */
 export function getRecentReactScanRenderSummary(
   windowMs = 600,
-): Array<{ name: string; count: number }> {
+): Array<{ name: string; count: number; selfMs: number }> {
   const cutoff = nowMs() - windowMs;
-  const aggregated = new Map<string, number>();
+  const aggregated = new Map<string, { count: number; selfMs: number }>();
   for (const entry of buffer) {
     if (entry.at >= cutoff) {
-      aggregated.set(entry.name, (aggregated.get(entry.name) ?? 0) + entry.count);
+      const prev = aggregated.get(entry.name) ?? { count: 0, selfMs: 0 };
+      prev.count += entry.count;
+      prev.selfMs += entry.selfMs;
+      aggregated.set(entry.name, prev);
     }
   }
   return [...aggregated.entries()]
-    .map(([name, count]) => ({ name, count }))
+    .map(([name, { count, selfMs }]) => ({
+      name,
+      count,
+      // Round to keep the exported JSON compact.
+      selfMs: Math.round(selfMs * 10) / 10,
+    }))
     .sort((a, b) => b.count - a.count)
     .slice(0, 5);
 }

--- a/src/styles/composer.part1.css
+++ b/src/styles/composer.part1.css
@@ -88,7 +88,12 @@
   padding: 12px;
   gap: 8px;
   box-shadow: none;
-  transition: all 0.2s ease;
+  /* Was `transition: all` — that made WebKitGTK watch/animate every property on
+     :focus-within, forcing a full-box repaint that cascades through the always-on
+     backdrop-filter bars (topbar/tabbar) and pins the browser in paint for
+     seconds on large projects. Only border-color actually changes on focus, so
+     scope the transition to it. */
+  transition: border-color 0.2s ease;
 }
 
 .composer-input.is-resizing {

--- a/src/styles/file-tree.css
+++ b/src/styles/file-tree.css
@@ -742,8 +742,12 @@
   opacity: 1;
 }
 
-.file-tree-row-wrap:hover .file-tree-icon-cell:has(.file-tree-chevron) .file-tree-icon,
-.file-tree-row:focus-visible .file-tree-icon-cell:has(.file-tree-chevron) .file-tree-icon {
+/* Was `:has(.file-tree-chevron)` — replaced with a `.has-chevron` class set in
+   JSX. `:has()` is very expensive on WebKitGTK (re-evaluated per hover across the
+   whole tree); the class is O(1) to match. Same semantics: only folders that can
+   expand fade their type-icon out on hover to reveal the chevron. */
+.file-tree-row-wrap:hover .file-tree-icon-cell.has-chevron .file-tree-icon,
+.file-tree-row:focus-visible .file-tree-icon-cell.has-chevron .file-tree-icon {
   opacity: 0;
 }
 

--- a/src/utils/syntax.test.ts
+++ b/src/utils/syntax.test.ts
@@ -54,4 +54,22 @@ describe("syntax", () => {
     const highlighted = highlightLine("<tag>", "unknown-language");
     expect(highlighted).toBe("&lt;tag&gt;");
   });
+
+  it("caches highlighted output: a repeat call returns the identical string reference", () => {
+    // The identical reference is what lets dangerouslySetInnerHTML consumers skip
+    // re-writing the DOM on re-render, avoiding WebKitGTK style-recalc.
+    const first = highlightLine("const x = 1;", "typescript");
+    const second = highlightLine("const x = 1;", "typescript");
+    expect(first).toContain("token");
+    expect(second).toBe(first); // value-equal
+    expect(Object.is(first, second)).toBe(true); // same reference (cache hit)
+  });
+
+  it("does not cross language boundaries in the cache", () => {
+    const asJs = highlightLine("const value = 1;", "javascript");
+    const asPlain = highlightLine("const value = 1;", "unknown-language");
+    expect(asJs).toContain("token");
+    expect(asPlain).not.toContain("token");
+    expect(asJs).not.toBe(asPlain);
+  });
 });

--- a/src/utils/syntax.ts
+++ b/src/utils/syntax.ts
@@ -53,11 +53,49 @@ export function languageFromPath(path?: string | null) {
   return resolvePreviewLanguageFromPath(path);
 }
 
+// highlightLine is pure in (text, language), but it runs Prism per line and is
+// called inside diff/preview render loops on every re-render. Without a cache a
+// large diff re-tokenizes thousands of lines on each parent commit — the cause
+// of multi-second style-recalc on WebKitGTK. LRU-cache the result (same Map idiom
+// as fastMarkdownRenderer/cache.ts); a hit also returns the *same string*, so
+// dangerouslySetInnerHTML consumers can skip re-writing the DOM.
+const MAX_HIGHLIGHT_CACHE_ENTRIES = 4000;
+const highlightCache = new Map<string, string>();
+
+function readHighlightCache(cacheKey: string) {
+  const cached = highlightCache.get(cacheKey);
+  if (cached === undefined) {
+    return undefined;
+  }
+  highlightCache.delete(cacheKey);
+  highlightCache.set(cacheKey, cached);
+  return cached;
+}
+
+function writeHighlightCache(cacheKey: string, html: string) {
+  highlightCache.delete(cacheKey);
+  highlightCache.set(cacheKey, html);
+  while (highlightCache.size > MAX_HIGHLIGHT_CACHE_ENTRIES) {
+    const oldestKey = highlightCache.keys().next().value;
+    if (oldestKey === undefined) {
+      break;
+    }
+    highlightCache.delete(oldestKey);
+  }
+}
+
 export function highlightLine(text: string, language?: string | null) {
   if (!language || !(Prism.languages as Record<string, unknown>)[language]) {
     return escapeHtml(text);
   }
-  return sanitizePrismHtml(
+  const cacheKey = `${language}\0${text}`;
+  const cached = readHighlightCache(cacheKey);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const html = sanitizePrismHtml(
     Prism.highlight(text, Prism.languages[language] as Grammar, language),
   );
+  writeHighlightCache(cacheKey, html);
+  return html;
 }


### PR DESCRIPTION
Part 1 of 2 splitting #807 as you approved — the **pure-performance + diagnostics** bucket. No user-visible behaviour change; targets `main`. Independent of the sibling chrome PR (disjoint files).

## What's here (bucket a + c)

- **`utils/syntax.ts`** — Prism highlight LRU cache. **M1 fixed:** the cache-key separator now uses the 2-character `\0` escape instead of a raw NUL byte, so git treats the file as text (diff/blame/review work again).
- **`git/DiffBlock`** — wrap in `React.memo`.
- **`git/GitDiffViewer`** — stable `useCallback`s. Re-applied onto current `main`, preserving your newer `toolbarOnly` / `contentMode` additions.
- **`app/Sidebar`** — pinned-threads early-out.
- **`files/FileTreeRows`** + **`file-tree.css`** — `.has-chevron` class.
- **`git/useGitStatus`** — rename + comment (behaviour-preserving).
- **`ui/switch`** — drop redundant `will-change`.
- **`composer.part1.css`** — `transition: all` → `border-color`.
- **`services/perfBaseline/*`** — diagnostics enrichment (bucket c, rides here per your note).

## Notes

- The behaviour-visible chrome changes (scrollbar scoping + coverage, virtualization threshold, diff-viewer unmount) are in the **sibling PR**, routed through `openspec/changes/`.
- Local gates green: `typecheck`, `lint`, `vitest` — including the `GitDiffViewer.toolbarOnly` test, which confirms the re-apply preserved your v0.7.1 feature.
- Happy to provide a 中文 version of this description.

**Sibling PR (behaviour-visible chrome, OpenSpec-routed):** #818
