### PR TITLE
fix(markdown): preserve display math container boundaries

### DIFF
--- a/.trellis/spec/frontend/index.md
+++ b/.trellis/spec/frontend/index.md
@@ -24,6 +24,7 @@
 | [Hook Guidelines](./hook-guidelines.md) | hook 编排、async safety、bridge 调用约束 | Active |
 | [State Management](./state-management.md) | local/global/persistent/runtime state 边界 | Active |
 | [Quality Guidelines](./quality-guidelines.md) | 禁止项、必做项、review checklist | Active |
+| [Markdown Math Normalization Idempotence](./quality-guidelines.md#markdown-math-normalization-must-preserve-container-and-math-range-idempotence) | Markdown container prefix、math-range idempotence 与回归口径 | Active |
 | [CodeMirror State-Coupled Extensions 不可跨越 Lazy Boundary](./quality-guidelines.md#codemirror-state-coupled-extensions-不可跨越-lazy-boundary) | 任何把 `@codemirror/*` state-coupled extension 拆到 lazy 边界后的硬性禁止 | Active |
 | [Type Safety](./type-safety.md) | strict TypeScript 与 boundary mapping 规则 | Active |
 

--- a/.trellis/spec/frontend/quality-guidelines.md
+++ b/.trellis/spec/frontend/quality-guidelines.md
@@ -334,3 +334,49 @@ import("@codemirror/search").then(({ search }) => setExtension(search({ top: tru
 ### 历史回归
 
 - 2026-06-11 `lazy-file-preview-dependencies` change 中曾尝试将 `@codemirror/search` 拆到 `FileCodeMirrorEditor` lazy 边界后，CI / 单元测试通过，但 Tauri 桌面中 Cmd+F 出现"开了但跳不回原文位置、replace 不同步"等 regression。该 change 已撤回并把 `@codemirror/search` 留在 file panel 启动路径上。详见 `openspec/changes/lazy-file-preview-dependencies/proposal.md` 的 *Withdrawn Optimization* 章节和 `openspec/docs/lazy-state-extension-regression-2026-06-11.md`。
+
+## Markdown Math Normalization MUST Preserve Container and Math-Range Idempotence
+
+### Scope / Trigger
+
+- Trigger：修改 `src/features/markdown/markdownMath.ts`、消息 Markdown math compatibility、file Markdown preview math normalization，或新增 delimiter / prose heuristic。
+- 目标：多 pass normalization 不能破坏 Markdown container boundary，也不能再次改写已经建立的 math range。
+
+### Signatures
+
+- `normalizeMarkdownMathForMessage(value: string): string`
+- `normalizeMarkdownMathForFilePreview(value: string): MarkdownMathNormalizationResult`
+- Shared implementation：`normalizeCommonMathDelimiters(value: string)`
+
+### Contracts
+
+- Normalization MUST operate on render-time copies；不得修改 canonical message、Codex JSONL 或 persisted file source。
+- Standalone `\\[` / `\\]` delimiter lines 只有在 opener / closer 具有相同 whitespace/blockquote prefix 时才可转换。
+- 成功转换 MUST 只替换两条 delimiter lines；formula body 与 source line count MUST remain unchanged。
+- Generic inline/fallback regex MUST NOT flatten unresolved standalone delimiters across list、blockquote 或 root containers。
+- 一旦 `$...$` / `$$...$$` range 已建立，后续 plain-parentheses 或其它 inline heuristic MUST treat its body as immutable math content；禁止 nested dollar wrapping。
+- Rich message 与 file preview MUST reuse the shared pure normalizer；lightweight streaming path MUST remain outside this heavy normalization chain。
+
+### Validation & Error Matrix
+
+| 场景 | 必须行为 | 禁止行为 |
+|---|---|---|
+| ordered-list standalone display | opener/body/closer 留在同一 list container | delimiter 退回 root，跨段吞入 prose |
+| blockquote/nested prefix | exact delimiter-line prefix preserved | 去掉 `>` 或 continuation indentation |
+| incompatible/unmatched delimiters | candidate unchanged | generic regex 跨 container 配对 |
+| display body starts with `(\\theta,...)` | parentheses 留在 display expression 内 | 转成 `$\\theta...$` 后再塞入 `$$...$$` |
+| file preview normalization | normalized line count 与 `lineMap` 稳定 | 为 delimiter conversion 插入/删除 source lines |
+| lightweight streaming | 保持原 lightweight path | 每个 delta 执行 full math normalization |
+
+### Good / Base / Bad Cases
+
+- Good：line-aware pass 原位把 `   \\[` / `   \\]` 改成 `   $$`，并在 plain-parentheses pass 前 guard established dollar math ranges。
+- Base：root-level `\\[x^2\\]`、inline `\\(x_i\\)` 与既有 `$...$` 继续使用原 compatibility behavior。
+- Bad：全局 `replace(/\\\\\[/, "$$")` 后重排 body，或让 `($\\theta$)` / `$$ $\\theta$ $$` 进入 `remark-math`。
+
+### Tests Required
+
+- Message DOM regression：断言预期 `.katex-display` 数量、`.katex-error` 为 0、后续 prose 不在 `.katex` subtree。
+- Pure normalization assertion：锁定 parenthesized display body 不出现 nested single-dollar delimiters。
+- File preview regression：覆盖 list、blockquote、unmatched/incompatible prefix 与 `lineMap`。
+- 若问题来自真实会话，verification artifact SHOULD 记录匿名化 fixture 或 session UUID replay 结果，但 test MUST NOT 依赖用户 home directory。

--- a/.trellis/workspace/yode/index.md
+++ b/.trellis/workspace/yode/index.md
@@ -1,0 +1,41 @@
+# Workspace Index - yode
+
+> Journal tracking for AI development sessions.
+
+---
+
+## Current Status
+
+<!-- @@@auto:current-status -->
+- **Active File**: `journal-1.md`
+- **Total Sessions**: 1
+- **Last Active**: 2026-07-15
+<!-- @@@/auto:current-status -->
+
+---
+
+## Active Documents
+
+<!-- @@@auto:active-documents -->
+| File | Lines | Status |
+|------|-------|--------|
+| `journal-1.md` | ~40 | Active |
+<!-- @@@/auto:active-documents -->
+
+---
+
+## Session History
+
+<!-- @@@auto:session-history -->
+| # | Date | Title | Commits | Branch |
+|---|------|-------|---------|--------|
+| 1 | 2026-07-15 | 修复 Markdown 公式容器边界 | `749dd0300c8e45d3915b0e691819162cf9bff0ea` | `fix/message-math-container-prefix` |
+<!-- @@@/auto:session-history -->
+
+---
+
+## Notes
+
+- Sessions are appended to journal files
+- New journal file created when current exceeds 2000 lines
+- Use `add_session.py` to record sessions

--- a/.trellis/workspace/yode/index.md
+++ b/.trellis/workspace/yode/index.md
@@ -8,7 +8,7 @@
 
 <!-- @@@auto:current-status -->
 - **Active File**: `journal-1.md`
-- **Total Sessions**: 1
+- **Total Sessions**: 2
 - **Last Active**: 2026-07-15
 <!-- @@@/auto:current-status -->
 
@@ -19,7 +19,7 @@
 <!-- @@@auto:active-documents -->
 | File | Lines | Status |
 |------|-------|--------|
-| `journal-1.md` | ~40 | Active |
+| `journal-1.md` | ~73 | Active |
 <!-- @@@/auto:active-documents -->
 
 ---
@@ -29,6 +29,7 @@
 <!-- @@@auto:session-history -->
 | # | Date | Title | Commits | Branch |
 |---|------|-------|---------|--------|
+| 2 | 2026-07-15 | 同步 PR 最终验证状态 | `8fe1c7af9624053e4be3010c2da99bade1ff6457` | `fix/message-math-container-prefix` |
 | 1 | 2026-07-15 | 修复 Markdown 公式容器边界 | `749dd0300c8e45d3915b0e691819162cf9bff0ea` | `fix/message-math-container-prefix` |
 <!-- @@@/auto:session-history -->
 

--- a/.trellis/workspace/yode/journal-1.md
+++ b/.trellis/workspace/yode/journal-1.md
@@ -1,0 +1,40 @@
+# Journal - yode (Part 1)
+
+> AI development session journal
+> Started: 2026-07-15
+
+---
+
+
+
+## Session 1: 修复 Markdown 公式容器边界
+
+**Date**: 2026-07-15
+**Task**: 修复 Markdown 公式容器边界
+**Branch**: `fix/message-math-container-prefix`
+
+### Summary
+
+保留独立 display math 在 ordered list 与 blockquote 中的 Markdown container prefix，阻止不兼容 delimiter 跨容器配对，并避免已建立的 dollar math range 被括号 heuristic 二次包裹；新增消息 DOM、file preview、lineMap 与真实 Codex UUID replay 回归证据。focused tests 43/43、typecheck、lint 通过；全量测试仅复现未触及 Sidebar 的 3 个主线基线失败。
+
+### Main Changes
+
+(Add details)
+
+### Git Commits
+
+| Hash | Message |
+|------|---------|
+| `749dd0300c8e45d3915b0e691819162cf9bff0ea` | (see git log) |
+
+### Testing
+
+- [OK] (Add test results)
+
+### Status
+
+[OK] **Completed**
+
+### Next Steps
+
+- None - task complete

--- a/.trellis/workspace/yode/journal-1.md
+++ b/.trellis/workspace/yode/journal-1.md
@@ -38,3 +38,36 @@
 ### Next Steps
 
 - None - task complete
+
+
+## Session 2: 同步 PR 最终验证状态
+
+**Date**: 2026-07-15
+**Task**: 同步 PR 最终验证状态
+**Branch**: `fix/message-math-container-prefix`
+
+### Summary
+
+远端 PR 核验发现 verification artifact 仍保留提交前的 manual QA TODO 与 commit/session deferred 状态；已同步为 rebuilt desktop verification DONE，并确认代码提交与 Trellis record 已完成。Trellis 脚本在 worktree 只读 Git metadata 环境中写文件成功、自动暂存失败，按脚本提示使用 direct git fallback 提交记录。
+
+### Main Changes
+
+(Add details)
+
+### Git Commits
+
+| Hash | Message |
+|------|---------|
+| `8fe1c7af9624053e4be3010c2da99bade1ff6457` | (see git log) |
+
+### Testing
+
+- [OK] (Add test results)
+
+### Status
+
+[OK] **Completed**
+
+### Next Steps
+
+- None - task complete

--- a/openspec/changes/fix-message-math-container-prefix/design.md
+++ b/openspec/changes/fix-message-math-container-prefix/design.md
@@ -1,0 +1,105 @@
+## Context
+
+当前 rich Markdown pipeline 使用 `remark-math + rehype-katex`。`remark-math` 不直接识别 raw `\\[...\\]`，因此 `normalizeCommonMathDelimiters()` 会先将其适配为 dollar delimiters。普通根层级 block 可以正确归一，但下面的 list continuation：
+
+```md
+1. 定义：
+   \\[
+   x^2+y^2
+   \\]
+```
+
+当前会变成：
+
+```md
+1. 定义：
+   $$
+x^2+y^2
+$$
+```
+
+opening 与 closing delimiter 因此属于不同 Markdown container。
+
+另一个失败形态来自同一函数内部的 pass ordering：
+
+```md
+\[
+(\theta,t_x,t_y),
+\]
+```
+
+standalone block 先正确变成 `$$...$$`，但后续 plain-parentheses heuristic 又产生：
+
+```md
+$$
+$\theta,t_x,t_y$,
+$$
+```
+
+这会让 KaTeX 报 `Can't use function '$' in math mode`。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 保持现有 delimiter compatibility architecture，不引入新的 Markdown parser 或 micromark extension。
+- 对独占一行且成对的 `\\[` / `\\]` 原位转换，并保留 whitespace/blockquote container prefix。
+- formula body 原样保留，normalization 前后行数一致。
+- 已进入 dollar math range 的内容不得再被 plain-parentheses heuristic 包裹。
+- 后续 prose 必须保持普通 Markdown，不得进入 math node 或 `.katex-error`。
+
+**Non-Goals:**
+
+- 不修改原始 Codex JSONL 或 canonical message text。
+- 不扩大 `looksLikeInlineLatexExpression()`，本 change 不处理 `\\(q\\)` / `\\(q=60\\)` heuristic。
+- 不改变 inline prose 中 `\\[expression\\]` 的既有转换语义。
+- 不修改 KaTeX、`remark-math`、`rehype-katex` plugin order 或 CSS。
+- 不把 normalization 放回 lightweight streaming hot path。
+
+## Decisions
+
+### Decision 1: line-aware standalone block normalization before generic regex
+
+新增 pure helper 扫描 code region 之外的文本行：
+
+1. delimiter line 只能包含 whitespace、blockquote markers、一个或多个反斜杠和 `[` / `]`；
+2. opening 与 closing delimiter 必须成对，并具有相同 container prefix；
+3. formula body 继续使用现有 conservative LaTeX predicate；
+4. 匹配成功时，仅把两条 delimiter line 改为同 prefix 的 `$$`，body 不重排。
+
+之后仍运行现有 generic regex，以继续支持单行 prose wrapper 和其它已覆盖场景。
+
+### Decision 2: protect established dollar math ranges from nested wrapping
+
+在 plain-parentheses replacement 前，以单次 bounded scan 收集 unescaped `$...$` / `$$...$$` ranges。若候选 offset 位于任一 math range 内，保持原文；range 外仍使用既有 conservative predicate 与 wrapper boundary 判断。
+
+该 guard 只阻止 nested wrapping，不修改公式内容，也不改变 normalizer 的 public API、plugin order 或 canonical message source。
+
+### Decision 3: preserve source line count and shared file-preview behavior
+
+helper 不插入或删除行，因此 message rendering 与 file preview 共用 normalizer 时，file annotation `lineMap` 不发生漂移。测试同时覆盖 DOM rendering 与 file document normalization。
+
+### Decision 4: unmatched or incompatible delimiters remain unchanged
+
+若找不到同 prefix closing delimiter、遇到 nested opener 或 expression 不满足现有 conservative predicate，则 line-aware pass 不改写该 block。generic bracket fallback 识别到 standalone wrapper 时同样保持原文，只继续处理 inline/prose wrapper，从而避免跨 container flattening。
+
+## Risks / Trade-offs
+
+- [Risk] container prefix 判定过宽可能把 prose line 当 delimiter。
+  - Mitigation：prefix 只接受 whitespace 与 Markdown blockquote marker，delimiter 必须独占余下整行。
+- [Risk] nested/unbalanced delimiters被错误配对。
+  - Mitigation：遇到新的 standalone opener 时放弃当前 candidate；unmatched block 保持原文。
+- [Risk] shared normalizer 改变 file preview line mapping。
+  - Mitigation：原位替换且补充 line-count/line-map regression test。
+- [Risk] dollar range guard 误把普通 prose 当 math。
+  - Mitigation：只收集成对、unescaped dollar delimiters；single-dollar range 遇到换行即失效，且 guard 只执行 non-mutating skip。
+- [Risk] 每次 rich render 增加额外扫描。
+  - Mitigation：standalone block 以 `value.includes("\\\\[")` fast path 提前退出；container scan 与 dollar range scan 均为 bounded linear pass，不引入 React state 或 effect。
+
+## Verification Strategy
+
+- Vitest DOM regression：ordered list 内两个 `\\[...\\]` blocks 后 prose 仍存在，存在预期 `.katex-display`，不存在 `.katex-error`。
+- Vitest DOM regression：`\\[(\\theta,t_x,t_y),\\]` normalization 不产生 nested `$...$`，并可由 KaTeX 正常 display render。
+- File document regression：normalized value 的 opener/body/closer 保持同 prefix，`lineMap` 长度与原 source line count 相等。
+- 使用 UUID `019f5fd5-25a4-7521-8949-12d9f6c466f3` 的真实 assistant message 重放 production `Markdown` component，断言 `.katex-error` 为 0。
+- Focused tests 后运行 `npm run typecheck`、`npm run lint` 和项目 test gate。

--- a/openspec/changes/fix-message-math-container-prefix/proposal.md
+++ b/openspec/changes/fix-message-math-container-prefix/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+消息区会在进入 `remark-math` 前把显式 `\\[...\\]` display delimiters 归一为 `$$...$$`。当前 multiline replacement 会丢失 ordered list、nested list 或 blockquote continuation line 的 Markdown container prefix，导致 opening delimiter 留在容器内、closing delimiter 退回根层级。随后 `remark-math` 跨段错误配对，KaTeX 将正文渲染为红色 `.katex-error`。
+
+同一 normalization pass 还有第二个局部冲突：standalone `\\[...\\]` 已转换成 dollar display math 后，plain-parentheses heuristic 仍会继续扫描其 body，把行首 `（\\theta,...）` / `(\\theta,...)` 再包成 `$...$`。KaTeX 因而在 math mode 内遇到 literal `$`，只在这类 display body 上报错，这也解释了为什么大部分 `\\[...\\]` 可以正常渲染而少数失败。
+
+## What Changes
+
+- 在现有 Markdown math normalization 架构内，增加 line-aware standalone `\\[...\\]` block normalization。
+- 仅原位替换成对 delimiter lines，并保留 opening/closing line 的原 container prefix；formula body 与行数保持不变。
+- plain-parentheses heuristic 在已形成的 `$...$` / `$$...$$` range 内 MUST skip，避免对 display body 做 nested dollar wrapping。
+- 保留现有 inline `\\[...\\]`、`\\(...\\)`、`$$...$$`、fenced code 与 lightweight streaming 行为。
+- 增加 ordered-list fixture、parenthesized display body 与 file-preview line mapping regression coverage。
+
+## Capabilities
+
+### Modified Capabilities
+
+- `message-markdown-latex-compatibility`: display delimiter normalization 必须保持 Markdown container boundary，且 established math range 不得被后续 inline heuristic 二次包裹。
+
+## Impact
+
+- Frontend implementation: `src/features/markdown/markdownMath.ts`
+- Message regression tests: `src/features/messages/components/Markdown.math-rendering.test.tsx`
+- File-preview regression tests: `src/features/files/utils/fileMarkdownDocument.test.ts`
+- 无新依赖、无 persisted data migration、无 backend contract change。

--- a/openspec/changes/fix-message-math-container-prefix/specs/message-markdown-latex-compatibility/spec.md
+++ b/openspec/changes/fix-message-math-container-prefix/specs/message-markdown-latex-compatibility/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: Display Math Delimiter Normalization MUST Preserve Markdown Container Boundaries
+
+消息区在把显式 `\\[...\\]` display delimiters 适配为 `remark-math` 支持的内部表示时，MUST 保留公式所在的 Markdown container boundary，且 MUST NOT 改写 canonical message source。
+
+#### Scenario: ordered-list display block keeps one container prefix
+
+- **WHEN** ordered list item 的 continuation lines 包含独占一行的 `\\[`、formula body 与 `\\]`
+- **THEN** normalization MUST 让 opening delimiter、formula body 与 closing delimiter 保持在同一 list container
+- **AND** formula MUST 渲染为 display math
+- **AND** 后续 prose MUST remain outside the math node
+- **AND** render output MUST NOT contain `.katex-error` caused by delimiter cross-pairing
+
+#### Scenario: blockquote or nested container remains structurally stable
+
+- **WHEN** standalone display delimiters 位于 whitespace/blockquote container prefix 内
+- **THEN** normalization MUST preserve the exact delimiter-line container prefix
+- **AND** normalization MUST NOT flatten the formula block to the document root
+
+#### Scenario: unmatched delimiter remains non-destructive
+
+- **WHEN** standalone opening delimiter 没有兼容的 closing delimiter
+- **THEN** the line-aware normalization pass MUST leave that candidate unchanged
+- **AND** it MUST NOT consume subsequent prose as a synthesized math block
+
+#### Scenario: file-preview source mapping remains stable
+
+- **WHEN** shared Markdown normalization processes a matched standalone display block
+- **THEN** normalized line count MUST equal source line count
+- **AND** file-preview `lineMap` MUST continue to map every normalized line to its original source line
+
+### Requirement: Established Math Ranges MUST NOT Be Wrapped Again
+
+一旦 normalization 已经建立 `$...$` 或 `$$...$$` math range，后续 compatibility heuristic MUST treat its body as math content and MUST NOT inject nested dollar delimiters。
+
+#### Scenario: parenthesized LaTeX inside display math is not wrapped again
+
+- **WHEN** standalone `\\[...\\]` display body 以 `(\\theta,t_x,t_y)` 或等价 parenthesized LaTeX 开头
+- **THEN** normalization MUST preserve the parentheses as part of the display expression
+- **AND** plain-parentheses heuristic MUST NOT insert nested single-dollar delimiters inside the display math range
+- **AND** render output MUST NOT contain a `.katex-error` caused by literal `$` in math mode

--- a/openspec/changes/fix-message-math-container-prefix/tasks.md
+++ b/openspec/changes/fix-message-math-container-prefix/tasks.md
@@ -1,0 +1,17 @@
+## 1. Regression Contract
+
+- [x] 1.1 在 `Markdown.math-rendering.test.tsx` 增加 ordered-list multiline `\\[...\\]` fixture；验证当前实现产生 `.katex-error` 或缺失预期 display math，并锁定后续 prose 不可被吞。
+- [x] 1.2 在 `fileMarkdownDocument.test.ts` 增加 shared normalizer regression；验证 delimiter/body container prefix 与 source line mapping 保持稳定。
+- [x] 1.3 增加 parenthesized display body regression，锁定 `\\[(\\theta,t_x,t_y),\\]` 不得被二次转换为 nested `$...$`。
+
+## 2. Normalizer Fix
+
+- [x] 2.1 在 `markdownMath.ts` 增加 line-aware standalone bracket display block helper，只原位转换相同 container prefix 的成对 delimiters。
+- [x] 2.2 将 helper 接入 `normalizeCommonMathDelimiters()`，保留 generic inline/fallback normalization 和 code-region boundary。
+- [x] 2.3 在 plain-parentheses heuristic 前收集 dollar math ranges，并跳过 range 内候选，防止 nested dollar wrapping。
+
+## 3. Verification
+
+- [x] 3.1 运行 focused Markdown/file-preview Vitest，记录 RED 与 GREEN evidence。
+- [x] 3.2 运行 `npm run typecheck`、`npm run lint`、`npm run test`，记录结果及任何与本 change 无关的既有失败。
+- [x] 3.3 尝试 strict OpenSpec validation，并在 `verification.md` 记录 CLI / fallback validator 的环境阻塞与 remaining manual risk。

--- a/openspec/changes/fix-message-math-container-prefix/verification.md
+++ b/openspec/changes/fix-message-math-container-prefix/verification.md
@@ -1,0 +1,144 @@
+# Verification
+
+## Status
+
+Implementation verified. Strict OpenSpec artifact validation remains environment-blocked because neither the CLI nor the repository fallback validator is executable in this workspace.
+
+## Regression Evidence
+
+### RED: Markdown container prefix loss
+
+Ordered-list `\\[...\\]` fixture originally normalized from:
+
+```md
+   \\[
+   B_0,\\qquad B_{180}=R_\\pi B_0;
+   \\]
+```
+
+to:
+
+```md
+   $$
+B_0,\\qquad B_{180}=R_\\pi B_0;
+$$
+```
+
+The message renderer produced an extra cross-paired math block and consumed later Chinese prose; file preview lost both list and blockquote prefixes.
+
+### RED: nested parenthetical conversion
+
+The focused regression proved that:
+
+```md
+\\[
+(\\theta,t_x,t_y),
+\\]
+```
+
+was normalized to:
+
+```md
+$$
+$\\theta,t_x,t_y$,
+$$
+```
+
+KaTeX then reported `Can't use function '$' in math mode`.
+
+### GREEN
+
+```text
+npx vitest run \
+  src/features/messages/components/Markdown.math-rendering.test.tsx \
+  src/features/files/utils/fileMarkdownDocument.test.ts \
+  src/features/files/components/FileMarkdownPreview.test.tsx
+
+3 test files passed
+43 tests passed
+```
+
+Coverage includes ordered-list prefix preservation, blockquote prefix preservation, unmatched delimiters, incompatible container prefixes, nested parenthetical protection, DOM KaTeX rendering, and file-preview line mapping.
+
+## Real Codex Session Replay
+
+Session UUID: `019f5fd5-25a4-7521-8949-12d9f6c466f3`
+
+- Production `Markdown` component replay passed with zero `.katex-error` nodes.
+- The previously failing tuple now normalizes as `$$ / (\\theta,t_x,t_y), / $$`, without nested single-dollar delimiters.
+- AST inspection around the screenshot area contains bounded math nodes instead of one cross-paired node consuming prose:
+
+```text
+math 488-490 [x,y,...]
+math 502-504 B_0,...
+math 509-511 \\Delta=...
+math 531-533 2qWH...
+```
+
+## Static Quality Gates
+
+- `npm run typecheck`: passed.
+- `npm run lint`: passed.
+- `npm run check:large-files`: exited 0; report mode listed six existing policy findings on latest `origin/main`, none touched by this change.
+- `git diff --check`: passed.
+- No API, backend, persistence, CSS, or streaming-state contract changed. The PR branch contains no dependency or manifest edit.
+
+## Full Test Gate
+
+`npm run test` was run outside the default sandbox restriction and reached batch 19, where `src/features/app/components/Sidebar.test.tsx` stopped the batch runner with three failures (`44/47` Sidebar tests passed):
+
+1. runtime notice bottom action count: expected `4`, received `2`;
+2. folder session creation test queried role `menuitem`, while the provider entry is exposed as `menuitemradio`;
+3. catalog-backed pending folder intent test has the same `menuitem` / `menuitemradio` mismatch.
+
+No Sidebar source, test, dependency, or shared provider-menu file differs from `origin/main` in this branch. A direct standalone rerun reproduced the same three assertions, so these are baseline failures rather than regressions introduced by the math normalizer.
+
+## OpenSpec Validation
+
+- `openspec validate fix-message-math-container-prefix --strict --no-interactive`: unavailable; `openspec` is not on PATH.
+- Documented shell fallback failed because `zsh` is not installed.
+- `python3 .claude/skills/osp-openspec-sync/scripts/validate-consistency.py --project-path . --full` failed because its upstream validator path `/home/yode/.claude/skills/osp-openspec-sync/scripts/validate-consistency.py` is absent.
+
+The proposal, design, tasks, delta spec, and this verification artifact were manually reviewed for the expected change structure, but strict schema validation is not claimed.
+
+## Remaining Manual Risk
+
+- A rebuilt cc-gui should open the target UUID once for visual confirmation in the actual desktop WebView.
+- The conservative `\\(q\\)` single-symbol heuristic remains intentionally unchanged; this change only fixes container-prefix loss and nested wrapping inside already established math ranges.
+
+## Break-Loop Analysis
+
+### 1. Root Cause Category
+
+- **Category**: D + E — Test Coverage Gap / Implicit Assumption.
+- **Specific Cause**: multi-pass normalizer implicitly assumed each regex saw only prose wrappers. In reality, an earlier pass can establish Markdown/math structure that a later pass must treat as immutable grammar rather than fresh text.
+
+### 2. Why the First Fix Was Incomplete
+
+1. Container-prefix preservation fixed the large cross-paired math node, but only exercised the list/blockquote structural failure.
+2. Replaying the complete target UUID exposed a second composition failure: plain-parentheses normalization still ran inside the newly established display block.
+3. Focused synthetic fixtures alone therefore did not fully represent the interaction among sequential normalization passes; production-component replay supplied the missing integration evidence.
+
+### 3. Prevention Mechanisms
+
+| Priority | Mechanism | Specific Action | Status |
+|---|---|---|---|
+| P0 | Architecture | line-aware delimiter replacement + established math-range guard | DONE |
+| P0 | Test Coverage | list/blockquote/unmatched/cross-container/nested-wrapper DOM and pure assertions | DONE |
+| P1 | Documentation | OpenSpec delta + Trellis frontend executable contract | DONE |
+| P1 | Integration | production `Markdown` replay for the reported UUID | DONE |
+| P2 | Manual QA | rebuilt desktop WebView visual check | TODO |
+
+### 4. Systematic Expansion
+
+- **Similar Issues**: any sequential Markdown normalizer can corrupt structure created by an earlier pass, especially alert/list normalization, dollar math repair, and prose heuristics.
+- **Design Improvement**: new passes should declare which grammar regions they may mutate and use line/range-aware guards instead of unconstrained cross-line regex replacement.
+- **Process Improvement**: bug fixes sourced from real sessions should combine minimal synthetic tests with one production-pipeline replay before completion.
+
+### 5. Knowledge Capture
+
+- [x] Updated OpenSpec proposal/design/spec/tasks/verification.
+- [x] Updated `.trellis/spec/frontend/quality-guidelines.md` and index.
+- [x] Added executable regression coverage.
+- [ ] No `src/templates/markdown/spec/` tree exists in this repository, so template sync is not applicable.
+- [ ] Commit and Trellis session record remain intentionally deferred until the user requests a commit.

--- a/openspec/changes/fix-message-math-container-prefix/verification.md
+++ b/openspec/changes/fix-message-math-container-prefix/verification.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Implementation verified. Strict OpenSpec artifact validation remains environment-blocked because neither the CLI nor the repository fallback validator is executable in this workspace.
+Implementation and rebuilt-desktop manual verification completed. Strict OpenSpec artifact validation remains environment-blocked because neither the CLI nor the repository fallback validator is executable in this workspace.
 
 ## Regression Evidence
 
@@ -101,9 +101,9 @@ No Sidebar source, test, dependency, or shared provider-menu file differs from `
 
 The proposal, design, tasks, delta spec, and this verification artifact were manually reviewed for the expected change structure, but strict schema validation is not claimed.
 
-## Remaining Manual Risk
+## Manual Verification and Remaining Risk
 
-- A rebuilt cc-gui should open the target UUID once for visual confirmation in the actual desktop WebView.
+- A rebuilt cc-gui opened the target UUID in the actual desktop WebView, and the previously failing formulas rendered correctly.
 - The conservative `\\(q\\)` single-symbol heuristic remains intentionally unchanged; this change only fixes container-prefix loss and nested wrapping inside already established math ranges.
 
 ## Break-Loop Analysis
@@ -127,7 +127,7 @@ The proposal, design, tasks, delta spec, and this verification artifact were man
 | P0 | Test Coverage | list/blockquote/unmatched/cross-container/nested-wrapper DOM and pure assertions | DONE |
 | P1 | Documentation | OpenSpec delta + Trellis frontend executable contract | DONE |
 | P1 | Integration | production `Markdown` replay for the reported UUID | DONE |
-| P2 | Manual QA | rebuilt desktop WebView visual check | TODO |
+| P2 | Manual QA | rebuilt desktop WebView visual check | DONE |
 
 ### 4. Systematic Expansion
 
@@ -141,4 +141,4 @@ The proposal, design, tasks, delta spec, and this verification artifact were man
 - [x] Updated `.trellis/spec/frontend/quality-guidelines.md` and index.
 - [x] Added executable regression coverage.
 - [ ] No `src/templates/markdown/spec/` tree exists in this repository, so template sync is not applicable.
-- [ ] Commit and Trellis session record remain intentionally deferred until the user requests a commit.
+- [x] Code commit and mandatory Trellis session record completed before PR publication.

--- a/src/features/files/utils/fileMarkdownDocument.test.ts
+++ b/src/features/files/utils/fileMarkdownDocument.test.ts
@@ -45,6 +45,86 @@ describe("fileMarkdownDocument", () => {
     expect(compiled.lineMap[6]).toBe(5);
   });
 
+  it("keeps list container prefixes while normalizing bracket display math", () => {
+    const rawMarkdown = [
+      "1. 模板关系",
+      "   \\[",
+      "   B_0,\\qquad B_{180}=R_\\pi B_0;",
+      "   \\]",
+      "",
+      "target paragraph",
+    ].join("\n");
+    const compiled = compileFileMarkdownDocument({
+      documentKey: "ws:workspace/list-math.md",
+      rawMarkdown,
+      rendererProfile: "file-markdown-github",
+    });
+
+    expect(compiled.body).toContain([
+      "   $$",
+      "   B_0,\\qquad B_{180}=R_\\pi B_0;",
+      "   $$",
+    ].join("\n"));
+    expect(compiled.lineMap).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+
+  it("keeps blockquote prefixes while normalizing bracket display math", () => {
+    const compiled = compileFileMarkdownDocument({
+      documentKey: "ws:workspace/quote-math.md",
+      rawMarkdown: [
+        "> 公式如下：",
+        "> \\[",
+        "> \\Delta=|s_0-s_{180}|;",
+        "> \\]",
+      ].join("\n"),
+      rendererProfile: "file-markdown-github",
+    });
+
+    expect(compiled.body).toContain([
+      "> $$",
+      "> \\Delta=|s_0-s_{180}|;",
+      "> $$",
+    ].join("\n"));
+    expect(compiled.lineMap).toEqual([1, 2, 3, 4]);
+  });
+
+  it("leaves unmatched bracket display delimiters unchanged", () => {
+    const rawMarkdown = [
+      "1. 未完成公式",
+      "   \\[",
+      "   x^2+y^2",
+      "",
+      "后续正文。",
+    ].join("\n");
+    const compiled = compileFileMarkdownDocument({
+      documentKey: "ws:workspace/unmatched-math.md",
+      rawMarkdown,
+      rendererProfile: "file-markdown-github",
+    });
+
+    expect(compiled.body).toBe(rawMarkdown);
+    expect(compiled.lineMap).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it("does not pair standalone bracket delimiters across containers", () => {
+    const rawMarkdown = [
+      "1. 不兼容边界",
+      "   \\[",
+      "   x^2",
+      "\\]",
+      "",
+      "后续正文。",
+    ].join("\n");
+    const compiled = compileFileMarkdownDocument({
+      documentKey: "ws:workspace/cross-container-math.md",
+      rawMarkdown,
+      rendererProfile: "file-markdown-github",
+    });
+
+    expect(compiled.body).toBe(rawMarkdown);
+    expect(compiled.lineMap).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+
     it("selects a bounded render strategy for markdown with many heavy blocks", () => {
     const rawMarkdown = Array.from({ length: 24 }, (_, index) => [
       "```mermaid",

--- a/src/features/markdown/markdownMath.ts
+++ b/src/features/markdown/markdownMath.ts
@@ -229,6 +229,51 @@ function hasUnescapedDollar(value: string) {
   return false;
 }
 
+type DollarMathRange = {
+  start: number;
+  end: number;
+};
+
+function collectDollarMathRanges(value: string): DollarMathRange[] {
+  const ranges: DollarMathRange[] = [];
+  let opening: { start: number; delimiterLength: 1 | 2 } | null = null;
+
+  for (let index = 0; index < value.length; index += 1) {
+    if (opening?.delimiterLength === 1 && value[index] === "\n") {
+      opening = null;
+      continue;
+    }
+    if (value[index] !== "$" || !isUnescapedCharacter(value, index)) {
+      continue;
+    }
+
+    const delimiterLength = value[index + 1] === "$" ? 2 : 1;
+    if (!opening) {
+      opening = { start: index, delimiterLength };
+      index += delimiterLength - 1;
+      continue;
+    }
+    if (opening.delimiterLength === 2 && delimiterLength === 1) {
+      continue;
+    }
+    if (opening.delimiterLength === 1 && delimiterLength === 2) {
+      ranges.push({ start: opening.start, end: index + 1 });
+      opening = null;
+      continue;
+    }
+
+    ranges.push({ start: opening.start, end: index + delimiterLength });
+    opening = null;
+    index += delimiterLength - 1;
+  }
+
+  return ranges;
+}
+
+function isInsideDollarMathRange(ranges: DollarMathRange[], index: number) {
+  return ranges.some((range) => index > range.start && index < range.end);
+}
+
 function normalizeMalformedDisplayMathSegments(value: string) {
   if (!value.includes("$$")) {
     return value;
@@ -442,9 +487,112 @@ function normalizeStandaloneMathDisplayLinesWithLineMap(value: string): Markdown
   };
 }
 
-function normalizeCommonMathDelimiters(value: string) {
+type StandaloneBracketDisplayMathDelimiter = {
+  kind: "open" | "close";
+  prefix: string;
+};
+
+function parseStandaloneBracketDisplayMathDelimiterLine(
+  line: string,
+): StandaloneBracketDisplayMathDelimiter | null {
+  const match = /^((?:[ \t]*>[ \t]*)*[ \t]*)(\\+)(\S)[ \t]*$/.exec(line);
+  const delimiter = match?.[3];
+  if (!match || (delimiter !== "[" && delimiter !== "]")) {
+    return null;
+  }
+  return {
+    kind: delimiter === "[" ? "open" : "close",
+    prefix: match[1] ?? "",
+  };
+}
+
+function isStandaloneBracketDisplayMathWrapper(
+  source: string,
+  startIndex: number,
+  endIndex: number,
+) {
+  const openingLineStart = source.lastIndexOf("\n", startIndex - 1) + 1;
+  const openingLineEndCandidate = source.indexOf("\n", startIndex);
+  const openingLineEnd = openingLineEndCandidate >= 0
+    ? openingLineEndCandidate
+    : source.length;
+  const closingLineStart = source.lastIndexOf("\n", endIndex - 1) + 1;
+  const closingLineEndCandidate = source.indexOf("\n", endIndex + 1);
+  const closingLineEnd = closingLineEndCandidate >= 0
+    ? closingLineEndCandidate
+    : source.length;
+  const opener = parseStandaloneBracketDisplayMathDelimiterLine(
+    source.slice(openingLineStart, openingLineEnd).replace(/\r$/, ""),
+  );
+  const closer = parseStandaloneBracketDisplayMathDelimiterLine(
+    source.slice(closingLineStart, closingLineEnd).replace(/\r$/, ""),
+  );
+  return opener?.kind === "open" && closer?.kind === "close";
+}
+
+function normalizeStandaloneBracketDisplayMathBlocks(value: string) {
+  if (!value.includes("\\[")) {
+    return value;
+  }
+
+  const lines = value.split(/\r?\n/);
   let changed = false;
-  let normalized = value.replace(
+
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
+    const opener = parseStandaloneBracketDisplayMathDelimiterLine(lines[lineIndex] ?? "");
+    if (opener?.kind !== "open") {
+      continue;
+    }
+
+    let closingLineIndex = -1;
+    for (
+      let candidateIndex = lineIndex + 1;
+      candidateIndex < lines.length;
+      candidateIndex += 1
+    ) {
+      const candidate = parseStandaloneBracketDisplayMathDelimiterLine(
+        lines[candidateIndex] ?? "",
+      );
+      if (!candidate) {
+        continue;
+      }
+      if (candidate.kind === "open" || candidate.prefix !== opener.prefix) {
+        break;
+      }
+      closingLineIndex = candidateIndex;
+      break;
+    }
+
+    if (closingLineIndex < 0) {
+      continue;
+    }
+
+    const expression = lines
+      .slice(lineIndex + 1, closingLineIndex)
+      .map((line) =>
+        opener.prefix && line.startsWith(opener.prefix)
+          ? line.slice(opener.prefix.length)
+          : line,
+      )
+      .join("\n")
+      .trim();
+    if (!looksLikeInlineLatexExpression(expression)) {
+      continue;
+    }
+
+    lines[lineIndex] = `${opener.prefix}$$`;
+    lines[closingLineIndex] = `${opener.prefix}$$`;
+    changed = true;
+    lineIndex = closingLineIndex;
+  }
+
+  return changed ? lines.join("\n") : value;
+}
+
+function normalizeCommonMathDelimiters(value: string) {
+  let normalized = normalizeStandaloneBracketDisplayMathBlocks(value);
+  let changed = normalized !== value;
+  normalized = normalized.replace(
     /(\\+)\(\s*([^\n]*?)\s*(\\+)\)/g,
     (
       match,
@@ -486,6 +634,12 @@ function normalizeCommonMathDelimiters(value: string) {
       if (!hasSafeDisplayLatexWrapperBoundary(source, endIndex)) {
         return match;
       }
+      // A standalone pair that survived the line-aware pass is unmatched,
+      // nested, or crosses Markdown containers. Keep it intact instead of
+      // letting this generic fallback flatten its line prefixes.
+      if (isStandaloneBracketDisplayMathWrapper(source, offset, endIndex)) {
+        return match;
+      }
       changed = true;
       if (isInlineMathWrapperInProseContext(source, offset, endIndex)) {
         return `$${expression}$`;
@@ -494,9 +648,13 @@ function normalizeCommonMathDelimiters(value: string) {
     },
   );
 
+  const dollarMathRanges = collectDollarMathRanges(normalized);
   normalized = normalized.replace(
     /[（(]\s*(\\[A-Za-z][^()\n（）]*?)\s*[）)]/g,
     (match, inner: string, offset: number, source: string) => {
+      if (isInsideDollarMathRange(dollarMathRanges, offset)) {
+        return match;
+      }
       if (!looksLikeInlineLatexExpression(inner)) {
         return match;
       }

--- a/src/features/messages/components/Markdown.math-rendering.test.tsx
+++ b/src/features/messages/components/Markdown.math-rendering.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { cleanup, render, waitFor } from "@testing-library/react";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { normalizeMarkdownMathForMessage } from "../../markdown/markdownMath";
 import { Markdown, prewarmKatexAssets } from "./Markdown";
 
 describe("Markdown math rendering", () => {
@@ -254,6 +255,64 @@ describe("Markdown math rendering", () => {
     await waitFor(() => {
       expect(container.querySelectorAll(".katex-display").length).toBeGreaterThanOrEqual(2);
     });
+  });
+
+  it("preserves ordered-list boundaries for multiline bracket display math", async () => {
+    const value = [
+      "1. 准备两个模板：",
+      "   \\[",
+      "   B_0,\\qquad B_{180}=R_\\pi B_0;",
+      "   \\]",
+      "",
+      "2. 比较两个分数：",
+      "   \\[",
+      "   \\Delta=|s_0-s_{180}|;",
+      "   \\]",
+      "",
+      "后续正文必须保持普通文本。",
+    ].join("\n");
+
+    const { container } = render(
+      <Markdown value={value} className="markdown" codeBlockStyle="message" />,
+    );
+
+    await waitFor(() => {
+      expect(container.querySelectorAll(".katex, .katex-error").length).toBeGreaterThan(0);
+    });
+    expect(container.querySelectorAll(".katex-display").length).toBe(2);
+    expect(container.querySelector(".katex-error")).toBeFalsy();
+    expect(container.textContent).toContain("后续正文必须保持普通文本。");
+    expect(
+      Array.from(container.querySelectorAll(".katex")).some((node) =>
+        node.textContent?.includes("后续正文必须保持普通文本。"),
+      ),
+    ).toBe(false);
+  });
+
+  it("does not rewrap parenthesized latex inside bracket display math", async () => {
+    const value = [
+      "\\[",
+      "(\\theta,t_x,t_y),",
+      "\\]",
+    ].join("\n");
+    const normalized = normalizeMarkdownMathForMessage(value);
+
+    expect(normalized).toContain([
+      "$$",
+      "(\\theta,t_x,t_y),",
+      "$$",
+    ].join("\n"));
+    expect(normalized).not.toContain("$\\theta,t_x,t_y$");
+
+    const { container } = render(
+      <Markdown value={value} className="markdown" codeBlockStyle="message" />,
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector(".katex-display")).toBeTruthy();
+    });
+    expect(container.querySelector(".katex-error")).toBeFalsy();
+    expect(container.querySelector(".katex-display .katex")).toBeTruthy();
   });
 
   it("does not double-wrap existing multi-line display math blocks", async () => {


### PR DESCRIPTION
## Summary

- 修复消息 Markdown 与文件预览在兼容 `\\[...\\]` display math 时丢失 Markdown list / blockquote container prefix 的问题。
- 防止后续 plain-parentheses heuristic 在已经建立的 `$...$` / `$$...$$` math range 内再次注入 dollar delimiters。
- 保持当前架构：消息区与文件预览继续复用 shared pure normalizer；canonical message、Codex JSONL、文件原文和 lightweight streaming path 均不改变。
- 增加 ordered list、blockquote、unmatched / incompatible delimiter、nested wrapping、DOM KaTeX rendering 与 file-preview `lineMap` 回归覆盖。

## Reproduction

将下面内容作为一条消息交给 production `Markdown` component 渲染：

```md
1. Prepare:
   \[
   B_0,\qquad B_{180}=R_\pi B_0;
   \]

2. Compare:
   \[
   \Delta=|s_0-s_{180}|;
   \]

Following prose must stay outside math.
```

修复前，第一个 block 会被等效转换为：

```md
1. Prepare:
   $$
B_0,\qquad B_{180}=R_\pi B_0;
$$
```

opening delimiter、formula body 和 closing delimiter 因而落入不同的 Markdown container level。`remark-math` 可能继续与后面的 delimiter 跨段配对，把 subsequent prose 一并吞进 math node。

另一个可独立复现的 composition failure 是：

```md
\[
(\theta,t_x,t_y),
\]
```

修复前会被多 pass normalization 处理成：

```md
$$
$\theta,t_x,t_y$,
$$
```

KaTeX 随后报错：`Can't use function '$' in math mode`。

## Root cause

1. 原有 generic cross-line replacement 用 capture 重新拼接 display block，只保留 opener 前的 whitespace，却丢失 formula body 与 closer 的 list / blockquote prefix。
2. normalizer 是 sequential multi-pass pipeline；前一 pass 建立 `$$...$$` 后，后一 pass 仍把 range 内的 parenthesized LaTeX 当作 prose，再次包裹为 `$...$`。

## Fix

- 新增 line-aware standalone bracket display pass，只在 opener / closer 拥有完全相同的 whitespace / blockquote prefix 时原位替换 delimiter line。
- unmatched、nested 或跨 container 的 standalone delimiter 保持原样，generic fallback 不再扁平化这些候选。
- 在 plain-parentheses heuristic 前收集既有 dollar math ranges，并跳过 range 内候选，保证 normalization idempotence。
- delimiter conversion 不插入或删除 source line，因此 file preview `lineMap` 保持稳定。

## Verification

- `npx vitest run src/features/messages/components/Markdown.math-rendering.test.tsx src/features/files/utils/fileMarkdownDocument.test.ts src/features/files/components/FileMarkdownPreview.test.tsx`
  - 3 test files passed
  - 43 tests passed
- `npm run typecheck`: passed
- `npm run lint`: passed
- `npm run check:large-files`: exit 0；仅报告 latest `main` 上 6 个未触及的既有 finding
- 使用 production `Markdown` component replay Codex session `019f5fd5-25a4-7521-8949-12d9f6c466f3`：0 个 `.katex-error`
- Manual：重新编译 cc-gui 后，原会话中此前失败的公式已正确渲染

## Known baseline failures

`npm run test` 运行到 batch 19 时，由 `src/features/app/components/Sidebar.test.tsx` 的 3 个既有失败停止（44/47 passed）：

1. runtime notice bottom action count：expected `4`, received `2`；
2. folder session creation test 查询 `menuitem`，实际 provider entry 为 `menuitemradio`；
3. catalog-backed pending folder intent test 存在相同 role mismatch。

本分支没有修改 Sidebar、provider menu、依赖或相关测试；standalone rerun 可在 latest `origin/main` 基线上复现同样的 3 个断言失败，因此不属于本 PR regression。

## OpenSpec note

本 PR 包含 proposal、design、tasks、delta spec 与 verification artifact。由于本地环境没有可执行的 `openspec` CLI / repository fallback validator，未声称 strict schema validation 已通过；artifact 已按仓库结构人工核对。