### PR TITLE
feat(ui): reduce idle chrome render cost (behaviour-visible split of #807)

### DIFF
--- a/openspec/changes/reduce-idle-chrome-render-cost/design.md
+++ b/openspec/changes/reduce-idle-chrome-render-cost/design.md
@@ -1,0 +1,46 @@
+# Design: Reduce idle chrome render cost
+
+## Scrollbar scoping
+
+**Problem.** `*::-webkit-scrollbar` / `*:hover` rules make WebKitGTK re-match and
+re-resolve (including `var()`) for every element on every style recalc — a large
+share of the multi-second `recalculate-styles` stalls on big projects.
+
+**Decision.** Style the scroll roots only: `html`, `body`, and an opt-in
+`.scrollable` class. The thumb is always shown (no `:hover` reveal) so no
+universal hover selector is needed.
+
+**Ceiling.** Any nested overflow container that wants a styled scrollbar must add
+`.scrollable`. Covered explicitly: `.messages`, the file-tree scroll containers,
+and the native-overflow settings sub-panels. The main settings view scrolls
+through a Radix `ScrollArea`, which renders its own overlay scrollbar and is
+unaffected. Vendor config dialogs still fall back to the platform scrollbar; they
+can opt in later without further CSS changes.
+
+## Diff viewer unmount-on-tab-switch
+
+**Problem.** The workspace diff viewer stayed mounted with its row virtualizer and
+per-row `ResizeObserver`s even when its tab was hidden, so it kept doing layout
+work while idle.
+
+**Decision.** Unmount it when its tab is not active.
+
+**Tradeoff (accepted by maintainer).** Unmounting discards transient view state:
+an unsaved code-annotation draft, the current text selection, and any lazily
+loaded full-diff. Persisted data (saved annotations, the diff itself) is
+unaffected and reloads on return. The maintainer noted they will manually verify
+the annotation flow on a large dirty project before landing.
+
+## File-tree virtualization threshold
+
+**Decision.** Lower the threshold from 250 to 30 entries. Below 30 the row count
+is small enough that virtualization overhead is not worth it; at or above 30 the
+saved DOM/render work dominates. No visible change other than that medium trees
+now scroll through a virtualized window.
+
+## Why a separate change from the pure-perf work
+
+The pure, behaviour-preserving optimizations (memoization, early-outs, the Prism
+LRU cache, cheaper CSS transitions) carry no user-visible change and ship in a
+separate PR. This change is scoped to the three behaviour-visible items above so
+each can be reviewed and, if needed, reverted independently.

--- a/openspec/changes/reduce-idle-chrome-render-cost/proposal.md
+++ b/openspec/changes/reduce-idle-chrome-render-cost/proposal.md
@@ -1,0 +1,43 @@
+# Proposal: Reduce idle chrome render cost
+
+## Why
+
+On large projects the app spent multi-second bursts in `recalculate-styles` and
+kept avoidable render/observer work alive while idle. Profiling on WebKitGTK
+(the Tauri Linux webview) traced most of it to app-wide chrome behaviour rather
+than to any one feature:
+
+- Universal `*` / `*:hover` scrollbar rules forced a style re-match and
+  `var()` re-resolve for **every** element on every style recalc.
+- The workspace diff viewer stayed mounted (with its virtualizer and resize
+  observers) even when its tab was not visible.
+- The file tree only virtualized past 250 entries, so medium trees rendered
+  every row.
+
+These are the behaviour-visible half of the idle-render work; the pure,
+behaviour-preserving optimizations ship separately.
+
+## What Changes
+
+- **Scrollbar scoping.** Scope scrollbar styling to the scroll roots
+  (`html`, `body`) plus an opt-in `.scrollable` class, replacing the universal
+  `*` rules. Add `.scrollable` to the chat list (`.messages`), the file-tree
+  scroll containers, and the settings sub-panels so they keep styled scrollbars.
+- **Diff viewer unmount-on-tab-switch.** Unmount the workspace diff viewer when
+  its tab is not active, releasing its virtualizer and observers while idle.
+- **File-tree virtualization threshold.** Lower the virtualization threshold
+  from 250 to 30 entries so medium trees stop rendering every row.
+
+## Impact
+
+- Affected spec: `ui-chrome-idle-render-cost` (new capability)
+- Affected code:
+  - `src/styles/base.css`
+  - `src/features/layout/components/DesktopLayout.tsx`
+  - `src/features/files/components/fileTreePanelInternals.ts`
+  - `src/features/messages/components/Messages.tsx`
+  - `src/features/files/components/FileTreePanel.tsx`, `FilePreviewPopover.tsx`
+  - `src/features/search/components/WorkspaceSearchPanel.tsx`
+  - `src/features/settings/**` (settings sub-panel scroll containers opt in)
+- Accepted tradeoff: switching away from the diff viewer's tab discards its
+  unsaved annotation draft, selection, and loaded full-diff (see design).

--- a/openspec/changes/reduce-idle-chrome-render-cost/specs/ui-chrome-idle-render-cost/spec.md
+++ b/openspec/changes/reduce-idle-chrome-render-cost/specs/ui-chrome-idle-render-cost/spec.md
@@ -1,0 +1,51 @@
+## ADDED Requirements
+
+### Requirement: Scrollbar styling SHALL be scoped to scroll roots and opt-in containers
+
+Custom scrollbar styling SHALL be applied to the scroll roots (`html`, `body`) and
+to elements that opt in with a `.scrollable` class, and SHALL NOT be applied
+through universal `*` / `*:hover` selectors.
+
+#### Scenario: chrome scroll areas keep styled scrollbars
+- **GIVEN** the app is running on the desktop webview
+- **WHEN** the chat message list, a file-tree scroll container, or a native-overflow settings sub-panel is scrollable
+- **THEN** that container SHALL carry the `.scrollable` opt-in and render the styled scrollbar
+- **AND** the styled scrollbar SHALL NOT depend on any universal `*` scrollbar selector
+
+#### Scenario: non-opted containers fall back to the platform scrollbar
+- **GIVEN** an overflow container that does not carry `.scrollable`
+- **WHEN** it becomes scrollable
+- **THEN** it SHALL fall back to the platform scrollbar
+- **AND** the application SHALL NOT re-introduce a universal `*` scrollbar rule to style it
+
+### Requirement: Workspace diff viewer SHALL unmount while its tab is inactive
+
+The workspace diff viewer SHALL be unmounted when its tab is not the active tab so
+that its virtualizer and observers do not run while idle.
+
+#### Scenario: diff viewer releases idle work when hidden
+- **GIVEN** the workspace diff viewer tab is not active
+- **WHEN** the layout renders
+- **THEN** the diff viewer SHALL be unmounted
+- **AND** its row virtualizer and per-row observers SHALL NOT run
+
+#### Scenario: transient view state is discarded on tab switch
+- **GIVEN** the diff viewer has an unsaved annotation draft, an active selection, or a lazily loaded full-diff
+- **WHEN** the user switches away from the diff viewer tab
+- **THEN** that transient view state MAY be discarded
+- **AND** persisted annotations and the underlying diff SHALL remain intact and reload when the tab is reopened
+
+### Requirement: File tree SHALL virtualize at a low entry threshold
+
+The file tree SHALL virtualize its rows once an entry count threshold of 30 is
+reached, rather than rendering every row up to a large threshold.
+
+#### Scenario: medium trees virtualize
+- **GIVEN** a file-tree level with 30 or more entries
+- **WHEN** the file tree renders
+- **THEN** the rows SHALL be virtualized to a scrolling window
+
+#### Scenario: small trees render directly
+- **GIVEN** a file-tree level with fewer than 30 entries
+- **WHEN** the file tree renders
+- **THEN** the rows MAY render without virtualization

--- a/openspec/changes/reduce-idle-chrome-render-cost/tasks.md
+++ b/openspec/changes/reduce-idle-chrome-render-cost/tasks.md
@@ -1,0 +1,8 @@
+# Tasks
+
+- [x] Scope scrollbar styling to `html`/`body` + opt-in `.scrollable`, removing the universal `*` rules.
+- [x] Add `.scrollable` to the chat list (`.messages`) and the file-tree scroll containers.
+- [x] Add `.scrollable` to the native-overflow settings sub-panels; leave the Radix `ScrollArea` main scroll untouched.
+- [x] Unmount the workspace diff viewer when its tab is not active.
+- [x] Lower the file-tree virtualization threshold from 250 to 30 entries.
+- [x] Validate with TypeScript typecheck, ESLint, focused Vitest, and `openspec validate`.

--- a/src/features/files/components/FilePreviewPopover.tsx
+++ b/src/features/files/components/FilePreviewPopover.tsx
@@ -128,7 +128,7 @@ export function FilePreviewPopover({
             </div>
           </div>
           {imageSrc ? (
-            <div className="file-preview-image">
+            <div className="file-preview-image scrollable">
               <img src={imageSrc} alt={path} />
             </div>
           ) : (
@@ -178,7 +178,7 @@ export function FilePreviewPopover({
               </button>
             </div>
           </div>
-          <div className="file-preview-lines" role="list">
+          <div className="file-preview-lines scrollable" role="list">
             {lines.map((_, index) => {
               const html = highlightedLines[index] ?? "&nbsp;";
               const isSelected =

--- a/src/features/files/components/FileTreePanel.tsx
+++ b/src/features/files/components/FileTreePanel.tsx
@@ -1934,7 +1934,7 @@ export function FileTreePanel({
       </div>
       <div
         ref={fileTreeListRef}
-        className={`file-tree-list${shouldVirtualizeFileTree ? " is-virtualized" : ""}`}
+        className={`file-tree-list scrollable${shouldVirtualizeFileTree ? " is-virtualized" : ""}`}
         data-file-tree-row-count={visibleFileTreeRows.length}
       >
         {showLoading ? (

--- a/src/features/files/components/fileTreePanelInternals.ts
+++ b/src/features/files/components/fileTreePanelInternals.ts
@@ -82,7 +82,11 @@ const SPECIAL_BUILD_ARTIFACT_DIRECTORIES = new Set([
   ".dart_tool",
 ]);
 export const EMPTY_DIRECTORY_METADATA: WorkspaceDirectoryEntry[] = [];
-export const FILE_TREE_VIRTUALIZATION_THRESHOLD = 250;
+// Lowered from 250: on WebKitGTK (Tauri's Linux webview) an un-virtualized tree
+// of even ~40 rows (each with 2 inline SVGs + hover selectors) causes multi-second
+// style-recalc/paint. Virtualizing at 30 keeps the live DOM small; the virtual
+// path already applies `contain` and is the production path for large trees.
+export const FILE_TREE_VIRTUALIZATION_THRESHOLD = 30;
 
 export function isSameOrDescendantFileTreePath(path: string, rootPath: string) {
   return path === rootPath || path.startsWith(`${rootPath}/`);

--- a/src/features/layout/components/DesktopLayout.tsx
+++ b/src/features/layout/components/DesktopLayout.tsx
@@ -403,7 +403,13 @@ export function DesktopLayout({
                     aria-hidden={centerMode !== "diff"}
                     ref={diffLayerRef}
                   >
-                    {gitDiffViewerNode}
+                    {/* Only mount the diff viewer when actually shown. It was
+                        always-mounted (CSS-hidden), so on a fresh chat it
+                        eager-loaded the WHOLE working-tree diff DOM — which on a
+                        large/dirty project made every WebKitGTK
+                        style recalc re-resolve that hidden subtree, the main jank
+                        source. Re-mounts (and reloads) on switch to the diff tab. */}
+                    {centerMode === "diff" ? gitDiffViewerNode : null}
                   </div>
                   <div
                     className={`content-layer content-layer--editor ${

--- a/src/features/messages/components/Messages.tsx
+++ b/src/features/messages/components/Messages.tsx
@@ -2397,7 +2397,7 @@ export const Messages = memo(function Messages({
         onScrollToAnchor={requestScrollToAnchor}
       />
       <div
-        className="messages"
+        className="messages scrollable"
         ref={containerRef}
         onScroll={updateAutoScroll}
       >

--- a/src/features/search/components/WorkspaceSearchPanel.tsx
+++ b/src/features/search/components/WorkspaceSearchPanel.tsx
@@ -254,7 +254,7 @@ export function WorkspaceSearchPanel({
           <div className="workspace-search-limit">{t("files.searchLimitReached")}</div>
         ) : null}
 
-        <div className="workspace-search-results">
+        <div className="workspace-search-results scrollable">
           {!workspaceId ? null : !isSearchMode ? null : searchLoading || searchError ? null :
             !searchResults || searchResults.files.length === 0 ? (
               <div className="workspace-search-empty">{t("files.noMatchesFound")}</div>

--- a/src/features/settings/components/AgentSettingsSection.tsx
+++ b/src/features/settings/components/AgentSettingsSection.tsx
@@ -434,7 +434,7 @@ export function AgentSettingsSection({ active }: AgentSettingsSectionProps) {
                 <div>{t("settings.agent.importDialog.columnName")}</div>
                 <div>{t("settings.agent.importDialog.columnId")}</div>
               </div>
-              <div className="settings-agent-table-body">
+              <div className="settings-agent-table-body scrollable">
                 {agentList.map((agent) => {
                   const checked = agentExport.selectedIds.has(agent.id);
                   return (
@@ -619,7 +619,7 @@ export function AgentSettingsSection({ active }: AgentSettingsSectionProps) {
                     <div>{t("settings.agent.importDialog.columnId")}</div>
                     <div>{t("settings.agent.importDialog.columnStatus")}</div>
                   </div>
-                  <div className="settings-agent-table-body">
+                  <div className="settings-agent-table-body scrollable">
                     {agentImport.preview.items.map((item) => {
                       const agent = item.data;
                       const checked = agentImport.selectedIds.has(agent.id);

--- a/src/features/settings/components/HistoryCompletionSettings.tsx
+++ b/src/features/settings/components/HistoryCompletionSettings.tsx
@@ -119,7 +119,7 @@ export function HistoryCompletionSettings() {
       </button>
 
       {showList && (
-        <div className="history-list-container">
+        <div className="history-list-container scrollable">
           {historyItems.length === 0 ? (
             <>
               <div className="history-empty">

--- a/src/features/settings/components/ProjectSessionManagementSection.tsx
+++ b/src/features/settings/components/ProjectSessionManagementSection.tsx
@@ -462,7 +462,7 @@ export function ProjectSessionManagementSection({
                             aria-label={t("workspace.searchProjects")}
                           />
                         </div>
-                        <div className="settings-project-sessions-workspace-list">
+                        <div className="settings-project-sessions-workspace-list scrollable">
                           {filteredWorkspaceSections.map((section) => (
                             <div
                               key={section.id ?? "ungrouped"}
@@ -611,7 +611,7 @@ export function ProjectSessionManagementSection({
                   {t("settings.projectSessionLoading")}
                 </div>
               ) : null}
-              <ul className="settings-project-sessions-list">
+              <ul className="settings-project-sessions-list scrollable">
               {orderedThreads.map((thread) => {
                 const selected = Boolean(selectedIds[thread.id]);
                 const engineType = resolveEngineType(thread.engineSource);

--- a/src/features/settings/components/PromptSection/index.tsx
+++ b/src/features/settings/components/PromptSection/index.tsx
@@ -625,7 +625,7 @@ export function PromptSection({
                           {t("settings.prompt.argumentHintLabel")}: {prompt.argumentHint}
                         </div>
                       )}
-                      <div className="settings-prompt-content-preview">
+                      <div className="settings-prompt-content-preview scrollable">
                         {prompt.content}
                       </div>
                     </div>
@@ -680,7 +680,7 @@ export function PromptSection({
                           {t("settings.prompt.argumentHintLabel")}: {prompt.argumentHint}
                         </div>
                       )}
-                      <div className="settings-prompt-content-preview">
+                      <div className="settings-prompt-content-preview scrollable">
                         {prompt.content}
                       </div>
                     </div>

--- a/src/features/settings/components/SessionRadarHistoryManagementSection.tsx
+++ b/src/features/settings/components/SessionRadarHistoryManagementSection.tsx
@@ -266,7 +266,7 @@ export function SessionRadarHistoryManagementSection({
           {orderedEntries.length === 0 ? (
             <div className="settings-project-sessions-empty">{t("settings.radarHistoryEmpty")}</div>
           ) : (
-            <ul className="settings-project-sessions-list">
+            <ul className="settings-project-sessions-list scrollable">
               {orderedEntries.map((entry) => {
                 const selected = Boolean(selectedIds[entry.id]);
                 return (

--- a/src/features/settings/components/SkillsSection.tsx
+++ b/src/features/settings/components/SkillsSection.tsx
@@ -1087,7 +1087,7 @@ export function SkillsSection({
                 <div className="settings-skills-tree-root">
                   {engineRootSummary || primaryEngineRootPath}
                 </div>
-                <div className="settings-skills-tree-scroll">
+                <div className="settings-skills-tree-scroll scrollable">
                   {rootTreeLoading ? (
                     <div className="settings-skills-tree-state">{t("settings.skillsPanel.treeLoading")}</div>
                   ) : rootTreeError ? (
@@ -1209,7 +1209,7 @@ export function SkillsSection({
                         {t("settings.skillsPanel.detailDirectoryHint", { count: selectedDirectoryChildCount })}
                       </div>
                     ) : (
-                      <div className="settings-skills-content-wrap">
+                      <div className="settings-skills-content-wrap scrollable">
                         {selectedFileIsImage ? (
                           selectedImageSrc ? (
                             <div className="fvp-image-preview">

--- a/src/features/settings/components/settings-view/sections/CodexSection.tsx
+++ b/src/features/settings/components/settings-view/sections/CodexSection.tsx
@@ -1356,7 +1356,7 @@ export function CodexSection({
                   </span>
                 </div>
                 {installerState.logLines.length > 0 ? (
-                  <pre className="settings-installer-log-output">
+                  <pre className="settings-installer-log-output scrollable">
                     {installerState.logLines
                       .map((line) => {
                         const stream = line.stream

--- a/src/features/settings/components/settings-view/sections/EmailSenderSettings.tsx
+++ b/src/features/settings/components/settings-view/sections/EmailSenderSettings.tsx
@@ -1022,7 +1022,7 @@ export function EmailSenderSettings({
                     <X size={14} aria-hidden />
                   </Button>
                 </div>
-                <div className="settings-mail-detail-scroll">
+                <div className="settings-mail-detail-scroll scrollable">
                   {selectedTimeline.length === 0 ? (
                     <div className="settings-help">{t("settings.emailTimelineEmpty")}</div>
                   ) : (

--- a/src/features/settings/components/settings-view/sections/SessionManagementSection.tsx
+++ b/src/features/settings/components/settings-view/sections/SessionManagementSection.tsx
@@ -1835,7 +1835,7 @@ export function SessionManagementSection({
                 <div className="settings-project-sessions-nav-title">
                   {t("settings.workspacePickerLabel")}
                 </div>
-                <div className="settings-project-sessions-nav-list">
+                <div className="settings-project-sessions-nav-list scrollable">
                   {workspaceOptions.map((option) => {
                     const active = option.id === workspaceId;
                     return (
@@ -2497,7 +2497,7 @@ export function SessionManagementSection({
                 </button>
               </div>
             </header>
-            <div className="settings-session-curtain-messages">
+            <div className="settings-session-curtain-messages scrollable">
               {sessionCurtain.isLoading ? (
                 <div className="settings-session-curtain-empty">
                   {t("settings.sessionManagementCurtainLoading")}

--- a/src/features/settings/components/settings-view/sections/SessionManagementSessionList.tsx
+++ b/src/features/settings/components/settings-view/sections/SessionManagementSessionList.tsx
@@ -58,7 +58,7 @@ export function SessionListSection({
           <div className="text-sm text-muted-foreground">{description}</div>
         ) : null}
       </div>
-      <ul className="settings-project-sessions-list">
+      <ul className="settings-project-sessions-list scrollable">
         {entries.map((entry) => {
           const selectionKey = buildWorkspaceSessionSelectionKey(entry);
           const selected = Boolean(selectedIds[selectionKey]);

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -53,64 +53,68 @@
  * - 悬停时颜色变深，给用户反馈
  */
 
-@property --sb-thumb-color {
-  syntax: '<color>';
-  initial-value: transparent;
-  inherits: false;
-}
-
-@property --sb-thumb-alpha {
-  syntax: '<number>';
-  initial-value: 0;
-  inherits: false;
-}
-
 /* Firefox 滚动条 */
-* {
+/*
+ * Intentionally NO transition on `*`. A previous version animated a
+ * registered @property (--sb-thumb-alpha) on every element for 2000ms on hover,
+ * driving a live color-mix() on `*::-webkit-scrollbar-thumb`. On WebKitGTK
+ * (Tauri's Linux webview) that forced app-wide style recalc on every animation
+ * tick after any hover — the cause of multi-second frame drops. The thumb now
+ * reveals instantly on hover via a plain color swap (no animation).
+ */
+/*
+ * Scrollbar styling is applied to the SCROLL ROOT only, not `*`.
+ * Universal `*` / `*:hover` scrollbar rules force WebKitGTK to re-match and
+ * re-resolve (incl. var()) for EVERY element on every style recalc — a large
+ * part of the multi-second `recalculate-styles` stalls on big projects. Scoping
+ * to `html`/`body` (+ an opt-in `.scrollable` class) removes that per-element
+ * cost. Thumb is always shown (no `:hover` reveal) to avoid a universal hover
+ * selector; it's subtle enough. Ceiling: nested overflow containers that want a
+ * styled scrollbar must add `.scrollable`. The chat list (`.messages`), the
+ * file-tree scroll containers, and the settings sub-panels opt in explicitly;
+ * the main settings view scrolls through a Radix `ScrollArea` (its own overlay
+ * scrollbar, unaffected). Vendor config dialogs still fall back to the platform
+ * scrollbar.
+ */
+html,
+body,
+.scrollable {
   scrollbar-width: thin;
-  scrollbar-color: transparent transparent;
-  --sb-thumb-color: var(--scrollbar-thumb);
-  --sb-thumb-alpha: 0;
-  transition-property: --sb-thumb-alpha;
-  transition-duration: 2000ms;
-  transition-timing-function: ease-out;
-  transition-delay: 120ms;
-}
-
-*:hover {
   scrollbar-color: var(--scrollbar-thumb) transparent;
-  --sb-thumb-alpha: 1;
-  transition-duration: 2000ms;
-  transition-timing-function: ease-in-out;
-  transition-delay: 0ms;
 }
 
 /* Webkit 浏览器滚动条 (Chrome, Safari, Edge, Tauri WebView) */
-*::-webkit-scrollbar {
+html::-webkit-scrollbar,
+body::-webkit-scrollbar,
+.scrollable::-webkit-scrollbar {
   width: 8px;
   height: 8px;
 }
 
-*::-webkit-scrollbar-track {
+html::-webkit-scrollbar-track,
+body::-webkit-scrollbar-track,
+.scrollable::-webkit-scrollbar-track {
   background: transparent;
 }
 
-*::-webkit-scrollbar-thumb {
-  background-color: color-mix(
-    in srgb,
-    var(--sb-thumb-color) calc(var(--sb-thumb-alpha) * 100%),
-    transparent
-  );
+html::-webkit-scrollbar-thumb,
+body::-webkit-scrollbar-thumb,
+.scrollable::-webkit-scrollbar-thumb {
+  background-color: var(--scrollbar-thumb);
   border-radius: 4px;
   border: 2px solid transparent;
   background-clip: content-box;
 }
 
-*:hover::-webkit-scrollbar-thumb:hover {
+html::-webkit-scrollbar-thumb:hover,
+body::-webkit-scrollbar-thumb:hover,
+.scrollable::-webkit-scrollbar-thumb:hover {
   background-color: var(--scrollbar-thumb-hover);
 }
 
-*::-webkit-scrollbar-corner {
+html::-webkit-scrollbar-corner,
+body::-webkit-scrollbar-corner,
+.scrollable::-webkit-scrollbar-corner {
   background: transparent;
 }
 


### PR DESCRIPTION
Part 2 of 2 splitting #807 as you approved — the **behaviour-visible chrome** bucket, routed through `openspec/changes/reduce-idle-chrome-render-cost/` per your governance. Targets `main`. Independent of the sibling pure-perf PR (disjoint files).

## What's here (bucket b) + the M2 coverage fix

- **Scrollbar scoping** `*` → `html, body, .scrollable`. **M2 fixed:** added `.scrollable` to `.messages`, the file-tree scroll containers (list, preview image/lines, search results), and the native-overflow **settings sub-panels**. The main settings view scrolls through a Radix `ScrollArea` (its own overlay scrollbar, unaffected); vendor config dialogs are left as a follow-up (they opt in with the same class, no further CSS).
- **Diff-viewer unmount-on-tab-switch** — releases its virtualizer / resize-observers while idle. **Accepted tradeoff (per your note):** the unsaved annotation draft, selection, and lazily-loaded full-diff are discarded on tab switch; persisted annotations and the diff itself are intact and reload on return. Called out in the OpenSpec design for your annotation-flow verification on a large dirty project.
- **File-tree virtualization threshold** 250 → 30.
- **OpenSpec change** — proposal / design / tasks + a `ui-chrome-idle-render-cost` spec delta.

## One thing we dropped

While splitting we found #807's "reduced-transparency topbar backdrop" **duplicated a rule already in `main`** — `.app.reduced-transparency .main-topbar { backdrop-filter: none }` has existed at `main.css` since v0.6.9. #807 added a byte-identical second copy (a no-op). We dropped it rather than carry dead CSS and document it in the spec, so the OpenSpec change describes three real behaviour-visible items, not four.

## Notes

- Local gates green: `typecheck`, `lint`, `openspec validate`, `vitest`.
- Happy to provide a 中文 version of this description.

**Sibling PR (pure-perf + diagnostics):** #817
