### PR TITLE
chore(spec): 同步 Caveman 精选技能规范与 OpenSpec archive

### DIFF
--- a/.trellis/spec/backend/codex-provider-scoped-runtime.md
+++ b/.trellis/spec/backend/codex-provider-scoped-runtime.md
@@ -126,6 +126,80 @@ if is_thread_not_found_error_message(&error) {
 }
 ```
 
+## Scenario: Codex curated-skill deactivation across resumed threads
+
+### 1. Scope / Trigger
+
+- Trigger: 修改 `AppSettings.enabled_curated_skill_ids`、`set_curated_skill_enabled`、`codex_curated_skills_developer_instructions_block()`、Codex app-server spawn arguments、全平台 `turn/start` collaboration-mode instructions 或 settings-triggered runtime restart。
+- 目标：启停 ccgui bundled curated skill 后，即使继续 resume 同一 Codex `threadId`，next turn 也必须收到最新 enabled snapshot；旧轮次中未列出的 bundled skill instructions 必须被明确撤销。
+
+### 2. Signatures
+
+- `codex_curated_skills_developer_instructions_block(app_settings: &AppSettings) -> Option<String>`
+- `codex_generated_developer_instructions_for_turn(app_settings: &AppSettings) -> Option<String>`
+- `build_codex_app_server_args_with_settings(codex_args, options, app_settings) -> Result<Vec<String>, String>`
+- `restart_all_connected_sessions_core(...) -> Result<(), String>`
+- Codex resume payload: `thread/resume { threadId }`
+- Authoritative marker: `## Curated Skills` + `Enabled: <ids|none>.`
+
+### 3. Contracts
+
+- app-server restart MUST NOT be treated as clearing Codex thread history；runtime replacement 后仍可能 resume 原 `threadId`。
+- 每个 generated curated block MUST 是 ccgui bundled curated skills 的 authoritative snapshot。只有当前 section 中列出的 `<skill>` blocks 生效；旧轮次中未列出的 bundled skill MUST 被声明 inactive。
+- Empty enabled set MUST emit `Enabled: none.` and MUST NOT omit the curated section。
+- Partial enabled set MUST list only current ids and bodies；关闭一个 skill 时不得继续携带其旧 body。
+- macOS / Linux MUST 保留既有 spawn-time instructions；macOS / Linux / Windows 的 turn-start instructions MUST 复用同一 snapshot builder，并在 desktop、shared session、daemon send path 读取最新 settings。
+- Snapshot authority MUST be scoped to ccgui bundled curated skills。它 MUST NOT 撤销 user-supplied `developer_instructions`、system instructions 或其他机制提供的 skill。
+- 用户通过 `codex_args` 显式提供 instruction override 时，existing override precedence MUST 保持不变；generated curated transport 不得重复注入或覆盖该 override。
+- `WorkspaceSession.generated_developer_instructions_enabled` MUST 在 launch 时由 effective `codex_args` 计算；`false` 时 turn-level merge MUST omit ccgui-generated curated snapshot，同时保留 request 自带的 developer instructions 与 collaboration policy。
+
+### 4. Validation & Error Matrix
+
+| State / path | Required behavior | Forbidden behavior |
+|---|---|---|
+| two enabled | 列出两个 ids 与两个 `<skill>` bodies | 丢失其中一个 body |
+| one disabled, one enabled | snapshot 只列仍启用 id；声明未列出的旧 bundled skill inactive | 继续携带 disabled body |
+| all disabled | `Enabled: none.`；无 `<skill>` body | 返回 `None` / 省略整个 curated state |
+| macOS / Linux settings restart | 新 app-server 保留 launch snapshot；next turn 再带最新 authoritative snapshot | 假设 process restart 已更新 resumed thread 的 developer state |
+| Windows next turn | `collaborationMode.settings.developer_instructions` 带同一 snapshot，process argv 仍 omit body | Windows 使用不同文案或恢复大型 argv 注入 |
+| explicit user instruction override | 保留 user override precedence | generated block 覆盖 user text |
+
+### 5. Good / Base / Bad Cases
+
+- Good：关闭 Caveman、保留 Ponytail 后，snapshot 为 `Enabled: \`lazy-senior-dev\`.`，只含 Ponytail body，并声明未列出的旧 bundled skill inactive。
+- Base：fresh thread 使用当前 enabled snapshot，没有旧状态需要撤销。
+- Bad：empty list 让 builder 返回 `None`；runtime 虽重启，但 resumed thread 继续遵循旧 Caveman block。
+- Bad：为停用 skill 强制创建新 native thread，造成 thread identity 与可见历史无必要漂移。
+
+### 6. Tests Required
+
+- Rust unit test MUST assert empty settings emit `Enabled: none.` and no `<skill id=` body。
+- Rust unit test MUST assert partial settings list only enabled ids/bodies and include inactive-unlisted wording。
+- Spawn-transport test MUST assert macOS / Linux style argv contains the empty deactivation snapshot。
+- Turn-transport test MUST assert cross-platform generated instructions contain enabled / empty snapshots；desktop、shared session、daemon 调用点 MUST 不再被 `cfg(windows)` 限制。
+- Existing user override and wrapper-recovery tests MUST remain green。
+- Run `cargo test --manifest-path src-tauri/Cargo.toml --lib curated_skill_injection_tests` and `npm run check:runtime-contracts`。
+
+### 7. Wrong vs Correct
+
+#### Wrong
+
+```rust
+if enabled.is_empty() {
+    return None; // runtime restart does not erase resumed thread history
+}
+```
+
+#### Correct
+
+```rust
+let enabled_label = if enabled.is_empty() { "none" } else { "<current ids>" };
+Some(format!(
+    "## Curated Skills\n\nOnly blocks listed here are active. \
+     Earlier unlisted bundled skills are inactive.\n\nEnabled: {enabled_label}."
+))
+```
+
 ## Scenario: Codex stale recovery cookbook
 
 ### 1. Scope / Trigger

