### PR TITLE
chore(gitattributes): enforce LF line endings for agent catalog Markd…

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 src-tauri/resources/curated-skills/**/*.md text eol=lf
+src-tauri/resources/agent-catalogs/**/*.md text eol=lf


### PR DESCRIPTION
…own files

Extend the repository text normalization rules to cover Markdown files under `src-tauri/resources/agent-catalogs/**/*.md`, matching the existing treatment for curated skills.

Consistent LF endings prevent platform-specific CRLF changes, reduce noisy diffs, and keep agent catalog content deterministic across development, packaging, and review environments. This metadata-only change does not alter file contents or runtime behavior.

Constraint: Agent catalog Markdown files must use LF line endings in Git
Confidence: high
Scope-risk: narrow
Tested: Reviewed the updated `.gitattributes` pattern
Not-tested: Runtime behavior, which is unaffected by this change