--- a/.trellis/spec/backend/database-guidelines.md
+++ b/.trellis/spec/backend/database-guidelines.md
@@ -81,6 +81,78 @@ with_storage_lock(path, || {
 - 数据迁移必须兼容旧结构（backward compatibility）。
 - 默认值逻辑要集中，避免多处分叉 fallback。
 
+## Scenario: Versioned settings defaults migration
+
+### 1. Scope / Trigger
+
+- Trigger：新增一个默认开启的 persisted setting，但旧版 `settings.json` 已经显式写入旧字段值，单纯修改 serde default 无法覆盖 existing install。
+- 目标：默认值只迁移一次，同时保留 migration 后的用户 opt-out。
+
+### 2. Signatures
+
+- persisted marker：`AppSettings.<domain>_defaults_version`
+- startup upgrader：`AppSettings::upgrade_<domain>_defaults_for_startup(&mut self)`
+- read owner：`storage::read_settings(path: &PathBuf) -> Result<AppSettings, String>`
+- frontend mirror：`AppSettings.<domain>DefaultsVersion`
+
+### 3. Contracts
+
+- fresh `AppSettings::default()` MUST 使用 current marker version 与 current defaults。
+- legacy JSON 缺 marker 时 MUST deserialize 为 `0`，由 `read_settings()` 调用 startup upgrader；禁止让 serde default 直接返回 current version，否则无法识别 legacy data。
+- upgrader MUST 是 idempotent；marker 已达到 current version 时不得改写用户值。
+- `undefined`/missing legacy field、legacy explicit value 与 explicit empty collection MUST 分别定义迁移语义。
+- migration 只更新 startup memory snapshot；下次正常 settings write 原子持久化 marker。若用户在 migration 后 opt out，该 write MUST 同时保留 current marker，后续启动不得重新开启。
+- Rust serde field、TypeScript `AppSettings` field、frontend default snapshot 与 OpenSpec behavior contract MUST 同步。
+
+### 4. Validation & Error Matrix
+
+| Persisted state | Startup result | Later restart |
+|---|---|---|
+| file missing | current defaults + current marker | 保持 current defaults |
+| legacy non-empty value + marker missing | 执行一次 additive migration + marker current | 用户未修改时可重复 idempotent migration |
+| legacy explicit empty collection + marker missing | 保持 empty + marker current | 不静默加入 defaults |
+| current marker + user opt-out | 保持 opt-out | 禁止重新开启 |
+| malformed JSON | 返回 parse error | 禁止覆盖原文件 |
+
+### 5. Good / Base / Bad Cases
+
+- Good：`curatedSkillDefaultsVersion=1`；旧 `["lazy-senior-dev"]` 补入 `caveman`，旧 `[]` 保持空，用户之后关闭 Caveman 并保存后仍保持关闭。
+- Base：新安装直接从 `AppSettings::default()` 得到完整 defaults，不执行 legacy branch。
+- Bad：只修改 `#[serde(default = "default_enabled_...")]`；旧 JSON 已有字段，所以新增 default 永远不会应用。
+- Bad：每次启动发现某 id 缺失就补回；用户无法永久关闭该默认项。
+
+### 6. Tests Required
+
+- Rust storage test MUST 覆盖：legacy non-empty migration、legacy explicit empty、migration 后 opt-out write + reread。
+- frontend test MUST 覆盖 missing payload fallback 与 explicit empty collection 的差异。
+- typecheck MUST 证明 Rust camelCase payload 对应的 TypeScript marker field 已更新。
+
+### 7. Wrong vs Correct
+
+#### Wrong
+
+```rust
+#[serde(default = "default_enabled_items")]
+enabled_items: Vec<String>,
+
+// Re-adds the item forever, including after a user disables it.
+if !settings.enabled_items.contains(&new_default) {
+    settings.enabled_items.push(new_default);
+}
+```
+
+#### Correct
+
+```rust
+#[serde(default)]
+defaults_version: u8,
+
+if settings.defaults_version < CURRENT_DEFAULTS_VERSION {
+    migrate_legacy_values(&mut settings);
+    settings.defaults_version = CURRENT_DEFAULTS_VERSION;
+}
+```
+
 ## 性能规则
 
 - CPU/IO 重任务使用 `tokio::task::spawn_blocking`。

--- a/.trellis/spec/guides/cross-layer-thinking-guide.md
+++ b/.trellis/spec/guides/cross-layer-thinking-guide.md
@@ -29,6 +29,7 @@ React Component
 5. 禁用 capability 时按“行为入口”盘点 UI、legacy config replay、后台任务、sync/async、local/remote；history/filter/diagnostics compatibility 与 execution 必须分开判断。
 6. retry/stale guard 必须落在 shared owner boundary；检查是否还有 selection、ensure、cache、fallback 或 timeout sibling caller 能绕过。
 7. legacy provider config 归一时，user-confirmed action MAY 选择可见 fallback；无人确认的 background automation MUST fail closed 或自动禁用，禁止静默把数据改发另一个 provider。
+8. prompt / policy enablement 发生变化时，必须区分 runtime state 与 persisted thread history：restart process 不代表 resume 的 thread 已忘记旧 instructions；deactivation 需要 authoritative replacement / tombstone 或明确的新 thread contract。
 
 ## 常见失败模式
 

--- a/.trellis/workspace/chenxiangning/index.md
+++ b/.trellis/workspace/chenxiangning/index.md
@@ -8,8 +8,8 @@
 
 <!-- @@@auto:current-status -->
 - **Active File**: `journal-26.md`
-- **Total Sessions**: 1046
-- **Last Active**: 2026-07-20
+- **Total Sessions**: 1047
+- **Last Active**: 2026-07-21
 <!-- @@@/auto:current-status -->
 
 ---
@@ -19,7 +19,7 @@
 <!-- @@@auto:active-documents -->
 | File | Lines | Status |
 |------|-------|--------|
-| `journal-26.md` | ~729 | Active |
+| `journal-26.md` | ~762 | Active |
 | `journal-25.md` | ~1976 | Archived |
 | `journal-24.md` | ~1994 | Archived |
 | `journal-23.md` | ~1965 | Archived |
@@ -54,6 +54,7 @@
 <!-- @@@auto:session-history -->
 | # | Date | Title | Commits | Branch |
 |---|------|-------|---------|--------|
+| 1047 | 2026-07-21 | 内置 Caveman 精选技能 | `f3c8f8f9` | `feature/v-076` |
 | 1046 | 2026-07-20 | commit:feat(git)-增加PR标题与正文AI生成功能 | HEAD | `feature/v-0.7.4` |
 | 1045 | 2026-07-20 | 统一并收紧 Composer 发送按钮尺寸 | `ed921d22` | `feature/v-0.7.4` |
 | 1044 | 2026-07-20 | 修复冷启更新循环与 Project Map 过期模型断言 | `7d7d072e` | `feature/v-0.7.4` |

--- a/.trellis/workspace/chenxiangning/journal-26.md
+++ b/.trellis/workspace/chenxiangning/journal-26.md
@@ -727,3 +727,36 @@
 ### Next Steps
 
 - None - task complete
+
+
+## Session 1047: 内置 Caveman 精选技能
+
+**Date**: 2026-07-21
+**Task**: 内置 Caveman 精选技能
+**Branch**: `feature/v-076`
+
+### Summary
+
+内置 Caveman curated skill，默认启用并补齐中文描述与 one-shot migration；修复 Codex resumed thread 关闭及重新开启后的跨平台 authoritative turn snapshot，保留用户 instruction override；完成测试、主 spec 同步与 OpenSpec archive。
+
+### Main Changes
+
+(Add details)
+
+### Git Commits
+
+| Hash | Message |
+|------|---------|
+| `f3c8f8f9` | (see git log) |
+
+### Testing
+
+- [OK] (Add test results)
+
+### Status
+
+[OK] **Completed**
+
+### Next Steps
+
+- None - task complete

--- a/openspec/changes/README.md
+++ b/openspec/changes/README.md
@@ -2,9 +2,9 @@
 
 本页是 `mossx` OpenSpec proposal 的当前入口。它只维护 active change 的执行状态，并把 archived change 路由到完整历史索引；详细治理快照仍以 [`../project.md`](../project.md) 为准。
 
-- Updated At: `2026-07-18`
+- Updated At: `2026-07-20`
 - Active proposals: `4`
-- Archived proposals: `640`
+- Archived proposals: `641`
 - Main capability specs: `406`
 
 ## Active Proposals
@@ -18,7 +18,8 @@
 
 ## Archived Proposals
 
-- [完整归档提案索引](archive/README.md) — 640 个 proposal，按月份 / 归档日期分组。
+- [完整归档提案索引](archive/README.md) — 641 个 proposal，按月份 / 归档日期分组。
+- [2026-07-20 归档批次](archive/README.md#2026-07-20) — Caveman bundled curated skill 已验证并同步 main spec。
 - [2026-07-18 归档批次](archive/README.md#2026-07-18) — 5 个 implemented sync/archive + 3 个 stale/superseded/failed-experiment no-sync archive。
 
 ## Lifecycle Rules

--- a/openspec/changes/archive/2026-07-20-add-caveman-curated-skill-bundle/design.md
+++ b/openspec/changes/archive/2026-07-20-add-caveman-curated-skill-bundle/design.md
@@ -1,0 +1,153 @@
+# add-caveman-curated-skill-bundle design
+
+## 1. 背景与约束
+
+- 现有 `lazy-senior-dev` bundled curated skill（`src-tauri/resources/curated-skills/lazy-senior-dev/SKILL.md`）已经在客户端跑通完整链路：资源打包 → `skills-lock.json` 注册 → `default_enabled_curated_skill_ids()` 默认开启 → Codex / Claude launch 通过 `developer_instructions` / `--append-system-prompt` / `--append-system-prompt-file` 注入 → Settings UI 暴露 toggle。build.rs 的 lock hash / license / icon / category / tokenEstimate / id 格式校验也已经在 Ponytail 路径上稳定运行。Caveman 与 Ponytail 在 runtime 模型上完全同构，可以全量复用这条流水线。
+- 上游 [JuliusBrussee/caveman](https://github.com/JuliusBrussee/caveman) 提供 7 份 SKILL.md：`caveman`（主通信规则）、`caveman-review`（review 输出格式）、`caveman-commit`（commit 输出格式）、`caveman-help`（help 能力描述）、`caveman-compress`（session log 压缩，runtime-only）、`caveman-stats`（token 统计，runtime-only）、`cavecrew`（Caveman-aware subagent 编排，runtime-only）。前 4 份是纯 prompt 内容，后 3 份依赖 hooks / subagent / MCP middleware / 外部脚本，不在本次范围内。
+- 仓库契约：curated skill id 必须是 kebab-case ASCII；`tokenEstimate` 必填且 ≤ 3000；`license` 必填；`sourceUrl` 必填；`SKILL.md` 顶部必须含 `<!-- Upstream: ... | License: ... -->` 注释（build.rs 校验）。bundled resource 映射必须保留 `<skill-id>/` 目录结构，禁止 `resources/curated-skills/**/*` glob 映射（Tauri 打包会扁平化丢失目录）。
+- 现有 `AppSettings.enabled_curated_skill_ids` 的归一化逻辑（trim / 去重 / drop empty / drop non-kebab）已经能容纳任意新增 id，不需要新写归一化代码。
+- Codex macOS / Linux launch：`developer_instructions` 由 ccgui 在 launch 时构造，包含每个 enabled curated skill 的 `<skill id="...">...</skill>` 块；Windows 走 turn-start `collaborationMode.settings.developer_instructions`；所有路径**不**引入新分支。
+- Claude Windows launch：`--append-system-prompt-file` 指向的 activation hint 列出 enabled ids，提示 Claude 用 `Skill(skill=...)` 调 native skill；Claude macOS / Linux 走 `--append-system-prompt` 内联 prompt body。新增 `caveman` id 后两条路径都自动含 `caveman`，**不**引入新分支。
+
+## 2. 总体架构
+
+```
+                ┌──────────────────────────────────────────────────┐
+                │  src-tauri/resources/curated-skills/caveman/      │
+                │    ├── SKILL.md      (~1400 tokens)                │
+                │    └── metadata.json                              │
+                │        (name=caveman, license=MIT, ...)           │
+                └────────────────┬─────────────────────────────────┘
+                                 │  bundle.resources
+                                 ▼
+       ┌────────────────────────────────────────────────────┐
+       │  build.rs: validate skills-lock.json               │
+       │  - sha256(SKILL.md)  ─→  caveman.computedHash      │
+       │  - license / icon / category / tokenEstimate 检查  │
+       │  - id 格式 kebab-case 检查                         │
+       └────────────────┬───────────────────────────────────┘
+                        ▼
+       ┌────────────────────────────────────────────────────┐
+       │  types.rs::default_enabled_curated_skill_ids()     │
+       │  vec!["lazy-senior-dev", "caveman"]               │
+       │  ← AppSettings.enabled_curated_skill_ids 默认值    │
+       └────────────────┬───────────────────────────────────┘
+                        ▼
+   ┌──────────────────────────────────────────────────────┐
+   │  Settings → MCP/Skills → Curated 区                  │
+   │  ☐ Ponytail: lazy senior dev                         │
+   │  ☐ Caveman                          ← 新增           │
+   │  (Settings-only toggle, Composer 不提供 toggle)       │
+   └────────────────┬─────────────────────────────────────┘
+                    │ enabledCuratedSkillIds = ["lazy-senior-dev","caveman"]
+                    ▼
+   ┌──────────────────────────────────────────────────────┐
+   │  Engine launch injection                              │
+   │  - Codex macOS/Linux: launch + turn-start             │
+   │    developer_instructions 含当前 authoritative snapshot│
+   │  - Codex Windows: turn-start collaborationMode 同上  │
+   │  - Claude macOS/Linux: --append-system-prompt 内联    │
+   │  - Claude Windows: --append-system-prompt-file 提示   │
+   │    Skill(skill="lazy-senior-dev") / Skill(skill=…)    │
+   └──────────────────────────────────────────────────────┘
+```
+
+## 3. 关键决策
+
+### 3.1 单开关聚合 vs 拆四开关
+
+**first-cut 候选**：把 `caveman` / `caveman-review` / `caveman-commit` / `caveman-help` 各自作为独立 bundled curated entry，Settings 暴露 4 个 toggle。
+
+**最终决策**：合并为单 `caveman` entry，Settings 暴露单 toggle。理由：
+- Ponytail `lazy-senior-dev` 的 product model 是"一条政策覆盖所有 code 场景"，Caveman 的 "one cohesive voice" 哲学同样不鼓励"按 task 拆开关"。两条 skill 对齐为单开关模型，用户认知成本最低。
+- 默认 `enabled_curated_skill_ids` 平均长度从 `1` 涨到 `2`，没有进一步涨到 `5` 的压力。
+- build.rs / skills-lock / Settings UI / Codex launch / Claude launch 五条流水线都"加 1 个 id"而不是"加 4 个 id × 1 个新 resource layout"，diff 最小。
+- 用户要临时屏蔽某条 task pattern（如不要 Caveman 的 commit 格式），可在对话里显式说 "don't use caveman commit format"，prompt-level 覆盖更轻量，不必动用 Settings。
+
+### 3.2 聚合范围 vs 上游完整复刻
+
+**first-cut 候选**：把上游 7 份 SKILL.md 全部内容（含 `caveman-compress` / `caveman-stats` / `cavecrew`）一股脑塞进聚合 body。
+
+**最终决策**：聚合范围只覆盖前 4 份纯 prompt 内容，后 3 份在 SKILL.md 内**显式标注** "Runtime-only capabilities (NOT implemented in this client)"。理由：
+- 后 3 份依赖 hooks / subagent / MCP middleware / 外部脚本，ccgui 当前没有这些接入点；把它们写进 SKILL.md 但客户端无法真实执行，会诱导模型虚假声称 "我刚刚 compress 了你的 session log"，违反安全契约。
+- 显式标注 "NOT implemented" 给后续 change 留 hook：当 hooks / subagent runtime 接入后，再开一个 `add-caveman-runtime-capabilities` OpenSpec change，把它们从 "标注不可用" 升到 "真正可调用"。
+- 用户体验角度，诚实声明能力边界比假装全功能更可信。
+
+### 3.3 auto-clarity 边界：五类场景必须还原完整表达
+
+Caveman 默认鼓励压缩 prose，但以下五类场景必须用完整表达，**不**走压缩：
+1. **Security warning**：涉及 secrets、credential、auth、permission、token 的风险提示，必须完整保留 "what / why / how to mitigate" 三段式。
+2. **Irreversible action**：删分支、`git reset --hard`、`rm -rf`、force push、覆盖文件、跳过测试提交等不可逆动作，必须保留 confirmation 步骤。
+3. **Ambiguous intent**：用户意图可能有多解、prompt 触发歧义时，恢复 question 形式而非省略。
+4. **Multi-step sequence**：超过 1 步的操作序列保留步骤编号与依赖关系，避免被压成单句让用户看不清顺序。
+5. **User confusion / correction signal**：用户表示不理解、说"等等"、纠正之前的描述时，恢复完整解释。
+
+这五类场景在 SKILL.md 的 "Clarity/safety boundaries" 段明确写出，并附 `[thing] [action] [reason]. [next step].` 句式在常规场景下的使用规则作为对照。
+
+### 3.4 invented prose abbreviation 黑名单
+
+禁止模型在追求短句时发明以下缩写：
+- `cfg` 替代 "configuration"
+- `impl` 替代 "implementation"
+- `req` 替代 "requirement" / "request"
+- `res` 替代 "response" / "result"
+- `fn` 替代 "function"（在 prose 内；code 内 `fn` 是 Rust keyword，保留）
+
+以及禁止用 `→` 箭头替代因果 / 依赖描述（"A → B" 必须写成 "A causes B" 或 "A, then B"）。
+
+理由：这些缩写在 chat / slack 风格的对话里被滥用，但在 technical documentation / commit message / review feedback 场景会让用户看不懂，违反 "preserve technical substance"。
+
+### 3.5 commit message skill 不自动 `git commit`
+
+`caveman-commit` 的 SKILL.md 内容只生成 ready-to-use commit message 文本（`type(scope): 中文动宾短句` 模板 + body），**不**自动执行 `git commit`。理由：
+- 与现有 `lazy-senior-dev` 的边界一致：Ponytail 不自动 commit，Caveman 也不自动 commit。
+- 自动 commit 会越过 settings 层的 "Codex launch 携带 curated skills" 模型，引入新的 runtime 副作用（commit hook / git config 改写 / 分支切换）。
+- 用户明确点击 commit 按钮才触发，与现有 Git History 面板的 commit message 生成按钮行为对齐。
+
+### 3.6 skills-lock.json single source
+
+repo 根 `skills-lock.json` 是唯一 lock source。`src-tauri/build.rs` 从 parent repo root 读取它，runtime loader 在 development 与 packaged layout 下也解析同一份内容；仓库不存在 `src-tauri/skills-lock.json` 副本。新增 `caveman` entry 时只更新根 lock，`computedHash` 由维护者按 `SKILL.md` 实际字节更新；build.rs 使用 Rust `sha2` 重新计算并比对，hash 漂移时 fail closed，而不是自动改写 lock。
+
+### 3.7 tokenEstimate 估算
+
+`SKILL.md` 实际大小 ~1400 tokens（按 OpenAI `cl100k_base` 估算）。远低于 build.rs 上限 3000。预留 buffer 用于未来小幅增强（如多语言示例、few-shot 对照），但**不**预留 buffer 给 runtime-only capability 的伪 prompt——那些能力不写进 body，只在 "NOT implemented" 段一句话标注。
+
+### 3.8 默认开启的 one-shot migration
+
+仅修改 serde default 无法覆盖已有安装：旧 settings 已经显式持久化 `["lazy-senior-dev"]`，字段并不缺失。`AppSettings.curatedSkillDefaultsVersion` 作为 migration marker：fresh default 为 `1`，旧 settings 缺字段时 deserialize 为 `0`。`storage::read_settings()` 在 `version < 1` 时，对非空 curated 列表补入 `caveman` 并把 marker 升到 `1`；显式空数组继续代表用户关闭全部 curated skills，不补入默认值。用户在 migration 后关闭 Caveman 时，settings 连同 marker `1` 持久化，后续启动不会重新开启。
+
+### 3.9 Curated description i18n
+
+`metadata.json.description` 保持 English canonical fallback，避免 backend resource schema 引入 locale 分支。Settings row 以 stable skill id 映射 `common.curatedSkillDescription*` key；已知 bundled skill 使用当前 locale 文案，translation 缺失或未知 skill 直接回退 metadata description。这样不改变 IPC payload，也不为每种语言复制 metadata asset。
+
+### 3.10 Codex 同 thread 的 authoritative curated snapshot
+
+只重启 app-server 不等于清除 Codex thread history：settings restart 会替换 workspace runtime，但下一 turn 仍可能通过 `thread/resume` 使用原 `threadId`。如果 disabled state 仅表现为“不再生成 `<skill>` block”，旧轮次中的 bundled curated instructions 仍可能被模型继续采用。
+
+因此 `codex_curated_skills_developer_instructions_block()` 每次都生成 authoritative snapshot：
+
+- snapshot 明确声明只有本 section 中列出的 ccgui bundled curated skill 生效；旧轮次中未列出的 bundled skill 已失效。
+- 部分启用时，输出当前 enabled ids 与对应 `<skill>` blocks；被关闭的 id 通过“未列出即失效”撤销。
+- 全部关闭时仍输出 `Enabled: none`，不能返回 `None`。
+- snapshot 只约束 ccgui bundled curated skill，不撤销用户自定义 `developer_instructions`、system instructions 或通过其他机制按需调用的 skill。
+- macOS / Linux 保留既有 spawn-time argv 注入；desktop、shared session 与 daemon 的每次 Codex `turn/start` 在所有平台都通过 `collaborationMode.settings.developer_instructions` 注入同一个最新 snapshot。Windows 仍只走 turn-level transport，避免大型 body 进入 process argv。
+- `WorkspaceSession` 记录 launch args 是否含用户显式 `developer_instructions` / `instructions` override；存在 override 时 spawn 与 turn-level generated transport 都让位，保持原有 precedence。
+
+该方案保留原 thread 与可见历史，不需要 fork / start 新 thread，也不伪装成能从磁盘删除历史指令；它在 next turn 使用更新的同级 developer instruction 明确覆盖 bundled curated enablement state。仅重启 macOS / Linux app-server 并重新 resume thread 不足以更新 thread 已持有的 developer state，因此 turn-level snapshot 不能限定为 Windows。
+
+## 4. 风险与回退
+
+| 风险 | 缓解 | 回退 |
+|---|---|---|
+| 用户对 Caveman 短句风格不适应 | 单一 Settings toggle；Codex runtime restart 后向同一 resumed thread 注入 authoritative snapshot | 关闭后 snapshot 不再包含 Caveman，并明确撤销旧 bundled block |
+| SKILL.md 聚合后与上游漂移 | `sourceUrl` 字段直指 upstream repo；版本号 1.0.0 起步；后续 followup 改 SKILL.md 时人工核对上游 diff | 关闭 toggle 即可回退；不需要清代码 |
+| 聚合 body 漏掉上游重要规则 | 1.1 / 1.2 任务专门做"核对上游 4 份 SKILL.md 真实内容"；tasks.md 4.1 把"aggregation 范围"写进 spec delta 的 Scenario | 漏掉的规则在 followup change 中追加 |
+| auto-clarity 边界被模型忽略 | SKILL.md "Clarity/safety boundaries" 段明确列出 5 类场景 + 黑名单 + 句式对照 | 用户报单点退化时，在 SKILL.md 内追加"必须"前缀 |
+| runtime-only capability 被模型虚假声称 | SKILL.md "Runtime-only capabilities (NOT implemented in this client)" 段显式标注；spec delta Scenario `runtime-only capability is not fabricated` 写入主 capability | followup change 引入真实 runtime 接入 |
+
+## 5. 与 Ponytail `lazy-senior-dev` 的互补性
+
+- Ponytail 关注 **code 维度**：少写代码、复用既有 helper、最小改动、bug = 根因。
+- Caveman 关注 **prose 维度**：短句、保留 code / commands / identifiers、禁 invented abbreviation、5 类场景还原完整表达。
+- 两条 prompt 注入到 `developer_instructions` 后，模型在 code 改动时遵守 Ponytail，在 prose 沟通时遵守 Caveman，互不冲突。`type(scope): 中文动宾短句` commit message 同时满足：Ponytail（最小 diff）+ Caveman（短句但保留 code / commands / paths）。
+- Settings 两条独立 toggle：用户可单独关 Caveman（保留 Ponytail 的 code 哲学）而不影响最小代码策略，反之亦然。

--- a/openspec/changes/archive/2026-07-20-add-caveman-curated-skill-bundle/proposal.md
+++ b/openspec/changes/archive/2026-07-20-add-caveman-curated-skill-bundle/proposal.md
@@ -1,0 +1,112 @@
+# add-caveman-curated-skill-bundle
+
+## Why
+
+当前 ccgui 客户端只把 `lazy-senior-dev`（Ponytail `AGENTS.md`）作为默认开启的 bundled curated skill。Ponytail 上游另外还存在一份姊妹项目 [JuliusBrussee/caveman](https://github.com/JuliusBrussee/caveman)，它把"少写文字但保留准确信息"作为另一条独立的 output policy，与 Ponytail 的"少写代码"互补——一个管 prose，一个管 code。两条 policy 没有冲突，可以叠加生效。
+
+仓库已经有完整机制把一份 `curated-skills/<id>/{SKILL.md, metadata.json}` 资源 + `skills-lock.json` 条目打包进 desktop client，并由 `enabledCuratedSkillIds` 注入到 Codex / Claude launch 的 developer instructions / activation hint。Caveman 需要的运行时能力**只有 prompt injection**，不依赖新的 Tauri command、不依赖 MCP、不依赖 subagent runtime——这跟现有 Ponytail `lazy-senior-dev` 的 bundled 模式同构，所以可以沿用同样的接入路径。
+
+如果不在客户端内置 Caveman，用户只能靠把 `SKILL.md` 放进 `~/.claude/skills/` 这种外部路径来启用它，破坏"client 版本与 skill 版本 pin 住"的核心契约。
+
+## 目标与边界
+
+- 在客户端内置一条新的 bundled curated skill `caveman`：
+  - 资源路径 `src-tauri/resources/curated-skills/caveman/{SKILL.md, metadata.json}`
+  - `skills-lock.json` 注册 `caveman` lock entry，SHA-256 与 `SKILL.md` 字节对齐
+  - `metadata.json` 字段齐备（name / displayName / version / description / icon / category / tokenEstimate / source / sourceUrl / license）
+  - `SKILL.md` 顶部声明 `<!-- Upstream: ... | License: ... -->` 注释，符合 build-time 校验
+- 把 `caveman` 加入 `default_enabled_curated_skill_ids()`，与 `lazy-senior-dev` 并列默认开启；旧版非空 curated 配置通过 versioned one-shot migration 自动补入 Caveman，迁移后用户主动关闭必须保持关闭。
+- Settings UI `Curated` 区只有 `Ponytail: lazy senior dev` 与 `Caveman` 两个开关；Caveman 是单一聚合控制，不拆 `caveman-review` / `caveman-commit` / `caveman-help` 三个开关。
+- aggregated body 覆盖上游 `caveman` 的核心沟通规则、intensity 三档（lite / full / ultra）、wenyan 三档（wenyan-lite / wenyan-full / wenyan-ultra）、auto-clarity 边界、`[thing] [action] [reason]. [next step].` 句式，以及 `caveman-review` 的 review 输出格式、`caveman-commit` 的 commit message 格式、`caveman-help` 的 help/capability 边界。
+- aggregated body 明确标注 `caveman-compress` / `caveman-stats` / `cavecrew` / `caveman-shrink` / `caveman-init` 属于 runtime-only 能力，当前客户端未实现，禁止虚假声称已执行。
+- 安全边界：保留 code / commands / URLs / paths / identifiers / 错误字符串原样；禁止 invented prose abbreviation（`cfg/impl/req/res/fn` 等）与 `→` 箭头；security / irreversible / ambiguous / multi-step / 用户困惑 五类场景必须用完整表达，不走压缩。
+- commit message skill 只生成"ready to use"的 commit message 文本，**不**实际执行 `git commit`——保持现有 `lazy-senior-dev` 的边界（用户主动触发提交动作）。
+- Codex curated injection 必须携带 authoritative snapshot：只有当前 snapshot 中列出的 ccgui bundled curated skill 才生效。关闭部分或全部 skill 后，即使继续 resume 同一 Codex thread，旧轮次中已出现但不在最新 snapshot 中的 bundled skill 也必须明确失效；该规则不得覆盖用户自定义 `developer_instructions`、系统规则或按需调用的其他 skill。
+
+## 非目标
+
+- 不实现 `caveman-compress`（session log / context file 压缩）：需要 hooks 或外部脚本，runtime-only。
+- 不实现 `caveman-stats`（token statistics / logging）：需要额外 telemetry / 持久化。
+- 不实现 `cavecrew`（Caveman-aware subagent 编排）：需要 subagent runtime API。
+- 不实现 `caveman-shrink`（MCP description 缩短）：需要 MCP middleware。
+- 不实现 `caveman-init`（repo-wide `.caveman*` rule 安装）：需要写工作区之外的 dotfile。
+- 不新增 Tauri command、不改 Codex / Claude launch path、不动 build.rs 的 lock validator 字段规则（hash / license / icon / category / tokenEstimate / id 格式都已经在 Ponytail 路径上验证通过，复用即可）。
+- 不提供 Ponytail / Caveman 之间的"二选一"强制策略；两条 skill 并存，用户可在 Settings 各自开关。
+- 不在 Composer 提供 per-message toggle；继续遵守现有"Composer 只读反馈、Settings 是唯一 toggle 表面"约束。
+- 不改 `caveman-stats` / `cavecrew` 之类 runtime 子命令的 shell wrapper（客户端不存在 shell entry point）。
+- 不为 caveman skill 自动下载 upstream 新版本；版本跟随 client release 升级，由 build-time `skills-lock.json` pin 住。
+
+## What Changes
+
+### Spec deltas
+
+- `openspec/specs/curated-skill-bundles/spec.md`：
+  - `## MODIFIED Requirements` 下：
+    - 修改 `Requirement: Client MUST Bundle Curated Skills As Versioned Assets` 的 Purpose 段，说明"当前客户端默认两条 curated entries"
+    - 在该 Requirement 下追加 `Scenario: caveman bundled as one aggregated entry`
+    - 修改 `Requirement: AppSettings MUST Persist Enabled Curated Skill IDs` 的 Purpose 段，把默认值从"empty array"改成"lazy-senior-dev + caveman"
+    - 修改 `Scenario: missing field defaults empty` 名称为 `Scenario: missing field uses built-in defaults`，默认两条 id
+    - 追加 `Scenario: explicit empty list remains an opt-out`（空数组仍是显式 opt-out）
+    - 追加 `Scenario: Caveman is toggled as one family`（Caveman 单开关控制整个 family）
+  - `## ADDED Requirements` 下：
+    - 新增 `Requirement: Caveman Core MUST Use One Aggregated Control`，聚合 body 覆盖 communication rules / review / commit / help，明确 runtime-only capability 不可声称、safety boundary 必须还原完整表达。
+
+### Rust / 资源
+
+- `src-tauri/resources/curated-skills/caveman/SKILL.md`：单一聚合主 skill（~1400 tokens，远低于 3000 上限），结构：ACTIVE persistence + Response rules + Intensity 三档 + Clarity/safety boundaries + Built-in task patterns (review / commit / help) + Runtime boundary + Output shape + When NOT to enable。
+- `src-tauri/resources/curated-skills/caveman/metadata.json`：必填字段齐备，`tokenEstimate: 1400`，`license: MIT`，`sourceUrl: https://github.com/JuliusBrussee/caveman`。
+- repo 根 `skills-lock.json`：新增 `caveman` entry，`computedHash` 是当前 `SKILL.md` 的真实 SHA-256；Ponytail entry hash 保持不变。`src-tauri/build.rs` 与 runtime loader 都复用这一份 lock single source。
+- `src-tauri/src/types.rs::default_enabled_curated_skill_ids()`：从 `vec!["lazy-senior-dev"]` 改成 `vec!["lazy-senior-dev", "caveman"]`。
+- `AppSettings.curated_skill_defaults_version` + `storage::read_settings()`：对旧版非空 curated 配置执行一次 Caveman default migration；显式空数组仍保持全量 opt-out，版本升级后不再自动补回。
+- `src-tauri/src/types.rs` 的 unit tests `app_settings_defaults_enable_core_curated_skills` 与 `app_settings_preserves_explicitly_empty_curated_skill_ids`：前者断言两条默认 id 都在，后者断言显式空数组仍然为空；无需新增 test 文件。
+
+### Frontend settings fallback
+
+- `src/features/settings/hooks/useAppSettings.ts` 的 frontend default 同步为 `lazy-senior-dev + caveman`，确保 remote / older backend payload 缺少 `enabledCuratedSkillIds` 时不会退回旧的单 skill 默认值。
+- `src/features/settings/hooks/useAppSettings.test.ts` 覆盖缺字段使用两条 built-in defaults，并继续覆盖显式 `[]` 不被默认值覆盖。
+- Curated row description 按 skill id 解析 i18n key；简体中文下 Caveman 与 Ponytail 描述显示中文，英文与其他 fallback locale 保持现有 fallback chain。
+
+### Build / runtime 行为
+
+- `tauri.conf.json` 的 `bundle.resources` 映射保持 `resources/curated-skills` → `curated-skills` 目录映射（已在 Ponytail 路径上验证）；build.rs 在 lock hash / license / icon / category / tokenEstimate / id 格式校验通过后自动重 build。
+- Codex macOS / Linux launch：`developer_instructions` 内 `<skill id="caveman">` 块自动包含（与 `lazy-senior-dev` 并列）。
+- Codex Windows launch：通过 turn-start `collaborationMode.settings.developer_instructions` 携带 `<skill id="caveman">`；argv 不带 `--profile ccgui-generated-instructions`。
+- Codex macOS / Linux spawn 与 Windows turn-start 使用同一 authoritative curated snapshot 文案；空列表也必须发送 `Enabled: none` deactivation state，不能通过省略 block 表示关闭，因为 app-server restart 后仍可能 resume 包含旧指令的 thread history。
+- Claude Windows launch：`--append-system-prompt-file` 指向的 activation hint 内含 `caveman` id，提示 Claude 调 `Skill(skill="caveman")`；Claude macOS / Linux 走现有 `--append-system-prompt` 路径。
+
+## 方案对比与取舍
+
+### 方案 A：单一聚合 `caveman` entry（采用）
+
+- 把 upstream `caveman` / `caveman-review` / `caveman-commit` / `caveman-help` 四份 SKILL.md 内容合并到一份 `caveman/SKILL.md`。
+- Settings 只暴露 `Caveman` 一个开关。
+- 优点：与 Ponytail `lazy-senior-dev`（一份 AGENTS.md 覆盖所有模式）的 product model 对齐；用户认知负担最小；build.rs / skills-lock / default enabled / Settings UI 全部沿用一条流水线；`tokenEstimate` 单值易估算。
+- 缺点：用户在 review / commit / help 三种 task pattern 之间无法单独屏蔽——但 Ponytail 的"lazy"哲学本来就不鼓励"按 task 拆开关"，与 Caveman 的"一以贯之"哲学契合。
+
+### 方案 B：拆成 `caveman` / `caveman-review` / `caveman-commit` / `caveman-help` 四个 entry（弃）
+
+- 优点：粒度细，用户可单独关 review 而保留 commit。
+- 缺点：与 Ponytail `lazy-senior-dev` 单开关 product model 不对称；Settings 多 3 个开关；`enabled_curated_skill_ids` 列表平均长度翻倍；用户初次接触客户端要理解 4 个 Caveman 相关开关与 1 个 Ponytail 开关的语义差异；build-time lock hash 与 token budget 需要重新对齐。
+
+### 方案 C：把 upstream `caveman` 全部子能力（含 compress / stats / cavecrew / shrink / init）一并 runtime 实现（弃）
+
+- 优点：理论上完整复刻 upstream。
+- 缺点：超出本变更范围（每个子能力都是独立 OpenSpec change，需要 hooks / subagent / MCP / shell wrapper）；CCGUI 当前没有这些 runtime 接入点；`cavecrew` 等依赖 multi-agent 编排，与现有 `curated-skill-bundles` capability 的"prompt-only 注入"模型不兼容；工作量是方案 A 的 5-10 倍。
+- 退路：上游 runtime-only capability 在 SKILL.md 内显式标注 "client 当前不实现"，给后续 change 留 hook。
+
+## 验收标准
+
+- `cargo check --manifest-path src-tauri/Cargo.toml` 0 error。
+- `cargo test --manifest-path src-tauri/Cargo.toml --lib curated_skill` 与两条 `types::tests::app_settings_*curated_skill*` default / explicit opt-out 校验全绿。
+- `openspec validate add-caveman-curated-skill-bundle --strict --no-interactive` 通过。
+- `npm run tauri dev` 启动 Settings → MCP / Skills → `Curated` 区只有 2 个 toggle：`Ponytail: lazy senior dev` 与 `Caveman`；两者默认勾选；关闭 Caveman 后 `enabledCuratedSkillIds` 仅剩 `["lazy-senior-dev"]`，重新打开恢复成 `["lazy-senior-dev", "caveman"]`。
+- 从只持久化 `["lazy-senior-dev"]` 的旧版 settings 首次升级时 Caveman 自动开启；用户随后关闭并重启后保持关闭；旧版显式 `[]` 不自动开启任何 curated skill。
+- 简体中文界面中 Caveman 描述显示中文；English locale 保持英文，未知 skill 或缺失 translation 时回退到 metadata description。
+- Codex macOS 启动后 `developer_instructions` 同时含 `<skill id="lazy-senior-dev">` 与 `<skill id="caveman">` 块；用户对谈时观察 prose 同时受 Caveman（短句、保留 code）+ Ponytail（最小改动、复用既有 helper）两条规则约束。
+- 在同一 Codex thread 中先启用两条 bundled curated skill，再关闭 Caveman 或关闭全部；下一 turn 的 authoritative snapshot 必须只列出仍启用的 id，或明确 `Enabled: none`，并声明旧轮次中未列出的 ccgui bundled curated instructions 已失效。不得要求创建新 thread 才能停用。
+- 触发 `caveman-commit` task pattern（直接对话："帮我写个 commit message"）时输出 `type(scope): 中文动宾短句` 模板 + ready-to-use message，**不**自动执行 `git commit`。
+- 触发 `caveman-review` task pattern（直接对话："review 一下 src-tauri/src/types.rs:1766"）时输出 `[file:line] [finding] [evidence] [next step]` 四要素 + 保留原 code 片段 + 不发明 `cfg/impl/req/res/fn` 类缩写。
+- 触发 `caveman-help`（直接对话："caveman 能做什么"）时输出 aggregated body 内已声明的能力清单 + 明确标注 `caveman-compress` / `caveman-stats` / `cavecrew` / `caveman-shrink` / `caveman-init` 不可用。
+- 安全边界：要求删除分支、覆盖文件、跳过测试、重置 git 状态时，Caveman 输出的安全警告不可被"短句化"压缩。
+- `skills-lock.json` 中 `caveman` 的 `computedHash` 与 `SKILL.md` 实际字节 SHA-256 一致；修改 SKILL.md 后 build.rs 必须自动 rerun，并在 lock hash 未同步时 fail closed。
+- SKILL.md token 数 ≤ 3000（实际 ~1400），符合 build-time tokenEstimate 校验。

--- a/openspec/changes/archive/2026-07-20-add-caveman-curated-skill-bundle/specs/curated-skill-bundles/spec.md
+++ b/openspec/changes/archive/2026-07-20-add-caveman-curated-skill-bundle/specs/curated-skill-bundles/spec.md
@@ -1,0 +1,180 @@
+## MODIFIED Requirements
+
+### Requirement: Client MUST Bundle Curated Skills As Versioned Assets
+
+The desktop client MUST bundle curated skills as application resources under
+`src-tauri/resources/curated-skills/<skill-id>/`. Each skill directory MUST
+contain `SKILL.md` and `metadata.json`. The app MUST package those resources via
+`tauri.conf.json` `bundle.resources` so curated skills are available offline and
+are tied to the client release version. The client MUST NOT fetch curated skill
+bodies from a remote marketplace or URL at runtime.
+
+The default bundled curated entries are `lazy-senior-dev` (Ponytail coding
+minimization policy) and `caveman` (Caveman concise communication policy).
+`caveman` is one user-facing switch: its review, commit-message, and help
+response patterns are aggregated into the single `caveman` body rather than
+exposed as separate toggles.
+
+`tauri.conf.json` MUST preserve each `<skill-id>/` directory when packaging
+curated skills. The preferred mapping is the directory mapping
+`"resources/curated-skills": "curated-skills"`; explicit per-skill directory
+mappings such as
+`"resources/curated-skills/<skill-id>": "curated-skills/<skill-id>"` are also
+valid. The app MUST NOT use the map-style glob
+`"resources/curated-skills/**/*": "curated-skills/"`, because Tauri flattens
+that glob and packaged clients lose the `<skill-id>/SKILL.md` and
+`<skill-id>/metadata.json` layout.
+
+#### Scenario: caveman bundled as one aggregated entry
+
+- **WHEN** the client is built
+- **THEN** the app resources MUST include `curated-skills/caveman/`
+- **AND** that directory MUST contain `SKILL.md` and `metadata.json`
+- **AND** `skills-lock.json` MUST contain exactly one curated entry named
+  `caveman` for the Caveman family
+- **AND** separate `caveman-review`, `caveman-commit`, and `caveman-help`
+  curated entries MUST NOT be required for bundled core behavior.
+
+### Requirement: AppSettings MUST Persist Enabled Curated Skill IDs
+
+`AppSettings` MUST include `enabled_curated_skill_ids: Vec<String>`, serialized
+to the frontend as `enabledCuratedSkillIds`, plus a versioned curated-default
+migration marker. New and reset defaults MUST contain `lazy-senior-dev` and
+`caveman`. A legacy non-empty curated list that predates Caveman MUST add it
+once during settings restore; after the marker advances, a user removing
+`caveman` MUST remain opted out on later restarts. An explicitly persisted
+empty array MUST remain empty to preserve a user opt-out. The setting MUST persist through the normal
+settings core and MUST be shared across workspaces for the same client install.
+Settings normalization MUST trim, de-duplicate, and drop empty or non
+kebab-case ASCII ids before persisting/restoring the field.
+
+Curated skill id changes MUST participate in Codex restart detection. macOS/Linux launch paths MUST preserve the existing app-server `developer_instructions` transport, while every supported platform MUST also send the latest authoritative snapshot at Codex turn start. Restart alone MUST NOT be treated as replacing developer state already associated with a resumed thread.
+
+Windows launch paths MUST avoid injecting ccgui-generated curated skill bodies through process argv when preserving them through argv would block startup. This MUST NOT mutate `enabledCuratedSkillIds`; the skill remains enabled and MUST be made available to Codex turns through JSON-RPC settings.
+
+Windows Claude launch paths MUST avoid injecting ccgui-generated curated skill bodies through process argv and MUST make enabled curated skills available through Claude native skill discovery. The native mirror path MUST be resolved from the effective Claude home rather than a hard-coded OS path.
+
+Windows Claude launch paths MUST activate enabled curated skills through a ccgui-managed short prompt file passed with `--append-system-prompt-file`. The activation hint MUST name enabled skill ids and tell Claude to invoke matching native Skills for suitable turns. It MUST NOT contain full curated skill bodies.
+
+#### Scenario: missing field uses built-in defaults
+
+- **WHEN** an existing config file does not contain `enabledCuratedSkillIds`
+- **THEN** restore MUST succeed
+- **AND** a new or reset settings object MUST contain `lazy-senior-dev` and
+  `caveman`.
+
+#### Scenario: explicit empty list remains an opt-out
+
+- **WHEN** a config file explicitly contains `"enabledCuratedSkillIds": []`
+- **THEN** restore MUST preserve an empty array
+- **AND** the client MUST NOT silently re-add either default curated skill.
+
+#### Scenario: legacy non-empty curated list enables Caveman once
+
+- **WHEN** an existing config contains `["lazy-senior-dev"]` and predates the
+  current curated-default migration marker
+- **THEN** restore MUST add `caveman` and advance the marker
+- **AND** removing `caveman` after migration MUST remain effective after restart
+- **AND** a legacy explicit empty list MUST remain empty.
+
+#### Scenario: Caveman is toggled as one family
+
+- **WHEN** the user toggles `Caveman` in Settings
+- **THEN** only the `caveman` id MUST be added to or removed from
+  `enabledCuratedSkillIds`
+- **AND** the review, commit-message, and help response patterns MUST follow
+  that same id
+- **AND** no child Caveman id (`caveman-review`, `caveman-commit`,
+  `caveman-help`) MUST be persisted.
+
+#### Scenario: current Codex thread receives an authoritative disabled snapshot
+
+- **WHEN** a bundled curated skill was injected into an existing Codex thread
+- **AND** the user later disables that skill while continuing the same thread
+- **THEN** the next generated developer instructions MUST identify the current
+  ccgui bundled curated skill set as authoritative
+- **AND** any earlier bundled curated skill whose id is absent from the current
+  snapshot MUST be declared inactive
+- **AND** an empty enabled set MUST emit an explicit `Enabled: none` state rather
+  than omitting the curated section
+- **AND** this state MUST NOT revoke user-supplied developer instructions,
+  system instructions, or skills exposed through other mechanisms.
+
+#### Scenario: re-enabled skills reach a resumed Codex thread on every platform
+
+- **WHEN** the user disables and then re-enables one or more bundled curated skills
+- **AND** Codex continues the same persisted thread after a runtime restart
+- **THEN** the next `turn/start` on macOS, Linux, and Windows MUST carry the latest
+  authoritative snapshot through `collaborationMode.settings.developer_instructions`
+- **AND** the snapshot MUST contain every currently enabled bundled skill body
+- **AND** macOS/Linux MUST retain their existing launch-time injection
+- **AND** Windows MUST continue omitting generated curated bodies from process argv.
+
+## ADDED Requirements
+
+### Requirement: Caveman Core MUST Use One Aggregated Control
+
+The bundled `caveman` skill MUST aggregate the upstream Caveman communication
+rules, intensity guidance (lite / full / ultra), wenyan guidance
+(wenyan-lite / wenyan-full / wenyan-ultra), auto-clarity boundaries, review
+response format, commit-message response format, and help / capability
+boundaries into one `SKILL.md`. The Settings UI MUST expose only the `caveman`
+switch for this family. The aggregated body MUST preserve exact code, commands,
+paths, URLs, identifiers, and error strings; MUST forbid invented prose
+abbreviations (`cfg`, `impl`, `req`, `res`, `fn` outside Rust code) and arrow
+substitutions (`A → B`); and MUST restore complete, unambiguous prose for
+security warnings, irreversible actions, ambiguous multi-step sequences, and
+user confusion / correction signals.
+
+The upstream `caveman-compress`, `caveman-stats`, `cavecrew`, `caveman-shrink`,
+and `caveman-init` features require file mutation, session-log hooks,
+subagent orchestration, MCP middleware, or repository rule installation that
+the client does not currently provide. Until matching runtime APIs exist, the
+bundled `caveman` body MUST identify these features as unavailable and MUST NOT
+claim to have executed them.
+
+The Settings row MUST localize the Caveman description for the active UI locale
+while preserving `metadata.json.description` as the fallback for missing
+translations. Simplified Chinese MUST display a Chinese description; English
+MUST continue to display an English description.
+
+#### Scenario: one Caveman switch controls aggregated behavior
+
+- **WHEN** `enabledCuratedSkillIds` contains `caveman`
+- **THEN** communication rules, intensity guidance, review output format,
+  commit-message output format, and help / capability boundaries MUST be
+  injected from the same `<skill id="caveman">` body
+- **AND** no `caveman-review`, `caveman-commit`, or `caveman-help` id MUST be
+  required or persisted.
+
+#### Scenario: runtime-only capability is not fabricated
+
+- **WHEN** the user asks for token statistics, session-log compression,
+  Caveman-aware subagent orchestration, MCP description shrinking, or
+  repository-wide Caveman initialization
+- **THEN** the client MUST NOT claim that the operation ran unless the
+  corresponding runtime integration is present
+- **AND** the assistant MUST state the capability boundary clearly.
+
+#### Scenario: Caveman safety boundary restores clarity
+
+- **WHEN** a response contains a security warning, irreversible action,
+  ambiguous multi-step sequence, or the user asks for clarification
+- **THEN** the Caveman rules MUST use complete, unambiguous prose for that
+  part
+- **AND** MUST retain required validation, error handling, accessibility, and
+  recovery information.
+
+#### Scenario: Caveman commit message skill never auto-executes git commit
+
+- **WHEN** the assistant generates a Caveman commit message
+- **THEN** the output MUST be a ready-to-use commit message text
+- **AND** the assistant MUST NOT execute `git commit`, `git commit -m`, or any
+  other commit-creating command on the user's behalf.
+
+#### Scenario: Caveman description follows the UI locale
+
+- **WHEN** Settings renders the Caveman row in Simplified Chinese
+- **THEN** the description MUST be Chinese
+- **AND** switching to English MUST use the English description
+- **AND** a missing translation MUST fall back to the bundled metadata text.

--- a/openspec/changes/archive/2026-07-20-add-caveman-curated-skill-bundle/tasks.md
+++ b/openspec/changes/archive/2026-07-20-add-caveman-curated-skill-bundle/tasks.md
@@ -1,0 +1,62 @@
+# add-caveman-curated-skill-bundle tasks
+
+## 1. Caveman skill 资源（P1）
+
+- [x] 1.1 [P0] 核实上游 `caveman` / `caveman-review` / `caveman-commit` / `caveman-help` 四份 `SKILL.md` 的真实内容（在 `/Users/chenxiangning/code/AI/github/caveman/skills/`），确认聚合范围内覆盖：communication rules + intensity 三档（lite / full / ultra）+ wenyan 三档 + auto-clarity 边界 + `[thing] [action] [reason]. [next step].` 句式 + review 输出格式 + commit 输出格式 + help / capability 描述。
+- [x] 1.2 [P0] 明确 runtime-only 边界（`caveman-compress` / `caveman-stats` / `cavecrew` / `caveman-shrink` / `caveman-init`）不属于本次聚合范围，写入 SKILL.md "Runtime-only capabilities (NOT implemented in this client)" 段，禁止虚假声称已执行。
+- [x] 1.3 [P0] `src-tauri/resources/curated-skills/caveman/SKILL.md`：单一聚合主 skill，~1400 tokens（远低于 3000 上限），结构：ACTIVE persistence → Response rules → Intensity → Clarity/safety boundaries → Built-in task patterns (review / commit / help) → Runtime-only capabilities → Output shape → When NOT to enable。顶部含 `<!-- Upstream: https://github.com/JuliusBrussee/caveman | License: MIT -->` 注释。
+- [x] 1.4 [P0] `src-tauri/resources/curated-skills/caveman/metadata.json`：必填字段 `name=caveman` / `displayName=Caveman` / `version=1.0.0` / `description=Caveman core: concise communication plus safe review and commit guidance, preserving technical substance and exact code or commands.` / `icon=message-circle` / `category=code-style` / `tokenEstimate=1400` / `source=upstream: JuliusBrussee/caveman (core communication rules)` / `sourceUrl=https://github.com/JuliusBrussee/caveman` / `license=MIT`。
+
+## 2. skills-lock.json（P2）
+
+- [x] 2.1 [P0] repo 根 `skills-lock.json` 新增 `caveman` entry：`assetPath=resources/curated-skills/caveman/SKILL.md`、`metadataPath=resources/curated-skills/caveman/metadata.json`、`minClientVersion=0.5.14`、`computedHash=<SKILL.md 字节 SHA-256>`；保留 `lazy-senior-dev` entry 不动。
+- [x] 2.2 [P0] 保持 repo 根 `skills-lock.json` 为唯一 lock source；`src-tauri/build.rs` 与 runtime loader 复用它，不创建 `src-tauri/skills-lock.json` 副本。
+- [x] 2.3 [P0] 修改 SKILL.md 后 `cargo build` 必须触发 build.rs 重新校验 hash；lock 未同步时 build fail closed，不自动改写 `computedHash`。
+
+## 3. Rust defaults + tests（P3）
+
+- [x] 3.1 [P0] `src-tauri/src/types.rs::default_enabled_curated_skill_ids()` 由 `vec!["lazy-senior-dev"]` 改为 `vec!["lazy-senior-dev", "caveman"]`（位于 `src-tauri/src/types.rs:1766-1768`）。
+- [x] 3.2 [P0] `src-tauri/src/types.rs` unit test `app_settings_defaults_enable_core_curated_skills`：分别构造默认 `AppSettings` 与 decode 缺字段 JSON `{}`，断言 `enabled_curated_skill_ids == vec!["lazy-senior-dev", "caveman"]`。
+- [x] 3.3 [P0] `src-tauri/src/types.rs` unit test `app_settings_preserves_explicitly_empty_curated_skill_ids`：decode 显式 `{"enabledCuratedSkillIds":[]}`，断言结果仍然为空数组（不被默认填充覆盖，保留用户显式 opt-out）。
+- [x] 3.4 [P0] frontend `useAppSettings` 的缺字段 fallback 同步为 `lazy-senior-dev + caveman`，并保留显式空数组 opt-out；focused Vitest 覆盖两种语义。
+- [x] 3.5 [P0] 新增 `curatedSkillDefaultsVersion=1` one-shot migration：旧版非空列表补入 Caveman，显式空数组不补，migration 后用户关闭 Caveman 不会在重启时被重新开启。
+- [x] 3.6 [P0] `storage::read_settings_migrates_caveman_default_once_and_preserves_opt_out` 覆盖 legacy enable、post-migration disable 与 legacy empty opt-out。
+
+## 3A. Curated description i18n（P3A）
+
+- [x] 3A.1 [P0] Curated row 按 stable skill id 解析 localized description，缺失 translation / 未知 id 回退 `metadata.json.description`。
+- [x] 3A.2 [P0] `en/common.ts` 与 `zh/common.ts` 补齐 Caveman / Lazy senior dev descriptions；中文模式显示中文。
+- [x] 3A.3 [P0] `categoryLabels.test.ts` 覆盖 localized Caveman description 与 fallback 行为。
+
+## 4. OpenSpec delta（P4）
+
+- [x] 4.1 [P0] `openspec/changes/add-caveman-curated-skill-bundle/specs/curated-skill-bundles/spec.md` 写 delta：
+  - `## MODIFIED Requirements` 包含修改 `Requirement: Client MUST Bundle Curated Skills As Versioned Assets`（追加 Caveman 默认 entry 描述 + 新 Scenario `caveman bundled as one aggregated entry`）。
+  - 修改 `Requirement: AppSettings MUST Persist Enabled Curated Skill IDs` 的 Purpose 段（默认两条 id）+ Scenario `missing field uses built-in defaults`（替代 `missing field defaults empty`）+ 新 Scenario `explicit empty list remains an opt-out` + 新 Scenario `Caveman is toggled as one family`。
+  - `## ADDED Requirements` 新增 `Requirement: Caveman Core MUST Use One Aggregated Control`（单一聚合 body + 安全边界 + runtime-only 不伪造）。
+- [x] 4.2 [P0] 主线 `openspec/specs/curated-skill-bundles/spec.md` **不**直接编辑；sync 阶段由 `openspec sync` 把 delta 合并回主线。
+- [x] 4.3 [P0] `openspec/changes/README.md` **不**编辑 active table：sync / archive 之后再加入。
+
+## 5. 验证与收尾（P5）
+
+- [x] 5.1 [P0] `cargo check --manifest-path src-tauri/Cargo.toml` → 0 error，无新增 warning（既有 dead-code 与本变更无关）。
+- [x] 5.2 [P0] `cargo test --manifest-path src-tauri/Cargo.toml --lib curated_skill` → 44/44 pass，其中包含 `types::tests::app_settings_defaults_enable_core_curated_skills` 与 `app_settings_preserves_explicitly_empty_curated_skill_ids`。
+- [x] 5.2a [P0] `npx vitest run src/features/settings/hooks/useAppSettings.test.ts` → 29/29 pass，覆盖缺字段的双默认值与显式空数组 opt-out。
+- [x] 5.3 [P0] `openspec validate add-caveman-curated-skill-bundle --strict --no-interactive` → valid。
+- [x] 5.4 [P0] `git diff --check` → 无 whitespace / conflict marker 警告。
+- [x] 5.5 [P1] `python3 ./.trellis/scripts/get_context.py --mode record` 在 commit 前取 developer id。
+- [x] 5.6 [P1] runtime contract scripts：`check-engine-capability-matrix.mjs` / `check-app-shell-runtime-contract.mjs` / `check-git-history-runtime-contract.mjs` / `check-refactor-imports.mjs` / `doctor:strict` 全绿（curated skill 不在它们 contract 覆盖范围，预计本变更不影响）。
+
+## 6. 文档同步（P6）
+
+- [x] 6.1 [P0] `openspec/changes/add-caveman-curated-skill-bundle/{proposal,tasks,design}.md` 同步反映实际实现 + 用户审查后任何修改。
+- [x] 6.2 [P0] `openspec/changes/add-caveman-curated-skill-bundle/specs/curated-skill-bundles/spec.md` delta 与 proposal / design 一致。
+- [x] 6.3 [P1] git commit（中文主体 Conventional Commit：`feat(curated-skills): 内置 Caveman 主体 curated skill`） + Trellis session record（用户已授权收口）。
+- [x] 6.4 [P1] 验证完成后按 release strategy 执行 OpenSpec sync / archive，并刷新对应 active / archive index。
+
+## 7. Codex current-thread deactivation（P7）
+
+- [x] 7.1 [P0] `codex_curated_skills_developer_instructions_block()` 输出 authoritative snapshot；部分关闭时未列出的旧 bundled skill 失效，全部关闭时显式输出 `Enabled: none`。
+- [x] 7.2 [P0] macOS / Linux spawn 与全平台 turn-start 复用同一个 snapshot builder；Windows 保持 turn-only transport，不 fork 新 thread，不覆盖 user-supplied / system instructions 或其他 skill mechanism。
+- [x] 7.3 [P0] Rust regression tests 覆盖 enabled snapshot、partial snapshot 与 empty deactivation snapshot，并断言 empty snapshot 不含任何 `<skill>` body。
+- [x] 7.4 [P0] 修复 re-enable regression：desktop、shared session、daemon 在 macOS / Linux / Windows 的 next `turn/start` 都读取最新 settings snapshot；保留 macOS / Linux 原 spawn 注入和 Windows argv omit 边界。

--- a/openspec/changes/archive/README.md
+++ b/openspec/changes/archive/README.md
@@ -2,13 +2,17 @@
 
 本页为 `mossx` 已归档 OpenSpec proposal 的完整可点击索引。目录名中的日期是 archive date，不代表 proposal 首次创建时间。
 
-- Updated At: `2026-07-18`
-- Indexed proposals: `640`
+- Updated At: `2026-07-20`
+- Indexed proposals: `641`
 - Source of truth: `openspec/changes/archive/<archive-date>-<change-id>/proposal.md`
 - Back to current changes: [`../README.md`](../README.md)
 - Back to workspace overview: [`../../project.md`](../../project.md)
 
-## 2026-07 (106)
+## 2026-07 (107)
+
+### 2026-07-20
+
+- [`2026-07-20-add-caveman-curated-skill-bundle`](2026-07-20-add-caveman-curated-skill-bundle/proposal.md) — verified implementation，已同步 main spec
 
 ### 2026-07-18
 

--- a/openspec/specs/curated-skill-bundles/spec.md
+++ b/openspec/specs/curated-skill-bundles/spec.md
@@ -17,6 +17,12 @@ contain `SKILL.md` and `metadata.json`. The app MUST package those resources via
 are tied to the client release version. The client MUST NOT fetch curated skill
 bodies from a remote marketplace or URL at runtime.
 
+The default bundled curated entries are `lazy-senior-dev` (Ponytail coding
+minimization policy) and `caveman` (Caveman concise communication policy).
+`caveman` is one user-facing switch: its review, commit-message, and help
+response patterns are aggregated into the single `caveman` body rather than
+exposed as separate toggles.
+
 `tauri.conf.json` MUST preserve each `<skill-id>/` directory when packaging
 curated skills. The preferred mapping is the directory mapping
 `"resources/curated-skills": "curated-skills"`; explicit per-skill directory
@@ -35,6 +41,16 @@ that glob and packaged clients lose the `<skill-id>/SKILL.md` and
 - **AND** `metadata.json` MUST declare `name`, `displayName`, `version`,
   `description`, `icon`, `category`, `tokenEstimate`, `source`, `sourceUrl`,
   and `license`.
+
+#### Scenario: caveman bundled as one aggregated entry
+
+- **WHEN** the client is built
+- **THEN** the app resources MUST include `curated-skills/caveman/`
+- **AND** that directory MUST contain `SKILL.md` and `metadata.json`
+- **AND** `skills-lock.json` MUST contain exactly one curated entry named
+  `caveman` for the Caveman family
+- **AND** separate `caveman-review`, `caveman-commit`, and `caveman-help`
+  curated entries MUST NOT be required for bundled core behavior.
 
 #### Scenario: packaged resources preserve skill directory layout
 
@@ -93,9 +109,18 @@ path for rebuilds, not a stale package-local path.
 
 ### Requirement: AppSettings MUST Persist Enabled Curated Skill IDs
 
-`AppSettings` MUST include `enabled_curated_skill_ids: Vec<String>`, serialized to the frontend as `enabledCuratedSkillIds`, and default it to an empty array. The setting MUST persist through the normal settings core and MUST be shared across workspaces for the same client install. Settings normalization MUST trim, de-duplicate, and drop empty or non kebab-case ASCII ids before persisting/restoring the field.
+`AppSettings` MUST include `enabled_curated_skill_ids: Vec<String>`, serialized
+to the frontend as `enabledCuratedSkillIds`, plus a versioned curated-default
+migration marker. New and reset defaults MUST contain `lazy-senior-dev` and
+`caveman`. A legacy non-empty curated list that predates Caveman MUST add it
+once during settings restore; after the marker advances, a user removing
+`caveman` MUST remain opted out on later restarts. An explicitly persisted
+empty array MUST remain empty to preserve a user opt-out. The setting MUST persist through the normal
+settings core and MUST be shared across workspaces for the same client install.
+Settings normalization MUST trim, de-duplicate, and drop empty or non
+kebab-case ASCII ids before persisting/restoring the field.
 
-Curated skill id changes MUST participate in Codex restart detection because Codex app-server `developer_instructions` are captured at launch time on macOS/Linux launch paths and at turn start on Windows paths. Restart is required so toggling a curated skill off does not leave stale curated skill instructions in a long-lived app-server process.
+Curated skill id changes MUST participate in Codex restart detection. macOS/Linux launch paths MUST preserve the existing app-server `developer_instructions` transport, while every supported platform MUST also send the latest authoritative snapshot at Codex turn start. Restart alone MUST NOT be treated as replacing developer state already associated with a resumed thread.
 
 Windows launch paths MUST avoid injecting ccgui-generated curated skill bodies through process argv when preserving them through argv would block startup. This MUST NOT mutate `enabledCuratedSkillIds`; the skill remains enabled and MUST be made available to Codex turns through JSON-RPC settings.
 
@@ -103,34 +128,88 @@ Windows Claude launch paths MUST avoid injecting ccgui-generated curated skill b
 
 Windows Claude launch paths MUST activate enabled curated skills through a ccgui-managed short prompt file passed with `--append-system-prompt-file`. The activation hint MUST name enabled skill ids and tell Claude to invoke matching native Skills for suitable turns. It MUST NOT contain full curated skill bodies.
 
-#### Scenario: missing field defaults empty
+#### Scenario: missing field uses built-in defaults
+
 - **WHEN** an existing config file does not contain `enabledCuratedSkillIds`
 - **THEN** restore MUST succeed
-- **AND** the field MUST default to an empty array.
+- **AND** a new or reset settings object MUST contain `lazy-senior-dev` and
+  `caveman`.
+
+#### Scenario: explicit empty list remains an opt-out
+
+- **WHEN** a config file explicitly contains `"enabledCuratedSkillIds": []`
+- **THEN** restore MUST preserve an empty array
+- **AND** the client MUST NOT silently re-add either default curated skill.
+
+#### Scenario: legacy non-empty curated list enables Caveman once
+
+- **WHEN** an existing config contains `["lazy-senior-dev"]` and predates the
+  current curated-default migration marker
+- **THEN** restore MUST add `caveman` and advance the marker
+- **AND** removing `caveman` after migration MUST remain effective after restart
+- **AND** a legacy explicit empty list MUST remain empty.
+
+#### Scenario: Caveman is toggled as one family
+
+- **WHEN** the user toggles `Caveman` in Settings
+- **THEN** only the `caveman` id MUST be added to or removed from
+  `enabledCuratedSkillIds`
+- **AND** the review, commit-message, and help response patterns MUST follow
+  that same id
+- **AND** no child Caveman id (`caveman-review`, `caveman-commit`,
+  `caveman-help`) MUST be persisted.
+
+#### Scenario: current Codex thread receives an authoritative disabled snapshot
+
+- **WHEN** a bundled curated skill was injected into an existing Codex thread
+- **AND** the user later disables that skill while continuing the same thread
+- **THEN** the next generated developer instructions MUST identify the current
+  ccgui bundled curated skill set as authoritative
+- **AND** any earlier bundled curated skill whose id is absent from the current
+  snapshot MUST be declared inactive
+- **AND** an empty enabled set MUST emit an explicit `Enabled: none` state rather
+  than omitting the curated section
+- **AND** this state MUST NOT revoke user-supplied developer instructions,
+  system instructions, or skills exposed through other mechanisms.
+
+#### Scenario: re-enabled skills reach a resumed Codex thread on every platform
+
+- **WHEN** the user disables and then re-enables one or more bundled curated skills
+- **AND** Codex continues the same persisted thread after a runtime restart
+- **THEN** the next `turn/start` on macOS, Linux, and Windows MUST carry the latest
+  authoritative snapshot through `collaborationMode.settings.developer_instructions`
+- **AND** the snapshot MUST contain every currently enabled bundled skill body
+- **AND** macOS/Linux MUST retain their existing launch-time injection
+- **AND** Windows MUST continue omitting generated curated bodies from process argv.
 
 #### Scenario: toggle persists
+
 - **WHEN** the user enables `lazy-senior-dev`
 - **THEN** `enabledCuratedSkillIds` MUST include `lazy-senior-dev`
 - **AND** the value MUST be restored after app restart.
 
 #### Scenario: Settings toggle reflects authoritative result immediately
+
 - **WHEN** the user toggles `lazy-senior-dev` in Settings `MCP / Skills`
 - **AND** `set_curated_skill_enabled` returns an updated `AppSettings`
 - **THEN** the visible switch MUST update from that returned `enabledCuratedSkillIds` in the current Settings view
 - **AND** the user MUST NOT need to switch to another module and back to see the new state.
 
 #### Scenario: Settings toggle failure preserves previous visible state
+
 - **WHEN** the user toggles `lazy-senior-dev` in Settings `MCP / Skills`
 - **AND** `set_curated_skill_enabled` fails
 - **THEN** the visible switch MUST remain on the previous `enabledCuratedSkillIds` state
 - **AND** Settings MUST surface the error instead of displaying a false successful toggle.
 
 #### Scenario: curated toggle requires Codex restart
+
 - **WHEN** `enabledCuratedSkillIds` changes
 - **THEN** `app_settings_change_requires_codex_restart` MUST return true
 - **AND** the next healthy Codex app-server launch MUST use the updated curated skill set.
 
 #### Scenario: Windows launch keeps setting enabled and avoids startup argv
+
 - **WHEN** `lazy-senior-dev` is enabled
 - **AND** Windows Codex app-server launch starts without ccgui-generated curated skill argv
 - **THEN** `enabledCuratedSkillIds` MUST remain unchanged
@@ -516,3 +595,69 @@ Enabled curated skill bodies MUST be available to supported engine launches when
 - **THEN** ccgui MUST remove the managed activation hint
 - **AND** Claude launch args MUST NOT include `--append-system-prompt-file`.
 
+### Requirement: Caveman Core MUST Use One Aggregated Control
+
+The bundled `caveman` skill MUST aggregate the upstream Caveman communication
+rules, intensity guidance (lite / full / ultra), wenyan guidance
+(wenyan-lite / wenyan-full / wenyan-ultra), auto-clarity boundaries, review
+response format, commit-message response format, and help / capability
+boundaries into one `SKILL.md`. The Settings UI MUST expose only the `caveman`
+switch for this family. The aggregated body MUST preserve exact code, commands,
+paths, URLs, identifiers, and error strings; MUST forbid invented prose
+abbreviations (`cfg`, `impl`, `req`, `res`, `fn` outside Rust code) and arrow
+substitutions (`A → B`); and MUST restore complete, unambiguous prose for
+security warnings, irreversible actions, ambiguous multi-step sequences, and
+user confusion / correction signals.
+
+The upstream `caveman-compress`, `caveman-stats`, `cavecrew`, `caveman-shrink`,
+and `caveman-init` features require file mutation, session-log hooks,
+subagent orchestration, MCP middleware, or repository rule installation that
+the client does not currently provide. Until matching runtime APIs exist, the
+bundled `caveman` body MUST identify these features as unavailable and MUST NOT
+claim to have executed them.
+
+The Settings row MUST localize the Caveman description for the active UI locale
+while preserving `metadata.json.description` as the fallback for missing
+translations. Simplified Chinese MUST display a Chinese description; English
+MUST continue to display an English description.
+
+#### Scenario: one Caveman switch controls aggregated behavior
+
+- **WHEN** `enabledCuratedSkillIds` contains `caveman`
+- **THEN** communication rules, intensity guidance, review output format,
+  commit-message output format, and help / capability boundaries MUST be
+  injected from the same `<skill id="caveman">` body
+- **AND** no `caveman-review`, `caveman-commit`, or `caveman-help` id MUST be
+  required or persisted.
+
+#### Scenario: runtime-only capability is not fabricated
+
+- **WHEN** the user asks for token statistics, session-log compression,
+  Caveman-aware subagent orchestration, MCP description shrinking, or
+  repository-wide Caveman initialization
+- **THEN** the client MUST NOT claim that the operation ran unless the
+  corresponding runtime integration is present
+- **AND** the assistant MUST state the capability boundary clearly.
+
+#### Scenario: Caveman safety boundary restores clarity
+
+- **WHEN** a response contains a security warning, irreversible action,
+  ambiguous multi-step sequence, or the user asks for clarification
+- **THEN** the Caveman rules MUST use complete, unambiguous prose for that
+  part
+- **AND** MUST retain required validation, error handling, accessibility, and
+  recovery information.
+
+#### Scenario: Caveman commit message skill never auto-executes git commit
+
+- **WHEN** the assistant generates a Caveman commit message
+- **THEN** the output MUST be a ready-to-use commit message text
+- **AND** the assistant MUST NOT execute `git commit`, `git commit -m`, or any
+  other commit-creating command on the user's behalf.
+
+#### Scenario: Caveman description follows the UI locale
+
+- **WHEN** Settings renders the Caveman row in Simplified Chinese
+- **THEN** the description MUST be Chinese
+- **AND** switching to English MUST use the English description
+- **AND** a missing translation MUST fall back to the bundled metadata text.

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -24,6 +24,16 @@
       "tokenEstimate": 1100,
       "minClientVersion": "0.5.14"
     },
+    "caveman": {
+      "kind": "curated",
+      "displayName": "Caveman",
+      "version": "1.0.0",
+      "assetPath": "resources/curated-skills/caveman/SKILL.md",
+      "metadataPath": "resources/curated-skills/caveman/metadata.json",
+      "computedHash": "12d16c4e8ad70d5c14a3f090581dc725b24658bf0caaf2b9e3aab17b47aa50bc",
+      "tokenEstimate": 1400,
+      "minClientVersion": "0.5.14"
+    },
     "vercel-cli-with-tokens": {
       "source": "vercel-labs/agent-skills",
       "sourceType": "github",

--- a/src-tauri/resources/curated-skills/caveman/SKILL.md
+++ b/src-tauri/resources/curated-skills/caveman/SKILL.md
@@ -1,0 +1,100 @@
+<!-- Upstream: https://github.com/JuliusBrussee/caveman | License: MIT -->
+
+# Caveman, concise communication mode
+
+Keep technical substance. Remove communication waste. Default to concise,
+direct answers while preserving enough context for the user to act safely.
+
+ACTIVE EVERY RESPONSE while this skill is enabled. Do not announce the mode or
+write a second normal answer explaining it. If the user says "stop caveman",
+"normal mode", or asks for a normal detailed answer, stop compressing for that
+conversation. The Settings switch remains the persistent client control.
+
+## Response rules
+
+- Drop filler, pleasantries, repeated conclusions, and unnecessary hedging.
+- Prefer short sentences and concrete verbs. Fragments are fine when clear.
+- State the cause, action, and next step once. Do not narrate obvious tool work.
+- Preserve the user's dominant language. Compress style; never translate unless asked.
+- Keep technical terms, API names, CLI commands, code, URLs, paths, identifiers,
+  and exact error messages unchanged.
+- Use code blocks for code and commands. Never compress or rewrite executable text.
+- Standard acronyms such as DB, API, and HTTP are fine. Do not invent prose
+  abbreviations such as `cfg`, `impl`, `req`, `res`, or `fn`; they reduce clarity
+  without reliably saving tokens. Do not replace causal prose with arrow glyphs.
+- Do not refer to yourself or label the answer "Caveman" unless the user asks
+  what mode is active.
+- Explain only the detail needed to support the decision or next action.
+
+## Intensity
+
+Use `full` behavior by default. If the user explicitly asks for a shorter or
+more detailed answer, adjust naturally while keeping technical accuracy:
+
+- `lite`: concise professional sentences; keep normal grammar.
+- `full`: remove filler and repetition; fragments are acceptable when clear.
+- `ultra`: state each fact once; remove only unambiguous connective prose.
+- `wenyan-lite`: semi-classical Chinese with light compression.
+- `wenyan-full`: classical Chinese with omitted subjects and concise particles.
+- `wenyan-ultra`: maximum classical terseness without losing technical meaning.
+
+Pattern: `[thing] [action] [reason]. [next step].`
+
+## Clarity and safety boundaries
+
+- Restore full clarity for security warnings, destructive or irreversible actions,
+  user confusion, ambiguity, and multi-step procedures where fragments could be
+  misread.
+- Ask a focused clarification question when the request lacks information needed
+  for a safe or correct result. Do not guess silently.
+- Include validation, error handling, accessibility, and recovery details when
+  they are necessary for correctness. Brevity never removes safety guards.
+- Keep code, commits, PR descriptions, user-facing copy, and required technical
+  documentation in their appropriate normal format; concise does not mean cryptic.
+
+## Built-in task patterns
+
+When the user asks for a code review, focus on actionable correctness, security,
+data-loss, and validation findings. One finding per line when practical:
+`L<line>: <severity> <problem>. <fix>.` Use `bug`, `risk`, `nit`, or `q`; skip
+praise, obvious observations, formatting nits that do not change meaning, and
+unrelated refactors. Include exact `path:line` when available, sort findings by
+file and line, and do not guess when more context is required. Say `LGTM` when
+no finding exists. For security findings, state the risk in clear normal prose
+before the concise fix line.
+
+When the user asks for a commit message, use Conventional Commits:
+`<type>(<scope>): <imperative summary>`. Keep the subject <=50 characters when
+possible (hard cap 72), omit a body unless non-obvious why, breaking changes,
+migration notes, security fixes, reverts, or issue references need it. Wrap body
+at 72 characters, use `-` bullets, and put `Closes #42` / `Refs #17` at the end.
+Never invent changes, add AI attribution unless project rules require it, or
+run `git add`, `git commit`, or amend; output only a message ready to use.
+
+When the user asks what Caveman can do, describe only capabilities exposed by
+this client: concise communication plus these review and commit response
+patterns. Do not claim token statistics, MCP middleware, file compression, or
+subagent presets are available unless the client adds those runtime features.
+
+## Runtime boundary
+
+The upstream Caveman repository also contains `caveman-compress`,
+`caveman-stats`, `cavecrew`, and `caveman-shrink`. These require file tools,
+session-log hooks, subagent orchestration, or MCP middleware. This bundled skill
+does not simulate those capabilities or claim they ran.
+
+`caveman-init` is also not part of this client bundle: it writes agent-specific
+rule files into a repository and requires its upstream installer script.
+
+## Output shape
+
+Lead with the result. Follow with the smallest useful explanation, evidence, and
+next step. Avoid decorative headings, tables, emojis, and raw log dumps unless
+they materially improve comprehension or the user asks for them.
+
+## 何时不启用 / When NOT to enable
+
+Do not force maximum brevity for safety-critical review, destructive operations,
+incident response, unfamiliar-domain exploration, requirements discovery, or
+complex architecture decisions. Use complete explanations when omission could
+cause a wrong implementation or unsafe action.

--- a/src-tauri/resources/curated-skills/caveman/metadata.json
+++ b/src-tauri/resources/curated-skills/caveman/metadata.json
@@ -1,0 +1,12 @@
+{
+  "name": "caveman",
+  "displayName": "Caveman",
+  "version": "1.0.0",
+  "description": "Caveman core: concise communication plus safe review and commit guidance, preserving technical substance and exact code or commands.",
+  "icon": "message-circle",
+  "category": "code-style",
+  "tokenEstimate": 1400,
+  "source": "upstream: JuliusBrussee/caveman (core communication rules)",
+  "sourceUrl": "https://github.com/JuliusBrussee/caveman",
+  "license": "MIT"
+}

--- a/src-tauri/src/backend/app_server.rs
+++ b/src-tauri/src/backend/app_server.rs
@@ -496,6 +496,7 @@ pub(crate) struct WorkspaceSession {
     pub(crate) thread_mode_state: ThreadModeState,
     pub(crate) mode_enforcement_enabled: AtomicBool,
     pub(crate) collaboration_mode_supported: AtomicBool,
+    pub(crate) generated_developer_instructions_enabled: bool,
     auto_compaction_threshold_percent: f64,
     auto_compaction_enabled: bool,
     auto_compaction_thread_state: Mutex<HashMap<String, AutoCompactionThreadState>>,
@@ -1136,6 +1137,8 @@ async fn spawn_workspace_session_once<E: EventSink>(
     launch_options: CodexAppServerLaunchOptions,
     app_settings: crate::types::AppSettings,
 ) -> Result<Arc<WorkspaceSession>, String> {
+    let generated_developer_instructions_enabled =
+        !codex_args_override_instructions(codex_args.as_deref());
     let mut command =
         build_codex_command_from_launch_context(launch_context, launch_options.hide_console);
     apply_codex_tui_compatible_terminal_env(&mut command);
@@ -1183,6 +1186,7 @@ async fn spawn_workspace_session_once<E: EventSink>(
         thread_mode_state: ThreadModeState::default(),
         mode_enforcement_enabled: AtomicBool::new(true),
         collaboration_mode_supported: AtomicBool::new(true),
+        generated_developer_instructions_enabled,
         auto_compaction_threshold_percent,
         auto_compaction_enabled,
         auto_compaction_thread_state: Mutex::new(HashMap::new()),
@@ -1322,6 +1326,7 @@ pub(crate) async fn make_test_workspace_session(id: &str) -> Arc<WorkspaceSessio
         thread_mode_state: crate::codex::thread_mode_state::ThreadModeState::default(),
         mode_enforcement_enabled: AtomicBool::new(false),
         collaboration_mode_supported: AtomicBool::new(false),
+        generated_developer_instructions_enabled: true,
         auto_compaction_threshold_percent: AUTO_COMPACTION_THRESHOLD_PERCENT,
         auto_compaction_enabled: true,
         auto_compaction_thread_state: Mutex::new(HashMap::new()),

--- a/src-tauri/src/backend/app_server_cli.rs
+++ b/src-tauri/src/backend/app_server_cli.rs
@@ -968,15 +968,28 @@ fn codex_curated_skills_developer_instructions_block(
 ) -> Option<String> {
     use crate::curated_skills;
     let enabled = curated_skills::list_enabled_curated_skill_bodies(app_settings);
-    if enabled.is_empty() {
-        return None;
+    let enabled_label = if enabled.is_empty() {
+        "none".to_string()
+    } else {
+        enabled
+            .iter()
+            .map(|(id, _)| format!("`{id}`"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+    let mut snapshot = format!(
+        "## Curated Skills\n\nThis section is the authoritative state for ccgui bundled curated skills in the current runtime or turn. Only `<skill>` blocks listed in this section are active. Any ccgui bundled curated-skill instructions from earlier turns whose id is not listed here are inactive and MUST NOT be followed. This state does not change user-supplied developer instructions, system instructions, or skills provided through other mechanisms.\n\nEnabled: {enabled_label}."
+    );
+    if !enabled.is_empty() {
+        let bodies = enabled
+            .into_iter()
+            .map(|(id, body)| format!("<skill id=\"{}\">\n{}\n</skill>", id, body))
+            .collect::<Vec<_>>()
+            .join("\n");
+        snapshot.push_str("\n\n");
+        snapshot.push_str(&bodies);
     }
-    let body = enabled
-        .into_iter()
-        .map(|(id, body)| format!("<skill id=\"{}\">\n{}\n</skill>", id, body))
-        .collect::<Vec<_>>()
-        .join("\n");
-    Some(format!("## Curated Skills\n\n{body}"))
+    Some(snapshot)
 }
 
 fn build_generated_developer_instructions(
@@ -995,7 +1008,6 @@ fn build_generated_developer_instructions(
     crate::codex::collaboration_policy::merge_developer_instructions(None, &directives)
 }
 
-#[cfg_attr(not(windows), allow(dead_code))]
 pub(crate) fn codex_generated_developer_instructions_for_turn(
     app_settings: &crate::types::AppSettings,
 ) -> Option<String> {
@@ -1018,7 +1030,9 @@ pub(crate) fn build_codex_app_server_args(
 ///   * `app_settings` is `Some`
 ///   * the user-supplied `codex_args` does NOT already contain a
 ///     `developer_instructions=` / `instructions=` override
-///   * at least one curated skill is enabled
+///
+/// The generated block is also present when no curated skill is enabled so a
+/// resumed Codex thread receives an authoritative deactivation snapshot.
 /// Existing developer instructions are preserved and the curated block is
 /// appended under a `## Curated Skills` heading via the same merge policy
 /// used by `merge_developer_instructions`.
@@ -1871,30 +1885,36 @@ mod curated_skill_injection_tests {
     }
 
     #[test]
-    fn codex_curated_skills_config_arg_returns_none_when_empty() {
+    fn codex_curated_skills_config_arg_emits_authoritative_snapshot_when_empty() {
         let s = settings_with(vec![]);
-        let out = codex_curated_skills_config_arg(&s, None);
-        assert!(out.is_none());
+        let out = codex_curated_skills_config_arg(&s, None).expect("disabled snapshot");
+        assert!(out.contains("authoritative state"));
+        assert!(out.contains("Enabled: none."));
+        assert!(!out.contains("<skill id="));
     }
 
     #[test]
-    fn codex_curated_skills_config_arg_includes_curated_section_header_when_no_existing() {
-        // Empty enabled set -> None
-        let s = settings_with(vec![]);
-        assert!(codex_curated_skills_config_arg(&s, None).is_none());
+    fn codex_curated_skills_config_arg_marks_unlisted_skills_inactive() {
+        let s = settings_with(vec!["lazy-senior-dev"]);
+        let out = codex_curated_skills_config_arg(&s, None).expect("enabled snapshot");
+        assert!(out.contains("Enabled: `lazy-senior-dev`."));
+        assert!(out.contains("whose id is not listed here are inactive"));
+        assert!(out.contains("<skill id=\"lazy-senior-dev\">"));
+        assert!(!out.contains("<skill id=\"caveman\">"));
     }
 
     #[test]
-    fn build_codex_app_server_args_with_settings_does_not_inject_when_disabled() {
+    fn build_codex_app_server_args_with_settings_injects_deactivation_when_disabled() {
         let s = settings_with(vec![]);
         let args =
             build_codex_app_server_args_with_settings(None, primary_no_hint(), Some(&s)).unwrap();
-        // Should not contain any developer_instructions arg.
-        let any_dev = args.iter().any(|a| a.contains("developer_instructions="));
-        assert!(
-            !any_dev,
-            "no developer_instructions should be injected when no curated is enabled"
-        );
+        let developer_instructions = args
+            .iter()
+            .find_map(|arg| arg.strip_prefix("developer_instructions="))
+            .map(decode_toml_string)
+            .expect("deactivation developer instructions");
+        assert!(developer_instructions.contains("Enabled: none."));
+        assert!(!developer_instructions.contains("<skill id="));
         // Final arg is "app-server".
         assert_eq!(args.last().map(String::as_str), Some("app-server"));
     }
@@ -1994,6 +2014,43 @@ mod curated_skill_injection_tests {
             instructions.contains("lazy-senior-dev"),
             "got: {instructions}"
         );
+    }
+
+    #[test]
+    fn codex_generated_developer_instructions_for_turn_includes_all_reenabled_skills() {
+        let s = settings_with(vec!["lazy-senior-dev", "caveman"]);
+        let instructions =
+            codex_generated_developer_instructions_for_turn(&s).expect("turn instructions");
+
+        assert!(
+            instructions.contains("Enabled: `lazy-senior-dev`, `caveman`."),
+            "got: {instructions}"
+        );
+        assert!(
+            instructions.contains("<skill id=\"lazy-senior-dev\">"),
+            "got: {instructions}"
+        );
+        assert!(
+            instructions.contains("<skill id=\"caveman\">"),
+            "got: {instructions}"
+        );
+    }
+
+    #[test]
+    fn codex_generated_developer_instructions_for_turn_deactivates_empty_snapshot() {
+        let s = settings_with(vec![]);
+        let instructions =
+            codex_generated_developer_instructions_for_turn(&s).expect("turn instructions");
+
+        assert!(
+            instructions.contains("writableRoots"),
+            "got: {instructions}"
+        );
+        assert!(
+            instructions.contains("Enabled: none."),
+            "got: {instructions}"
+        );
+        assert!(!instructions.contains("<skill id="), "got: {instructions}");
     }
 
     #[test]

--- a/src-tauri/src/backend/app_server_tests.rs
+++ b/src-tauri/src/backend/app_server_tests.rs
@@ -172,6 +172,7 @@ async fn make_workspace_session(id: &str) -> Arc<WorkspaceSession> {
         thread_mode_state: crate::codex::thread_mode_state::ThreadModeState::default(),
         mode_enforcement_enabled: AtomicBool::new(false),
         collaboration_mode_supported: AtomicBool::new(false),
+        generated_developer_instructions_enabled: true,
         auto_compaction_threshold_percent: AUTO_COMPACTION_THRESHOLD_PERCENT,
         auto_compaction_enabled: true,
         auto_compaction_thread_state: Mutex::new(HashMap::new()),

--- a/src-tauri/src/bin/cc_gui_daemon/daemon_state.rs
+++ b/src-tauri/src/bin/cc_gui_daemon/daemon_state.rs
@@ -11,18 +11,8 @@ const DELETE_ARCHIVE_TIMEOUT_MS: u64 = 2_000;
 const LIST_THREADS_LIVE_TIMEOUT_MS: u64 = 1_500;
 const CLAUDE_POST_COMPLETION_USAGE_GRACE_MS: u64 = 35_000;
 
-#[cfg(windows)]
-fn codex_windows_turn_developer_instructions(
-    settings: &crate::types::AppSettings,
-) -> Option<String> {
+fn codex_turn_developer_instructions(settings: &crate::types::AppSettings) -> Option<String> {
     crate::backend::app_server_cli::codex_generated_developer_instructions_for_turn(settings)
-}
-
-#[cfg(not(windows))]
-fn codex_windows_turn_developer_instructions(
-    _settings: &crate::types::AppSettings,
-) -> Option<String> {
-    None
 }
 
 fn normalize_daemon_disk_provider_profile(
@@ -2927,7 +2917,7 @@ impl DaemonState {
             let settings = self.app_settings.lock().await;
             (
                 settings.codex_mode_enforcement_enabled,
-                codex_windows_turn_developer_instructions(&settings),
+                codex_turn_developer_instructions(&settings),
             )
         };
         codex_core::send_user_message_core(

--- a/src-tauri/src/codex/mod.rs
+++ b/src-tauri/src/codex/mod.rs
@@ -110,14 +110,8 @@ async fn collect_commit_message_diff(
     Ok(combine_repository_diff_sections(sections))
 }
 
-#[cfg(windows)]
-fn codex_windows_turn_developer_instructions(settings: &AppSettings) -> Option<String> {
+fn codex_turn_developer_instructions(settings: &AppSettings) -> Option<String> {
     crate::backend::app_server_cli::codex_generated_developer_instructions_for_turn(settings)
-}
-
-#[cfg(not(windows))]
-fn codex_windows_turn_developer_instructions(_settings: &AppSettings) -> Option<String> {
-    None
 }
 
 fn hidden_auto_session_metadata(
@@ -1236,7 +1230,7 @@ pub(crate) async fn send_user_message(
         let settings = state.app_settings.lock().await;
         (
             settings.codex_mode_enforcement_enabled,
-            codex_windows_turn_developer_instructions(&settings),
+            codex_turn_developer_instructions(&settings),
         )
     };
 

--- a/src-tauri/src/shared/codex_core.rs
+++ b/src-tauri/src/shared/codex_core.rs
@@ -903,12 +903,16 @@ pub(crate) async fn send_user_message_core(
     params.insert("input".to_string(), json!(input));
     if can_send_collaboration_mode {
         let enriched_collaboration_mode =
-            if let Some(extra_directive) = extra_developer_instructions.as_ref() {
-                apply_policy_to_collaboration_mode_with_extra_directives(
-                    collaboration_mode,
-                    &policy,
-                    std::slice::from_ref(extra_directive),
-                )
+            if session.generated_developer_instructions_enabled {
+                if let Some(extra_directive) = extra_developer_instructions.as_ref() {
+                    apply_policy_to_collaboration_mode_with_extra_directives(
+                        collaboration_mode,
+                        &policy,
+                        std::slice::from_ref(extra_directive),
+                    )
+                } else {
+                    apply_policy_to_collaboration_mode(collaboration_mode, &policy)
+                }
             } else {
                 apply_policy_to_collaboration_mode(collaboration_mode, &policy)
             };

--- a/src-tauri/src/shared_sessions.rs
+++ b/src-tauri/src/shared_sessions.rs
@@ -23,18 +23,8 @@ const SHARED_STORE_LOCK_STALE_TIMEOUT: Duration = Duration::from_secs(30);
 const MAX_DELTA_SYNC_TURNS: usize = 8;
 const MAX_DELTA_SYNC_CHARS: usize = 4_000;
 
-#[cfg(windows)]
-fn codex_windows_turn_developer_instructions(
-    settings: &crate::types::AppSettings,
-) -> Option<String> {
+fn codex_turn_developer_instructions(settings: &crate::types::AppSettings) -> Option<String> {
     crate::backend::app_server_cli::codex_generated_developer_instructions_for_turn(settings)
-}
-
-#[cfg(not(windows))]
-fn codex_windows_turn_developer_instructions(
-    _settings: &crate::types::AppSettings,
-) -> Option<String> {
-    None
 }
 
 fn is_supported_shared_session_engine(engine: EngineType) -> bool {
@@ -930,7 +920,7 @@ pub async fn send_shared_session_message(
                 let settings = state.app_settings.lock().await;
                 (
                     settings.codex_mode_enforcement_enabled,
-                    codex_windows_turn_developer_instructions(&settings),
+                    codex_turn_developer_instructions(&settings),
                 )
             };
             let response = codex_core::send_user_message_core(

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -253,6 +253,7 @@ pub(crate) fn read_settings(path: &PathBuf) -> Result<AppSettings, String> {
     let mut settings: AppSettings = serde_json::from_str(&data).map_err(|e| e.to_string())?;
     settings.normalize_unified_exec_policy();
     settings.upgrade_runtime_pool_settings_for_startup();
+    settings.upgrade_curated_skill_defaults_for_startup();
     settings.sanitize_engine_gates();
     Ok(settings)
 }
@@ -287,7 +288,8 @@ pub(crate) fn write_json_file<T: Serialize>(path: &Path, value: &T) -> Result<()
 #[cfg(test)]
 mod tests {
     use super::{
-        read_settings, read_workspaces, write_workspaces, write_workspaces_preserving_existing,
+        read_settings, read_workspaces, write_settings, write_workspaces,
+        write_workspaces_preserving_existing,
     };
     use crate::types::{AppSettings, WorkspaceEntry, WorkspaceKind, WorkspaceSettings};
     use std::sync::{Arc, Barrier};
@@ -636,5 +638,55 @@ mod tests {
 
         let read = read_settings(&path).expect("read settings");
         assert_eq!(read.codex_warm_ttl_seconds, 7200);
+    }
+
+    #[test]
+    fn read_settings_migrates_caveman_default_once_and_preserves_opt_out() {
+        let temp_dir = std::env::temp_dir().join(format!("moss-x-test-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&temp_dir).expect("create temp dir");
+        let path = temp_dir.join("settings.json");
+
+        let mut legacy = serde_json::to_value(AppSettings::default()).expect("serialize settings");
+        legacy
+            .as_object_mut()
+            .expect("settings object")
+            .remove("curatedSkillDefaultsVersion");
+        legacy.as_object_mut().expect("settings object").insert(
+            "enabledCuratedSkillIds".to_string(),
+            serde_json::json!(["lazy-senior-dev"]),
+        );
+        std::fs::write(
+            &path,
+            serde_json::to_string(&legacy).expect("encode legacy settings"),
+        )
+        .expect("write legacy settings");
+
+        let mut migrated = read_settings(&path).expect("read legacy settings");
+        assert_eq!(
+            migrated.enabled_curated_skill_ids,
+            vec!["lazy-senior-dev".to_string(), "caveman".to_string()]
+        );
+        assert_eq!(migrated.curated_skill_defaults_version, 1);
+
+        migrated.enabled_curated_skill_ids = vec!["lazy-senior-dev".to_string()];
+        write_settings(&path, &migrated).expect("persist Caveman opt-out");
+        let opted_out = read_settings(&path).expect("read opted-out settings");
+        assert_eq!(
+            opted_out.enabled_curated_skill_ids,
+            vec!["lazy-senior-dev".to_string()]
+        );
+
+        legacy
+            .as_object_mut()
+            .expect("settings object")
+            .insert("enabledCuratedSkillIds".to_string(), serde_json::json!([]));
+        std::fs::write(
+            &path,
+            serde_json::to_string(&legacy).expect("encode empty legacy settings"),
+        )
+        .expect("write empty legacy settings");
+        let empty = read_settings(&path).expect("read empty legacy settings");
+        assert!(empty.enabled_curated_skill_ids.is_empty());
+        assert_eq!(empty.curated_skill_defaults_version, 1);
     }
 }

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -1370,6 +1370,10 @@ pub(crate) struct AppSettings {
         rename = "enabledCuratedSkillIds"
     )]
     pub(crate) enabled_curated_skill_ids: Vec<String>,
+    /// One-shot version marker for newly introduced default curated skills.
+    /// Legacy settings omit this field and deserialize as 0.
+    #[serde(default, rename = "curatedSkillDefaultsVersion")]
+    pub(crate) curated_skill_defaults_version: u8,
     /// Built-in Agent Catalog ids the user explicitly enabled for discovery in
     /// the Composer `#` picker. Enablement never injects a prompt by itself.
     #[serde(
@@ -1764,7 +1768,13 @@ fn default_browser_agent_allow_external_provider_fallback() -> bool {
 }
 
 pub(crate) fn default_enabled_curated_skill_ids() -> Vec<String> {
-    vec!["lazy-senior-dev".to_string()]
+    vec!["lazy-senior-dev".to_string(), "caveman".to_string()]
+}
+
+const CURRENT_CURATED_SKILL_DEFAULTS_VERSION: u8 = 1;
+
+fn default_curated_skill_defaults_version() -> u8 {
+    CURRENT_CURATED_SKILL_DEFAULTS_VERSION
 }
 
 pub(crate) fn default_enabled_builtin_agent_ids() -> Vec<String> {
@@ -1802,6 +1812,21 @@ impl AppSettings {
         self.codex_warm_ttl_seconds = self
             .codex_warm_ttl_seconds
             .max(default_codex_warm_ttl_seconds());
+    }
+
+    pub(crate) fn upgrade_curated_skill_defaults_for_startup(&mut self) {
+        if self.curated_skill_defaults_version >= CURRENT_CURATED_SKILL_DEFAULTS_VERSION {
+            return;
+        }
+        if !self.enabled_curated_skill_ids.is_empty()
+            && !self
+                .enabled_curated_skill_ids
+                .iter()
+                .any(|id| id == "caveman")
+        {
+            self.enabled_curated_skill_ids.push("caveman".to_string());
+        }
+        self.curated_skill_defaults_version = CURRENT_CURATED_SKILL_DEFAULTS_VERSION;
     }
 
     pub(crate) fn sanitize_engine_gates(&mut self) {
@@ -1930,6 +1955,7 @@ impl Default for AppSettings {
             browser_agent_allow_external_provider_fallback:
                 default_browser_agent_allow_external_provider_fallback(),
             enabled_curated_skill_ids: default_enabled_curated_skill_ids(),
+            curated_skill_defaults_version: default_curated_skill_defaults_version(),
             enabled_builtin_agent_ids: default_enabled_builtin_agent_ids(),
         }
     }
@@ -2333,17 +2359,17 @@ mod tests {
     }
 
     #[test]
-    fn app_settings_defaults_enable_lazy_senior_curated_skill() {
+    fn app_settings_defaults_enable_core_curated_skills() {
         let settings = AppSettings::default();
         assert_eq!(
             settings.enabled_curated_skill_ids,
-            vec!["lazy-senior-dev".to_string()]
+            vec!["lazy-senior-dev".to_string(), "caveman".to_string()]
         );
 
         let decoded: AppSettings = serde_json::from_str("{}").expect("deserialize settings");
         assert_eq!(
             decoded.enabled_curated_skill_ids,
-            vec!["lazy-senior-dev".to_string()]
+            vec!["lazy-senior-dev".to_string(), "caveman".to_string()]
         );
     }
 

--- a/src/features/curated-skills/components/CuratedSection.tsx
+++ b/src/features/curated-skills/components/CuratedSection.tsx
@@ -10,6 +10,7 @@ import ExternalLink from "lucide-react/dist/esm/icons/external-link";
 import {
   CATEGORY_DEFAULTS,
   resolveCategoryLabel,
+  resolveCuratedSkillDescription,
   translateOrFallback,
 } from "../i18n/categoryLabels";
 import { resolveLucideIcon } from "../utils/resolveLucideIcon";
@@ -208,6 +209,10 @@ function CuratedRow({ entry, isPending, onToggle }: CuratedRowProps) {
     () => resolveCategoryLabel(t, entry.category),
     [t, entry.category],
   );
+  const description = useMemo(
+    () => resolveCuratedSkillDescription(t, entry.name, entry.description),
+    [t, entry.name, entry.description],
+  );
   const tokenLabel = useMemo(() => {
     // Round to 0.1K granularity for display (1100 -> 1.1K).
     const thousands = entry.tokenEstimate / 1000;
@@ -295,7 +300,7 @@ function CuratedRow({ entry, isPending, onToggle }: CuratedRowProps) {
             </a>
           ) : null}
         </div>
-        <div className="curated-section-row-description">{entry.description}</div>
+        <div className="curated-section-row-description">{description}</div>
         <div className="curated-section-row-meta">
           <span
             className="curated-section-row-token"

--- a/src/features/curated-skills/i18n/categoryLabels.test.ts
+++ b/src/features/curated-skills/i18n/categoryLabels.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   resolveCategoryLabel,
+  resolveCuratedSkillDescription,
   translateOrFallback,
   CATEGORY_DEFAULTS,
   CATEGORY_LABELS_I18N,
@@ -85,6 +86,25 @@ describe("translateOrFallback", () => {
       { count: 1100 },
     );
     expect(out).toBe("1100 tokens");
+  });
+});
+
+describe("resolveCuratedSkillDescription", () => {
+  it("uses the localized Caveman description when available", () => {
+    const t = makeT(["common.curatedSkillDescriptionCaveman"]);
+    expect(resolveCuratedSkillDescription(t, "caveman", "fallback")).toBe(
+      "translated:common.curatedSkillDescriptionCaveman",
+    );
+  });
+
+  it("keeps metadata text for unknown or untranslated skills", () => {
+    const t = makeT([]);
+    expect(resolveCuratedSkillDescription(t, "caveman", "fallback")).toBe(
+      "fallback",
+    );
+    expect(resolveCuratedSkillDescription(t, "custom", "metadata")).toBe(
+      "metadata",
+    );
   });
 });
 

--- a/src/features/curated-skills/i18n/categoryLabels.ts
+++ b/src/features/curated-skills/i18n/categoryLabels.ts
@@ -26,6 +26,11 @@ export const CATEGORY_LABELS_I18N: Record<CuratedCategory, string> = {
   debug: "common.curatedCategoryDebug",
 };
 
+const CURATED_SKILL_DESCRIPTION_I18N: Record<string, string> = {
+  caveman: "common.curatedSkillDescriptionCaveman",
+  "lazy-senior-dev": "common.curatedSkillDescriptionLazySeniorDev",
+};
+
 /**
  * English defaults for the curated UI. Used as a last-resort fallback
  * when the i18n bundle is missing the corresponding key.
@@ -122,4 +127,13 @@ export function resolveCategoryLabel(
     CATEGORY_DEFAULTS.category[category as CuratedCategory] ?? category;
   if (!key) return fallback;
   return translateOrFallback(t, key, fallback);
+}
+
+export function resolveCuratedSkillDescription(
+  t: TFunction,
+  skillId: string,
+  fallback: string,
+): string {
+  const key = CURATED_SKILL_DESCRIPTION_I18N[skillId];
+  return key ? translateOrFallback(t, key, fallback) : fallback;
 }

--- a/src/features/settings/components/SettingsView.test.tsx
+++ b/src/features/settings/components/SettingsView.test.tsx
@@ -344,6 +344,7 @@ const baseSettings: AppSettings = {
   composerListContinuation: false,
   composerCodeBlockCopyUseModifier: false,
   workspaceGroups: [],
+  curatedSkillDefaultsVersion: 1,
   openAppTargets: [
     {
       id: "vscode",

--- a/src/features/settings/hooks/useAppSettings.test.ts
+++ b/src/features/settings/hooks/useAppSettings.test.ts
@@ -99,7 +99,9 @@ describe("useAppSettings", () => {
     expect(result.current.settings.sessionAttributionMode).toBe("related");
     expect(result.current.settings.enabledCuratedSkillIds).toEqual([
       "lazy-senior-dev",
+      "caveman",
     ]);
+    expect(result.current.settings.curatedSkillDefaultsVersion).toBe(1);
   });
 
   it("keeps legacy Gemini enablement disabled", async () => {

--- a/src/features/settings/hooks/useAppSettings.ts
+++ b/src/features/settings/hooks/useAppSettings.ts
@@ -55,7 +55,7 @@ const ALLOWED_NOTIFICATION_SOUND_IDS = new Set([
 ]);
 const allowedEmailSenderProviders = new Set(["126", "163", "qq", "custom"]);
 const allowedEmailSenderSecurity = new Set(["ssl_tls", "start_tls", "none"]);
-const DEFAULT_ENABLED_CURATED_SKILL_IDS = ["lazy-senior-dev"];
+const DEFAULT_ENABLED_CURATED_SKILL_IDS = ["lazy-senior-dev", "caveman"];
 
 function defaultEnabledCuratedSkillIds(): string[] {
   return [...DEFAULT_ENABLED_CURATED_SKILL_IDS];
@@ -246,6 +246,7 @@ const defaultSettings: AppSettings = {
   customThemePresetId: "vscode-dark-modern",
   customSkillDirectories: [],
   enabledCuratedSkillIds: defaultEnabledCuratedSkillIds(),
+  curatedSkillDefaultsVersion: 1,
   enabledBuiltInAgentIds: [],
   canvasWidthMode: "narrow",
   layoutMode: "default",

--- a/src/i18n/locales/en/common.ts
+++ b/src/i18n/locales/en/common.ts
@@ -37,6 +37,10 @@ const common = {
     curatedViewOnGithub: "View on GitHub",
     curatedViewOnGithubAria:
       "Open the upstream source for {{name}} in your browser",
+    curatedSkillDescriptionCaveman:
+      "Concise communication with safe review and commit guidance while preserving technical substance and exact code or commands.",
+    curatedSkillDescriptionLazySeniorDev:
+      "Ponytail's 7-level ladder: prefer YAGNI, reuse existing code, use the standard library, platform, or installed dependencies, and write the smallest reliable diff.",
     later: "Later",
     yes: "Yes",
     no: "No",

--- a/src/i18n/locales/zh/common.ts
+++ b/src/i18n/locales/zh/common.ts
@@ -61,6 +61,10 @@ const common = {
     curatedToggleAria: "开关 {{name}}",
     curatedViewOnGithub: "在 GitHub 查看",
     curatedViewOnGithubAria: "在浏览器打开 {{name}} 的上游源码",
+    curatedSkillDescriptionCaveman:
+      "精简沟通内容，同时保留技术要点、原始代码与命令，并提供安全的代码审查和提交信息指引。",
+    curatedSkillDescriptionLazySeniorDev:
+      "遵循 Ponytail 七级阶梯：优先 YAGNI、复用现有代码，依次采用标准库、平台能力或已安装依赖，并提交最小且可靠的改动。",
   },
 };
 

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -203,5 +203,6 @@ export type AppSettings = {
   commitPrompt?: string;
   sendShortcut?: "enter" | "cmdEnter";
   enabledCuratedSkillIds?: string[];
+  curatedSkillDefaultsVersion: number;
   enabledBuiltInAgentIds?: string[];
 };


### PR DESCRIPTION
## 背景
- 把 Caveman 精选技能的 spec 与 OpenSpec 设计文档归档同步到 main，并补充 Codex resumed thread deactivation 与 settings defaults migration 两个新场景的契约。

## 改动点
- `.trellis/spec/backend/codex-provider-scoped-runtime.md`：新增 Codex curated-skill deactivation across resumed threads 场景规范（authoritative snapshot、空集语义、用户 override precedence 等）。
- `.trellis/spec/backend/database-guidelines.md`：新增 Versioned settings defaults migration 场景规范（marker version、idempotent upgrader、legacy 显式空集合语义）。
- `.trellis/spec/guides/cross-layer-thinking-guide.md`：补第 8 条跨层规则，区分 runtime state 与 persisted thread history。
- `openspec/changes/archive/2026-07-20-add-caveman-curated-skill-bundle/design.md`：归档 Caveman bundled curated skill 的完整设计文档。
- `openspec/changes/README.md`：更新 active / archived proposal 计数与归档批次索引。
- `.trellis/workspace/chenxiangning/{index.md,journal-26.md}`：记录 session 1047（内置 Caveman 精选技能）。

## 验证
- `openspec validate --all --strict --no-interactive`
- `npm run check:runtime-contracts`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib curated_skill_injection_tests`