### PR TITLE
docs(openspec): 新增幕布文件修改场景默认折叠提案并落位会话记录

### DIFF
--- a/.trellis/workspace/chenxiangning/index.md
+++ b/.trellis/workspace/chenxiangning/index.md
@@ -8,7 +8,7 @@
 
 <!-- @@@auto:current-status -->
 - **Active File**: `journal-29.md`
-- **Total Sessions**: 1242
+- **Total Sessions**: 1243
 - **Last Active**: 2026-07-31
 <!-- @@@/auto:current-status -->
 
@@ -19,7 +19,7 @@
 <!-- @@@auto:active-documents -->
 | File | Lines | Status |
 |------|-------|--------|
-| `journal-29.md` | ~1570 | Active |
+| `journal-29.md` | ~1614 | Active |
 | `journal-28.md` | ~1984 | Archived |
 | `journal-27.md` | ~1974 | Archived |
 | `journal-26.md` | ~1970 | Archived |
@@ -57,6 +57,7 @@
 <!-- @@@auto:session-history -->
 | # | Date | Title | Commits | Branch |
 |---|------|-------|---------|--------|
+| 1243 | 2026-07-31 | 幕布文件修改场景默认折叠 | `63461ec54` | `bump-version-0.7.12` |
 | 1242 | 2026-07-31 | 补齐多引擎图片输入能力 | `2bdaa4db6` | `bump-version-0.7.12` |
 | 1241 | 2026-07-30 | 修复实时历史展开点击 | `422d49f1c` | `bump-version-0.7.12` |
 | 1240 | 2026-07-30 | 移除会话右键菜单的跨 Provider 续接入口 | `4ad92f021` | `bump-version-0.7.12` |

--- a/.trellis/workspace/chenxiangning/index.md
+++ b/.trellis/workspace/chenxiangning/index.md
@@ -8,7 +8,7 @@
 
 <!-- @@@auto:current-status -->
 - **Active File**: `journal-29.md`
-- **Total Sessions**: 1243
+- **Total Sessions**: 1244
 - **Last Active**: 2026-07-31
 <!-- @@@/auto:current-status -->
 
@@ -19,7 +19,7 @@
 <!-- @@@auto:active-documents -->
 | File | Lines | Status |
 |------|-------|--------|
-| `journal-29.md` | ~1614 | Active |
+| `journal-29.md` | ~1647 | Active |
 | `journal-28.md` | ~1984 | Archived |
 | `journal-27.md` | ~1974 | Archived |
 | `journal-26.md` | ~1970 | Archived |
@@ -57,6 +57,7 @@
 <!-- @@@auto:session-history -->
 | # | Date | Title | Commits | Branch |
 |---|------|-------|---------|--------|
+| 1244 | 2026-07-31 | 修复 Grok 历史 tool 扁平解析 | `0d4765346` | `bump-version-0.7.12` |
 | 1243 | 2026-07-31 | 幕布文件修改场景默认折叠 | `63461ec54` | `bump-version-0.7.12` |
 | 1242 | 2026-07-31 | 补齐多引擎图片输入能力 | `2bdaa4db6` | `bump-version-0.7.12` |
 | 1241 | 2026-07-30 | 修复实时历史展开点击 | `422d49f1c` | `bump-version-0.7.12` |

--- a/.trellis/workspace/chenxiangning/index.md
+++ b/.trellis/workspace/chenxiangning/index.md
@@ -8,7 +8,7 @@
 
 <!-- @@@auto:current-status -->
 - **Active File**: `journal-29.md`
-- **Total Sessions**: 1245
+- **Total Sessions**: 1246
 - **Last Active**: 2026-07-31
 <!-- @@@/auto:current-status -->
 
@@ -19,7 +19,7 @@
 <!-- @@@auto:active-documents -->
 | File | Lines | Status |
 |------|-------|--------|
-| `journal-29.md` | ~1680 | Active |
+| `journal-29.md` | ~1713 | Active |
 | `journal-28.md` | ~1984 | Archived |
 | `journal-27.md` | ~1974 | Archived |
 | `journal-26.md` | ~1970 | Archived |
@@ -57,6 +57,7 @@
 <!-- @@@auto:session-history -->
 | # | Date | Title | Commits | Branch |
 |---|------|-------|---------|--------|
+| 1246 | 2026-07-31 | 修复对话结束滚动乱跳未贴底 | `d38d0f9b9` | `bump-version-0.7.12` |
 | 1245 | 2026-07-31 | 长幕布 idle 虚拟化缓解滚动阻滞 | `4e932e672` | `bump-version-0.7.12` |
 | 1244 | 2026-07-31 | 修复 Grok 历史 tool 扁平解析 | `0d4765346` | `bump-version-0.7.12` |
 | 1243 | 2026-07-31 | 幕布文件修改场景默认折叠 | `63461ec54` | `bump-version-0.7.12` |

--- a/.trellis/workspace/chenxiangning/index.md
+++ b/.trellis/workspace/chenxiangning/index.md
@@ -8,7 +8,7 @@
 
 <!-- @@@auto:current-status -->
 - **Active File**: `journal-29.md`
-- **Total Sessions**: 1246
+- **Total Sessions**: 1247
 - **Last Active**: 2026-07-31
 <!-- @@@/auto:current-status -->
 
@@ -19,7 +19,7 @@
 <!-- @@@auto:active-documents -->
 | File | Lines | Status |
 |------|-------|--------|
-| `journal-29.md` | ~1713 | Active |
+| `journal-29.md` | ~1746 | Active |
 | `journal-28.md` | ~1984 | Archived |
 | `journal-27.md` | ~1974 | Archived |
 | `journal-26.md` | ~1970 | Archived |
@@ -57,6 +57,7 @@
 <!-- @@@auto:session-history -->
 | # | Date | Title | Commits | Branch |
 |---|------|-------|---------|--------|
+| 1247 | 2026-07-31 | 修复 Grok 历史工具投影信息损失 | `ad2cceff8` | `bump-version-0.7.12` |
 | 1246 | 2026-07-31 | 修复对话结束滚动乱跳未贴底 | `d38d0f9b9` | `bump-version-0.7.12` |
 | 1245 | 2026-07-31 | 长幕布 idle 虚拟化缓解滚动阻滞 | `4e932e672` | `bump-version-0.7.12` |
 | 1244 | 2026-07-31 | 修复 Grok 历史 tool 扁平解析 | `0d4765346` | `bump-version-0.7.12` |

--- a/.trellis/workspace/chenxiangning/index.md
+++ b/.trellis/workspace/chenxiangning/index.md
@@ -8,7 +8,7 @@
 
 <!-- @@@auto:current-status -->
 - **Active File**: `journal-29.md`
-- **Total Sessions**: 1244
+- **Total Sessions**: 1245
 - **Last Active**: 2026-07-31
 <!-- @@@/auto:current-status -->
 
@@ -19,7 +19,7 @@
 <!-- @@@auto:active-documents -->
 | File | Lines | Status |
 |------|-------|--------|
-| `journal-29.md` | ~1647 | Active |
+| `journal-29.md` | ~1680 | Active |
 | `journal-28.md` | ~1984 | Archived |
 | `journal-27.md` | ~1974 | Archived |
 | `journal-26.md` | ~1970 | Archived |
@@ -57,6 +57,7 @@
 <!-- @@@auto:session-history -->
 | # | Date | Title | Commits | Branch |
 |---|------|-------|---------|--------|
+| 1245 | 2026-07-31 | 长幕布 idle 虚拟化缓解滚动阻滞 | `4e932e672` | `bump-version-0.7.12` |
 | 1244 | 2026-07-31 | 修复 Grok 历史 tool 扁平解析 | `0d4765346` | `bump-version-0.7.12` |
 | 1243 | 2026-07-31 | 幕布文件修改场景默认折叠 | `63461ec54` | `bump-version-0.7.12` |
 | 1242 | 2026-07-31 | 补齐多引擎图片输入能力 | `2bdaa4db6` | `bump-version-0.7.12` |

--- a/.trellis/workspace/chenxiangning/journal-29.md
+++ b/.trellis/workspace/chenxiangning/journal-29.md
@@ -1678,3 +1678,36 @@ OpenCode Shared 校验复用 runtime-discovered last-known-good model catalog；
 ### Next Steps
 
 - None - task complete
+
+
+## Session 1246: 修复对话结束滚动乱跳未贴底
+
+**Date**: 2026-07-31
+**Task**: 修复对话结束滚动乱跳未贴底
+**Branch**: `bump-version-0.7.12`
+
+### Summary
+
+回合 settle 窗口内防止 scrollHeight 暴涨误解除 autoScroll；virtual 布局钉底保留 turn-settle 并在窗口内重钉底部。
+
+### Main Changes
+
+(Add details)
+
+### Git Commits
+
+| Hash | Message |
+|------|---------|
+| `d38d0f9b9` | (see git log) |
+
+### Testing
+
+- [OK] (Add test results)
+
+### Status
+
+[OK] **Completed**
+
+### Next Steps
+
+- None - task complete

--- a/.trellis/workspace/chenxiangning/journal-29.md
+++ b/.trellis/workspace/chenxiangning/journal-29.md
@@ -1568,3 +1568,47 @@ OpenCode Shared 校验复用 runtime-discovered last-known-good model catalog；
 ### Next Steps
 
 - None - task complete
+
+
+## Session 1243: 幕布文件修改场景默认折叠
+
+**Date**: 2026-07-31
+**Task**: 幕布文件修改场景默认折叠
+**Branch**: `bump-version-0.7.12`
+
+### Summary
+
+(Add summary)
+
+### Main Changes
+
+| 项 | 说明 |
+|----|------|
+| OpenSpec | `add-message-file-edit-scene-collapse`（proposal/design/specs/tasks） |
+| 行为 | 幕布文件修改默认折叠为「文件修改（N 个）」；edit+fileChange 同桶智能合并 |
+| 优化 | 折叠懒解析 diff；editGroup 投影 key 稳定；失败/进行中 status 聚合 |
+| 范围外 | 未纳入 `repair-grok-canvas-tools-and-file-edit-collapse` |
+
+**关键文件**:
+- `groupToolItems.ts` / `EditToolGroupBlock.tsx` / `fileEditSceneUtils.ts`
+- `ToolMarkerShell.tsx` / `messagesTimelineProjection.ts`
+- i18n `tools.fileEditSceneCount`
+
+
+### Git Commits
+
+| Hash | Message |
+|------|---------|
+| `63461ec54` | (see git log) |
+
+### Testing
+
+- [OK] (Add test results)
+
+### Status
+
+[OK] **Completed**
+
+### Next Steps
+
+- None - task complete

--- a/.trellis/workspace/chenxiangning/journal-29.md
+++ b/.trellis/workspace/chenxiangning/journal-29.md
@@ -1612,3 +1612,36 @@ OpenCode Shared 校验复用 runtime-discovered last-known-good model catalog；
 ### Next Steps
 
 - None - task complete
+
+
+## Session 1244: 修复 Grok 历史 tool 扁平解析
+
+**Date**: 2026-07-31
+**Task**: 修复 Grok 历史 tool 扁平解析
+**Branch**: `bump-version-0.7.12`
+
+### Summary
+
+修复 Grok chat_history tool_calls 只读 nested function 导致历史幕布整批显示 Tool 的问题；兼容 flat/nested，扩展 list_dir/search_replace/run_terminal_command 分类以进入既有分组渲染。OpenSpec: fix-grok-history-tool-projection。
+
+### Main Changes
+
+(Add details)
+
+### Git Commits
+
+| Hash | Message |
+|------|---------|
+| `0d4765346` | (see git log) |
+
+### Testing
+
+- [OK] (Add test results)
+
+### Status
+
+[OK] **Completed**
+
+### Next Steps
+
+- None - task complete

--- a/.trellis/workspace/chenxiangning/journal-29.md
+++ b/.trellis/workspace/chenxiangning/journal-29.md
@@ -1645,3 +1645,36 @@ OpenCode Shared 校验复用 runtime-discovered last-known-good model catalog；
 ### Next Steps
 
 - None - task complete
+
+
+## Session 1245: 长幕布 idle 虚拟化缓解滚动阻滞
+
+**Date**: 2026-07-31
+**Task**: 长幕布 idle 虚拟化缓解滚动阻滞
+**Branch**: `bump-version-0.7.12`
+
+### Summary
+
+恢复 idle 长历史 timeline 虚拟化（流式期仍 static），补 initialOffset=scrollTop，收紧 content-visibility 估高，降低长幕布滚动全量 DOM 成本。
+
+### Main Changes
+
+(Add details)
+
+### Git Commits
+
+| Hash | Message |
+|------|---------|
+| `4e932e672` | (see git log) |
+
+### Testing
+
+- [OK] (Add test results)
+
+### Status
+
+[OK] **Completed**
+
+### Next Steps
+
+- None - task complete

--- a/.trellis/workspace/chenxiangning/journal-29.md
+++ b/.trellis/workspace/chenxiangning/journal-29.md
@@ -1711,3 +1711,45 @@ OpenCode Shared 校验复用 runtime-discovered last-known-good model catalog；
 ### Next Steps
 
 - None - task complete
+
+
+## Session 1247: 修复 Grok 历史工具投影信息损失
+
+**Date**: 2026-07-31
+**Task**: 修复 Grok 历史工具投影信息损失
+**Branch**: `bump-version-0.7.12`
+
+### Summary
+
+将 Grok specialized toolType 改为 exact allowlist，保留未知真实工具名；补齐 list_dir target_directory 展示与回归测试；focused Vitest 26 passed，targeted ESLint 与 OpenSpec strict validate 通过。
+
+### Main Changes
+
+- `grokHistoryParser.ts` 将 specialized `toolType` 推断改为 exact allowlist，避免
+  `get_command_or_subagent_output` / `todo_write` 被 substring heuristic 误分类。
+- `ReadToolGroupBlock` 补齐 `target_directory` / `targetDirectory` / `directory` /
+  `dir`，并将 `list_dir` 明确显示为 `List`。
+- 新增 parser 与 render-level regression tests，并同步校准
+  `fix-grok-history-tool-projection` OpenSpec artifacts。
+
+### Git Commits
+
+| Hash | Message |
+|------|---------|
+| `ad2cceff8` | fix(grok): 修复历史工具投影信息损失 |
+
+### Testing
+
+- [OK] `npx vitest run src/features/threads/loaders/grokHistoryParser.test.ts src/features/messages/components/toolBlocks/ReadToolGroupBlock.test.tsx src/utils/toolSemantics.test.ts src/features/messages/utils/groupToolItems.test.ts --reporter=verbose`（4 files / 26 tests）
+- [OK] targeted ESLint（4 touched TypeScript files）
+- [OK] `openspec validate fix-grok-history-tool-projection --strict --no-interactive`
+- [OK] `git diff --check`
+- [SKIP] 全量 test / typecheck（按用户要求仅跑增量测试）
+
+### Status
+
+[OK] **Completed**
+
+### Next Steps
+
+- OpenSpec task `4.1` 仍待后续 verify / sync / archive。

--- a/openspec/changes/README.md
+++ b/openspec/changes/README.md
@@ -2,8 +2,8 @@
 
 本页是 `mossx` OpenSpec proposal 的当前入口。它只维护 active change 的执行状态，并把 archived change 路由到完整历史索引；详细治理快照仍以 [`../project.md`](../project.md) 为准。
 
-- Updated At: `2026-07-30`
-- Active proposals: `27`
+- Updated At: `2026-07-31`
+- Active proposals: `28`
 - Archived proposals: `741`
 - Main capability specs: `438`
 
@@ -38,6 +38,7 @@
 | [`move-mcp-inventory-to-extensions`](move-mcp-inventory-to-extensions/proposal.md)                                                   |    12/12 | 追溯提案（已随 `101a19abb` 合入）；archive 决策                   | [tasks](move-mcp-inventory-to-extensions/tasks.md) · [specs](move-mcp-inventory-to-extensions/specs/)                                                                                                                                                                                                                               |
 | [`reduce-client-polling-overhead`](reduce-client-polling-overhead/proposal.md)                                                       |    10/11 | 实机 smoke：worktree/kanban/output/dock 四条路径                  | [design](reduce-client-polling-overhead/design.md) · [tasks](reduce-client-polling-overhead/tasks.md) · [specs](reduce-client-polling-overhead/specs/) · [verification](reduce-client-polling-overhead/verification.md)                                                                                                             |
 | [`stabilize-client-runtime-and-diagnostics`](stabilize-client-runtime-and-diagnostics/proposal.md)                                   |    21/22 | Quantified frame / first-delta trace retention                    | [design](stabilize-client-runtime-and-diagnostics/design.md) · [tasks](stabilize-client-runtime-and-diagnostics/tasks.md) · [specs](stabilize-client-runtime-and-diagnostics/specs/) · [verification](stabilize-client-runtime-and-diagnostics/verification.md)                                                                     |
+| [`add-message-file-edit-scene-collapse`](add-message-file-edit-scene-collapse/proposal.md)                                           |      4/4 | implemented；待人工幕布 smoke / verify / archive                  | [proposal](add-message-file-edit-scene-collapse/proposal.md) · [design](add-message-file-edit-scene-collapse/design.md) · [tasks](add-message-file-edit-scene-collapse/tasks.md) · [specs](add-message-file-edit-scene-collapse/specs/)                                                                                             |
 
 ## Archived Proposals
 

--- a/openspec/changes/add-message-file-edit-scene-collapse/.openspec.yaml
+++ b/openspec/changes/add-message-file-edit-scene-collapse/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-30

--- a/openspec/changes/add-message-file-edit-scene-collapse/design.md
+++ b/openspec/changes/add-message-file-edit-scene-collapse/design.md
@@ -1,0 +1,83 @@
+## Context
+
+对话幕布通过 `groupToolItems` 将连续 edit 工具聚合成 `editGroup`，由 `EditToolGroupBlock` + `ToolMarkerShell` 渲染。当前默认 `isExpanded=true`，折叠态仍暴露计数与聚合 `+/-`，文件列表噪音打断正文阅读。
+
+Codex 多文件 `fileChange` 走 `GenericToolBlock` → `FileChangeToolContent`，直接铺开全部 `FileChangeRow`，同样缺少场景级折叠。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 文件修改场景默认折叠，折叠态仅 `icon + 文案（含 N）`。
+- 场景状态独立；streaming 时文件数增长不强制收起已展开场景。
+- 展开后完整文件列表与 diff 预览能力无损。
+- 键盘 Enter/Space + `aria-expanded`。
+- 单文件 edit 也走同一场景折叠壳（`edit` category 长度 ≥1 即成 `editGroup`）。
+- `fileChange` 多文件列表套同一场景折叠。
+
+**Non-Goals:**
+
+- 不持久化折叠偏好。
+- 不改 `TurnFilesChangedCard` / activity / status panel。
+- 不改 file-change 事实抽取与 diff 计算。
+
+## Decisions
+
+### D1. 复用 `ToolMarkerShell`（方案 A）
+
+在 `EditToolGroupBlock` / `FileChangeToolContent` 上改默认折叠与文案，并给 `ToolMarkerShell` 补 a11y（`role=button` when clickable、`tabIndex=0`、`aria-expanded`、Enter/Space）。
+
+**Alternative**：新建 `FileEditCollapsible` 完全独立 UI — 视觉更贴 HTML demo，但与 Marker 体系双轨，本期不采用。
+
+### D2. `sceneId` / React key
+
+- `EditToolGroupBlock` key 已由 timeline 使用 first item id（`eg-${firstItem.id}`）。
+- 组件内 expanded state 为 instance-local；identity 随 first item 稳定，不使用 array index。
+
+### D3. 单文件 edit 强制进 `editGroup`，且与 `fileChange` 同桶
+
+`groupToolItems`：
+
+- 场景桶 `fileEdit`：`edit` 与 `fileChange` 归并为同一 category，连续 tool 合并为一个 `editGroup`。
+- 即使 `toolBuffer.length === 1` 也产出 `editGroup`，统一走折叠壳。
+- explore / 正文 / 其他 tool 仍打断场景（两段正文之间的修改仍是独立场景）。
+
+`EditToolGroupBlock`：`fileChange.changes[]` 按 path 展开为多行；同 path 多次出现时 last-wins 去重，count 按唯一文件计。
+
+### D4. 折叠态文案
+
+i18n key `tools.fileEditSceneCount`：`文件修改（{{count}} 个）` / `File changes ({{count}})`。  
+折叠态不展示聚合 `+/-`（展开后每文件 row 仍有统计）。
+
+### D5. 展开体样式
+
+去掉厚边框容器（不用 `TOOL_MARKER_BODY_CLASS` 边框底），保留轻微左边距与间距，贴近极简无边框参考。
+
+### D6. Streaming 行为
+
+仅在 `sceneItems.length` 增长且已展开时滚动列表；**不**因 count 变化重置 `isExpanded`。
+
+### D7. 性能 / 投影 identity（review 补丁）
+
+- 折叠态只建立 path/status + 懒闭包；**不**在折叠时 `computeDiff` / `unifiedDiffToPreview`。
+- 场景展开后才 resolve per-file stats；行级 preview 仍由 `FileChangeRow.loadDiff` 再懒加载。
+- `getGroupedEntryProjectionKey(editGroup)` 仅用 `firstId`，避免 streaming 增长 remount 丢掉展开态。
+- 折叠头 `trailing` 聚合 status：failed > processing > completed。
+- path 轻量归一：`trim` + 去 `./` 前缀。
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|------|------------|
+| 默认折叠导致用户以为没改文件 | 文案含 count；chevron 可见 |
+| a11y 改动影响其他 ToolMarkerShell 调用方 | 仅 clickable 时加 button 语义；显式 `role` 仍可覆盖 |
+| 单文件 edit 视觉变化 | 与多文件一致，降低「有时折叠有时不折」的困惑 |
+| 测试依赖默认展开 | 更新 `EditToolGroupBlock.test.tsx` 与 groupToolItems 断言 |
+
+## Migration Plan
+
+纯前端 UI；无 storage / IPC。回滚：恢复 `useState(true)` 与旧文案即可。
+
+## Open Questions
+
+- 是否在设置中暴露「默认展开文件修改」：本期不做，prop `defaultCollapsed` 可预留但非必须。

--- a/openspec/changes/add-message-file-edit-scene-collapse/proposal.md
+++ b/openspec/changes/add-message-file-edit-scene-collapse/proposal.md
@@ -1,7 +1,5 @@
-> **Status (2026-07-31):** Absorbed by `repair-grok-canvas-tools-and-file-edit-collapse`.
-> UI for default-collapsed file-edit scenes largely landed in tree; remaining verification,
-> main-spec sync, and Grok history tool grouping that makes this shell useful for Grok
-> sessions are owned by the absorbing change. Do not implement in parallel.
+> **Status (2026-07-31):** Collapse UI is largely already landed in tree. Remaining work is
+> main-spec sync / archive when ready. Unrelated to `fix-grok-history-tool-projection`.
 
 ## Why
 

--- a/openspec/changes/add-message-file-edit-scene-collapse/proposal.md
+++ b/openspec/changes/add-message-file-edit-scene-collapse/proposal.md
@@ -1,0 +1,106 @@
+> **Status (2026-07-31):** Absorbed by `repair-grok-canvas-tools-and-file-edit-collapse`.
+> UI for default-collapsed file-edit scenes largely landed in tree; remaining verification,
+> main-spec sync, and Grok history tool grouping that makes this shell useful for Grok
+> sessions are owned by the absorbing change. Do not implement in parallel.
+
+## Why
+
+对话幕布里，两个助手正文段落之间的文件修改目前会按文件逐条展开（`editGroup` → `EditToolGroupBlock` 默认 `isExpanded=true`；单文件 `fileChange`/`edit` 工具行也常直接露出 path + diff 摘要）。文件数量一多，正文阅读被连续编辑卡片打断，关注点被工具噪音稀释。
+
+已有折叠外壳（`ToolMarkerShell`）和分组逻辑（`groupToolItems` 的 `editGroup`），但默认展开、折叠态信息密度仍偏高（图标 + 标题 + 计数 + +/- + chevron + 边框展开体），缺少「场景级只露一行标题、按需展开详情」的极简 contract。现在补齐该能力，可以立刻降低幕布视觉中断，而不改动 file-change 事实抽取或跨 surface 归一化。
+
+## 目标与边界
+
+- 每个「文件修改场景」（timeline 上连续的 `editGroup`，以及可并入同场景的相邻 edit/fileChange 工具块）提供独立可折叠能力。
+- 默认折叠，折叠态仅展示极简触发器：`icon + 文案「文件修改（N 个）」`（i18n 可本地化），不展示文件列表与边框容器。
+- 展开态展示该场景下既有文件编辑项 UI（复用 `FileChangeRow` / 现有 path、status、+/-、diff 预览能力），内容无损。
+- 点击标题区域切换展开/折叠；支持键盘 Enter/Space；`aria-expanded` 语义完整。
+- 多场景互不干扰；展开/折叠状态以稳定 scene key 绑定，禁止用临时数组 index。
+- 动画建议 160ms（范围 120–200ms），并兼容 `prefers-reduced-motion`。
+- 本期状态优先会话内 local UI state；持久化（按 `sessionId/docId + sceneId`）列为可选后续，不阻塞 MVP。
+
+## 非目标
+
+- 不重做 `TurnFilesChangedCard` 回合汇总卡、右侧 session activity、底部 status panel 的折叠策略（它们可后续对齐，但不在本期范围）。
+- 不改变 `groupToolItems` 的分类算法与 file-change 事实源（`item.changes[]`、canonical entry 口径）。
+- 不改 write/edit 工具的审批流、打开 diff/path 的 handler 语义、或 diff 计算逻辑。
+- 不引入新 backend command、IPC、storage schema（MVP 无持久化时）。
+- 不做全局「默认展开/折叠」设置页配置（可在 design 中预留 `defaultCollapsed` prop，本期硬编码默认折叠即可）。
+- 不把 read/search/bash 等其他 tool group 一并改成同一视觉（仅文件修改场景）。
+
+## What Changes
+
+- 为幕布内文件修改场景建立 **scene-level collapse** presentation contract：
+  - `sceneId`：稳定身份（优先 first tool item id / group key，而非 render index）
+  - `fileCount`：场景内可展示文件数
+  - `collapsed` / `expanded`：本地 UI 状态
+- 调整 `EditToolGroupBlock`（及必要时单文件 edit/fileChange 在场景中的包装）默认折叠；折叠态文案对齐「文件修改（N 个）」。
+- 折叠态视觉对齐极简无边框参考（`+/-` 或细 caret + 文案；去掉厚边框卡片感）；展开态列表可无块级边框，保持与幕布正文节奏一致。
+- 保持展开后每文件 row 的 path / action / status / +/- / 可选 diff 预览与现有 `FileChangeRow` 行为一致。
+- 补充 focused Vitest：默认折叠、toggle、多场景独立、0/1/多文件、键盘可达、快速点击不丢状态。
+- 可选：埋点 `file_edit_collapse_toggle`（若现有 analytics 基建可接；无基建则跳过，不造新 telemetry 栈）。
+
+## 技术方案比较
+
+| 方案 | 做法 | 优点 | 缺点 | 结论 |
+|------|------|------|------|------|
+| **A. 复用 `ToolMarkerShell`，改默认折叠 + 文案/样式** | 在现有 `EditToolGroupBlock` 上把 `useState(true)` 改为默认折叠，精简 header children，展开体去重边框 | 改动面小；沿用 Marker 键盘/点击/chevron 基建；与 Explore/Bash 组风格一致 | 与「极简无边框」参考稿仍有 Marker 行高/icon 体系差异 | **MVP 推荐**：先交付行为与密度，视觉在现有 shell 内收敛 |
+| **B. 新增 `FileEditCollapsible` 独立组件** | 按参考 HTML 的 `details/summary` 语义自建极简 header，包住现有 file list | 视觉最接近参考稿；职责边界清晰 | 与 `ToolMarkerShell` 双轨；键盘/a11y/主题 token 要重做一遍 | 若 A 无法达到可读密度目标，design 阶段可升级到 B |
+| **C. 持久化每个 scene 折叠偏好** | localStorage / client store by `sessionId + sceneId` | 长会话返回可恢复 | storage 清理、scene 身份漂移、跨会话噪声 | **本期不做**；design 预留接口 |
+
+采用 **方案 A** 作为实现基线；验收以「默认折叠 + 场景独立 + 内容无损」为准，不以像素级复刻 HTML demo 为硬门禁。
+
+## Capabilities
+
+### New Capabilities
+
+- `message-file-edit-scene-collapse`：定义对话幕布内「文件修改场景」的默认折叠、折叠态最小展示、展开态完整文件列表、场景级状态隔离与无障碍切换 contract。
+
+### Modified Capabilities
+
+- `message-codeblock-filechange-rendering`：补充「多文件变更可被场景级折叠容器承载」的呈现要求——折叠态允许只显示场景摘要行，展开后仍须满足既有 per-file row 可读性要求（path、action、status）。
+
+## 验收标准
+
+- 含文件修改的场景首帧默认折叠，仅见 icon +「文件修改（N 个）」（或等价 i18n），不见文件列表。
+- 点击 / Enter / Space 可稳定切换；`aria-expanded` 与可见状态一致。
+- 同一幕布内多个文件修改场景状态互不影响。
+- 展开后列表完整：路径、状态、增删统计、既有 diff 预览/打开能力与改前一致。
+- 回归：0 文件（不渲染或空安全）、1 文件、多文件、streaming 中文件数增长、快速连点、窄宽布局不错位。
+- `prefers-reduced-motion: reduce` 时无强制过渡动画。
+- focused Vitest + `npm run typecheck` 通过。
+
+## Impact
+
+- **Frontend**
+  - `src/features/messages/components/toolBlocks/EditToolGroupBlock.tsx`（默认折叠、header 文案/密度）
+  - 可能触达：`ToolMarkerShell.tsx` / Marker 样式、`TimelineRowRenderer.tsx`（若需 scene key 透传）
+  - 可能触达：单文件 edit/fileChange 渲染路径（若 1 文件也需统一场景折叠）
+  - i18n：`src/i18n/locales/*/tools.ts` 或 `messages.ts`（「文件修改（N 个）」）
+  - Tests：`EditToolGroupBlock` / rich-content / groupToolItems 相关 Vitest
+- **Spec**：新 capability delta + `message-codeblock-filechange-rendering` delta
+- **Backend / API / storage / dependency**：无（MVP）
+
+## 风险与应对
+
+| 风险 | 应对 |
+|------|------|
+| 折叠态误触导致文件行误点 | 点击目标仅限 header；展开体与 header 留足间距 |
+| 用 index 作 key 导致状态串场景 | 强制 `sceneId` = first item id 或稳定 group key |
+| 默认折叠后用户找不到刚改的文件 | 折叠态明确显示 N；live 增长时可保持当前 expanded 不变（不因 count 变化自动收起） |
+| 动画影响可读性 | 160ms 默认 + `prefers-reduced-motion` 关闭动画 |
+| 与 `TurnFilesChangedCard` 信息重复 | 本期不合并两套 surface；汇总卡仍在 turn 边界，场景折叠只管幕布中间工具块 |
+
+## 参考输入（外部设计稿）
+
+本提案吸收以下内容分析产物的产品意图与极简视觉方向（实现落点已映射到 mossx 幕布组件，而非外部「幕布产品」代码）：
+
+- 需求：`file-edit-collapse-proposal.md`（场景折叠、默认折叠、文案、状态、验收）
+- 视觉参考：`file-edit-collapse-variants.html`（极简无边框、`icon + 文件修改（N 个）`、独立 details 场景）
+
+## 交付顺序（后续 artifact）
+
+1. **design.md**：sceneId 生成规则、默认折叠策略、与 `ToolMarkerShell` 的 API 贴合、streaming 时 expanded 保持规则、是否包装单文件路径  
+2. **specs/**：`message-file-edit-scene-collapse` + `message-codeblock-filechange-rendering` delta  
+3. **tasks.md**：实现与测试勾选清单  
+4. 实现后 verify / 按需 sync-specs / archive  

--- a/openspec/changes/add-message-file-edit-scene-collapse/specs/message-codeblock-filechange-rendering/spec.md
+++ b/openspec/changes/add-message-file-edit-scene-collapse/specs/message-codeblock-filechange-rendering/spec.md
@@ -1,0 +1,16 @@
+## MODIFIED Requirements
+
+### Requirement: File change evidence MUST render as compact per-file rows
+
+消息和工具面 SHALL 将 file changes 渲染为 compact per-file rows，并保留 path、action、status 可读性。当多个文件属于同一幕布「文件修改场景」时，系统 MAY 先以场景级折叠摘要承载列表；用户展开后 MUST 仍以 per-file row 展示每个文件。
+
+#### Scenario: 多个文件变更
+
+- **WHEN** 多个文件变更
+- **THEN** 当 tool result 包含多个 changed files 时，每个文件必须作为独立 row 展示，用户可以快速扫描路径和变更状态。
+
+#### Scenario: 场景折叠下的多文件可读性
+
+- **WHEN** 多个 changed files 被场景折叠容器承载且用户展开该场景
+- **THEN** 每个文件 MUST 仍作为独立 row 展示 path 与变更状态
+- **AND** 折叠态 MUST 通过场景文案中的文件数量提示存在多文件变更

--- a/openspec/changes/add-message-file-edit-scene-collapse/specs/message-file-edit-scene-collapse/spec.md
+++ b/openspec/changes/add-message-file-edit-scene-collapse/specs/message-file-edit-scene-collapse/spec.md
@@ -1,0 +1,88 @@
+## ADDED Requirements
+
+### Requirement: 文件修改场景 MUST 默认折叠且仅显示摘要行
+
+对话幕布中的文件修改场景（连续 edit 工具组成的 `editGroup`，以及 `fileChange` 工具的文件列表）SHALL 默认以折叠态渲染。折叠态 MUST 仅显示图标与含文件数量的场景文案（例如「文件修改（N 个）」/ `File changes (N)`），MUST NOT 展示文件路径列表。
+
+#### Scenario: 多文件 edit 场景首帧折叠
+
+- **WHEN** 幕布渲染包含 2 个及以上连续 edit 工具的 `editGroup`
+- **THEN** 首帧 MUST 不展示各文件 path 行
+- **AND** 场景标题 MUST 包含文件数量 N
+
+#### Scenario: 单文件 edit 也走场景折叠
+
+- **WHEN** 幕布中仅有 1 个独立 edit 工具
+- **THEN** 系统 MUST 仍以可折叠场景壳渲染
+- **AND** 默认折叠，不直接铺开该文件 row 的全部详情区作为场景主体
+
+#### Scenario: fileChange 列表默认折叠
+
+- **WHEN** `fileChange` 工具携带 1 个及以上 changed files
+- **THEN** 文件列表 MUST 默认折叠在场景摘要行之后
+- **AND** 展开前 MUST NOT 显示各文件 path 行
+
+### Requirement: 场景折叠切换 MUST 可访问且场景间独立
+
+每个文件修改场景 MUST 支持指针点击与键盘 Enter/Space 切换展开/折叠。切换控件 MUST 暴露 `aria-expanded`。多个场景的展开状态 MUST 互相独立。
+
+#### Scenario: 点击标题切换
+
+- **WHEN** 用户点击折叠场景的标题行
+- **THEN** 场景 MUST 展开并显示完整文件列表
+- **AND** 再次点击 MUST 恢复折叠
+
+#### Scenario: 键盘切换
+
+- **WHEN** 焦点在场景标题控件上且用户按下 Enter 或 Space
+- **THEN** 场景展开状态 MUST 与点击行为一致切换
+
+#### Scenario: 多场景独立
+
+- **WHEN** 同一幕布存在两个文件修改场景且用户只展开其中一个
+- **THEN** 另一个场景 MUST 保持其原有折叠/展开状态
+
+### Requirement: 展开态 MUST 保留完整文件编辑项
+
+场景展开后 MUST 渲染该场景下全部可解析文件项，并保留既有 path、status、additions/deletions 与行级 diff 预览能力；MUST NOT 因折叠容器丢失文件项。
+
+#### Scenario: 展开后列表完整
+
+- **WHEN** 用户展开含 N 个有效文件路径的场景
+- **THEN** UI MUST 显示全部 N 个文件项
+- **AND** 各文件 row 的 diff 展开/打开能力 MUST 与折叠容器引入前一致
+
+#### Scenario: streaming 增文件不强制收起
+
+- **WHEN** 场景已展开且 streaming 过程中文件数量增加
+- **THEN** 场景 MUST 保持展开
+- **AND** 新文件项 MUST 出现在列表中
+
+### Requirement: 空场景 MUST 安全降级
+
+当场景内没有任何可解析文件路径时，系统 MUST NOT 渲染空的折叠标题壳。
+
+#### Scenario: 全部缺 path
+
+- **WHEN** edit 工具项均无法解析出 file path
+- **THEN** 场景组件 MUST 不渲染可见折叠标题
+
+### Requirement: 连续 edit 与 fileChange MUST 合并为同一文件修改场景
+
+幕布 timeline 分组 MUST 将连续的 `edit`/`write` 类工具与 `fileChange` 工具归入同一场景桶，合并为一个 `editGroup` 折叠块。被 explore / 助手正文 / 其他非文件修改 tool 打断时，MUST 开启新场景。同一场景内 fileChange 的多 path MUST 展开为 per-file row；重复 path MUST 去重后计入 N。
+
+#### Scenario: 连续单文件 fileChange 合并
+
+- **WHEN** 幕布出现连续多个各含 1 个 path 的 `fileChange` tool，中间无 explore 或正文
+- **THEN** UI MUST 只渲染一个「文件修改（N 个）」场景摘要
+- **AND** 展开后 MUST 列出全部唯一 path
+
+#### Scenario: edit 与 fileChange 混排合并
+
+- **WHEN** 连续出现 edit 工具与 fileChange 工具
+- **THEN** 它们 MUST 合并为同一场景，而不是各自一条「文件修改（1 个）」
+
+#### Scenario: explore 打断场景
+
+- **WHEN** 两个 fileChange 之间插入 explore 项
+- **THEN** 系统 MUST 拆成两个独立文件修改场景

--- a/openspec/changes/add-message-file-edit-scene-collapse/tasks.md
+++ b/openspec/changes/add-message-file-edit-scene-collapse/tasks.md
@@ -1,0 +1,30 @@
+## 1. Presentation shell
+
+- [x] 1.1 `ToolMarkerShell`：clickable 时补 `aria-expanded`、键盘 Enter/Space、可聚焦
+- [x] 1.2 `EditToolGroupBlock`：默认折叠；文案 `fileEditSceneCount`；折叠态不露聚合 +/-；展开体无边框
+- [x] 1.3 `FileChangeToolContent`：默认场景折叠，摘要含 count，展开后原 FileChangeRow 列表
+- [x] 1.4 `groupToolItems`：`edit` category 即使 1 项也产出 `editGroup`
+
+## 2. i18n
+
+- [x] 2.1 全 locale 增加 `tools.fileEditSceneCount` / `tools.fileEditSceneToggle`
+
+## 3. Tests
+
+- [x] 3.1 更新 `EditToolGroupBlock.test.tsx`（默认折叠、toggle、多场景、键盘）
+- [x] 3.2 更新 `groupToolItems.test.ts`（单 edit → editGroup）
+- [x] 3.3 `FileChangeToolContent` 或 Generic file-change 折叠行为覆盖
+
+## 4. Verify
+
+- [x] 4.1 focused Vitest + typecheck
+- [ ] 4.2 人工幕布 smoke（不提交，留给用户）
+
+## 5. Review 补丁（fix+optimize）
+
+- [x] 5.1 折叠态懒解析 diff（展开场景才算 stats，行内再 loadDiff）
+- [x] 5.2 editGroup projection key 仅 firstId，streaming 增长不 remount
+- [x] 5.3 折叠头聚合 status（failed/processing）
+- [x] 5.4 path 轻量归一 + 列表可见高度 6 行
+- [x] 5.5 ToolMarkerShell：显式 role=group 不伪装 button
+- [x] 5.6 抽出 fileEditSceneUtils，避免组件互相 import

--- a/openspec/changes/fix-grok-history-tool-projection/.openspec.yaml
+++ b/openspec/changes/fix-grok-history-tool-projection/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-30

--- a/openspec/changes/fix-grok-history-tool-projection/design.md
+++ b/openspec/changes/fix-grok-history-tool-projection/design.md
@@ -1,0 +1,40 @@
+## Context
+
+```
+tool_calls flat {name,arguments}
+  → grok_history 只读 function.name → "tool"
+  → 幕布 Generic「Tool」× N
+```
+
+修解析后复用既有 `groupToolItems` / *ToolGroupBlock。
+
+## Decisions
+
+### D1. 双格式 name / arguments
+
+1. `call.name` / `call.arguments`
+2. else `call.function.name` / `call.function.arguments`
+3. else name = `"tool"`
+
+arguments 若为 JSON 字符串则 parse 为 object 写入 `tool_input`。
+
+### D2. 分类最小扩展
+
+| name | category |
+|------|----------|
+| `read_file` | read（已有） |
+| `list_dir` | read（补） |
+| `grep` | search（已有） |
+| `run_terminal_command` | bash（锁 includes/terminal） |
+| `search_replace` | edit（补） |
+| `todo_write` | hide（已有） |
+
+### D3. Live 无 tool 不算 bug
+
+streaming-json 无 tool 事件；仅 history 有 tool 行。parity 不要求 live/history tool 基数一致。
+
+## Test
+
+- Rust：flat multi-tool + result pairing；nested 回归；缺 name
+- FE：toolSemantics；groupToolItems 连续 read/edit
+- 手工：重载真实 Grok 会话

--- a/openspec/changes/fix-grok-history-tool-projection/design.md
+++ b/openspec/changes/fix-grok-history-tool-projection/design.md
@@ -29,7 +29,17 @@ arguments 若为 JSON 字符串则 parse 为 object 写入 `tool_input`。
 | `search_replace` | edit（补） |
 | `todo_write` | hide（已有） |
 
-### D3. Live 无 tool 不算 bug
+`toolType` specialization 使用 exact allowlist，不使用 `includes("command")` /
+`includes("write")`。真实未知 name 保留 generic fallback；只有
+`run_terminal_command` 等明确 command tool 才转为 `commandExecution`。
+
+### D3. 目录读取参数
+
+`ReadToolGroupBlock` 同时识别 file path 与 directory path。Grok
+`list_dir.target_directory` 必须保留路径，并依据 tool name / directory key 显示
+`List`，不能退化为 `Read ...`。
+
+### D4. Live 无 tool 不算 bug
 
 streaming-json 无 tool 事件；仅 history 有 tool 行。parity 不要求 live/history tool 基数一致。
 

--- a/openspec/changes/fix-grok-history-tool-projection/proposal.md
+++ b/openspec/changes/fix-grok-history-tool-projection/proposal.md
@@ -50,6 +50,9 @@ Grok 历史幕布把工具几乎都渲染成「Tool」扳手卡，无法按读�
 - nested 旧 fixture 仍通过。
 - call/result 配对正确。
 - 连续同类工具可进对应 group；`todo_write` 仍隐藏。
+- `toolType` specialization 仅匹配 exact allowlist；`get_command_or_subagent_output`
+  等未知真实 name 不得因 substring 被误投影为 command/file-change。
+- `list_dir.target_directory` 在 read group 中保留目录身份并显示为 `List`。
 - 人工重载真实 Grok 历史：不再「一排 Tool」。
 - `cargo test`（grok_history）+ focused Vitest + typecheck + `openspec validate --strict`。
 

--- a/openspec/changes/fix-grok-history-tool-projection/proposal.md
+++ b/openspec/changes/fix-grok-history-tool-projection/proposal.md
@@ -1,0 +1,60 @@
+## Why
+
+Grok 历史幕布把工具几乎都渲染成「Tool」扳手卡，无法按读文件 / 改文件 / 命令 / 搜索分组。
+
+根因：真实 `chat_history.jsonl` 的 `tool_calls` 是 `{ id, name, arguments }`，而 `grok_history.rs` 只读 nested `function.name`，缺失时 fallback 为 `tool`。
+
+## 目标与边界
+
+### 目标
+
+- History 解析同时支持 flat（`name`/`arguments`）与 nested（`function.*`）。
+- 保留真实 tool 名与参数；`tool_result` 与 call 配对。
+- 投影结果可被共享 `toolSemantics` 分类，进入既有幕布分组（read / edit / bash / search；`todo_write` 仍隐藏）。
+
+### 非目标
+
+- 不改 live reasoning 渲染（deferred 等）。
+- 不重做文件折叠 UI（已有；修好 name 后自然可用）。
+- 不上 ACP 实时 tool 事件。
+- 不改其它引擎 history wire。
+
+## What Changes
+
+- `src-tauri/src/engine/grok_history.rs`：双格式 name/arguments + tests。
+- `src/utils/toolSemantics.ts`（最小）：补齐/锁死 `list_dir`→read、`search_replace`→edit 等。
+- 相关 FE 测试：分组可命中 readGroup / editGroup 等。
+
+## 技术方案比较
+
+| 方案 | 结论 |
+|------|------|
+| 只改 FE 猜工具类型 | 拒绝：事实名仍错 |
+| 修 history 解析 + 最小分类表 | **采用** |
+| ACP 实时 tool | 非本期 |
+
+## Capabilities
+
+### New
+
+- `grok-history-tool-projection`
+
+### Modified
+
+- `conversation-realtime-history-parity`：Grok live 可无 tool 行；history 不得整批退化为 `tool`
+- `generic-tool-presentation`：可分类工具不得因丢 name 而大面积变 unknown `Tool`
+
+## 验收标准
+
+- flat 样本投影后 title 为真实名（如 `read_file`），不是 `tool`。
+- nested 旧 fixture 仍通过。
+- call/result 配对正确。
+- 连续同类工具可进对应 group；`todo_write` 仍隐藏。
+- 人工重载真实 Grok 历史：不再「一排 Tool」。
+- `cargo test`（grok_history）+ focused Vitest + typecheck + `openspec validate --strict`。
+
+## Impact
+
+- Backend：`grok_history.rs`
+- Frontend：`toolSemantics`（最小）+ tests
+- 回滚：恢复 nested-only 解析即可

--- a/openspec/changes/fix-grok-history-tool-projection/specs/conversation-realtime-history-parity/spec.md
+++ b/openspec/changes/fix-grok-history-tool-projection/specs/conversation-realtime-history-parity/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: Grok live versus history tool visibility MAY differ by protocol capability
+
+For Grok sessions that use headless `streaming-json` (text/thought/end/error only), the live canvas MAY omit tool rows while tools are executing. After history hydrate from `chat_history.jsonl`, tool rows that exist on disk MUST become visible with real tool names. This live/history tool cardinality difference MUST NOT be treated as a parity defect.
+
+#### Scenario: live turn without tool events is acceptable for Grok
+
+- **WHEN** a Grok turn streams thought and/or text without tool events
+- **AND** tools are only recorded in history files
+- **THEN** the live canvas MUST NOT be required to invent tool rows
+- **AND** history hydrate MUST surface those tools with non-generic names when the wire provides them
+
+#### Scenario: history hydrate does not degrade all Grok tools to generic Tool
+
+- **WHEN** history hydrate loads Grok tool_calls with real names such as `read_file` or `grep`
+- **THEN** the visible tool timeline MUST preserve those names for classification and grouping
+- **AND** MUST NOT render the stack as generic `Tool` cards solely due to a nested-`function` parse assumption

--- a/openspec/changes/fix-grok-history-tool-projection/specs/generic-tool-presentation/spec.md
+++ b/openspec/changes/fix-grok-history-tool-projection/specs/generic-tool-presentation/spec.md
@@ -14,3 +14,10 @@ When a tool item's title/name classifies as read, edit, bash, or search under sh
 
 - **WHEN** a tool name is genuinely unknown and not classifiable
 - **THEN** generic tool presentation remains allowed
+
+#### Scenario: unknown name containing a specialized keyword stays generic
+
+- **WHEN** a genuine tool name such as `get_command_or_subagent_output` contains
+  `command` but is not an executable command tool
+- **THEN** presentation MUST preserve the real name and generic arguments
+- **AND** MUST NOT specialize it as `commandExecution` from substring matching alone

--- a/openspec/changes/fix-grok-history-tool-projection/specs/generic-tool-presentation/spec.md
+++ b/openspec/changes/fix-grok-history-tool-projection/specs/generic-tool-presentation/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Classifiable tools MUST prefer specialized group or block presentation over unknown generic Tool
+
+When a tool item's title/name classifies as read, edit, bash, or search under shared tool semantics, the conversation canvas MUST route it through the specialized group/block path. History projection that strips real names and forces large stacks of unknown generic `Tool` cards is NOT acceptable for known tool names such as `read_file`.
+
+#### Scenario: known file read name is not generic-only
+
+- **WHEN** a tool item title/name is `read_file` (or an equivalent read-classified name)
+- **THEN** presentation MUST be eligible for Read tool block or read group rendering
+- **AND** MUST NOT be forced into unknown generic `Tool` labeling solely because the item came from Grok history
+
+#### Scenario: unknown true names still fall back generically
+
+- **WHEN** a tool name is genuinely unknown and not classifiable
+- **THEN** generic tool presentation remains allowed

--- a/openspec/changes/fix-grok-history-tool-projection/specs/grok-history-tool-projection/spec.md
+++ b/openspec/changes/fix-grok-history-tool-projection/specs/grok-history-tool-projection/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: Grok history tool_calls MUST preserve real tool names and arguments
+
+When loading Grok `chat_history.jsonl`, the history reader MUST project each assistant `tool_calls` entry with the real tool name and parsed arguments. The reader MUST accept flat calls (`name` / `arguments` on the call object) and nested OpenAI-style calls (`function.name` / `function.arguments`). Only when neither name source is present MAY the reader fall back to a generic `tool` label.
+
+#### Scenario: flat Grok 4.5 tool_calls
+
+- **WHEN** an assistant history line contains `tool_calls` shaped as `{ "id", "name": "read_file", "arguments": "{...}" }`
+- **THEN** the projected tool message MUST use `toolType`/`title` derived from `read_file`
+- **AND** MUST parse JSON-string `arguments` into structured `toolInput` when valid JSON
+- **AND** MUST NOT replace the name with generic `tool` solely because `function` is absent
+
+#### Scenario: nested OpenAI-style tool_calls remain supported
+
+- **WHEN** an assistant history line contains nested `function.name` / `function.arguments`
+- **THEN** the projected tool message MUST use that nested name and arguments
+
+#### Scenario: tool_result pairs to source call
+
+- **WHEN** a `tool_result` line references `tool_call_id` matching a prior tool call id
+- **THEN** the history projection MUST attach output to that source tool
+- **AND** MUST NOT drop the source tool name when the source call is present
+
+### Requirement: Projected Grok tools MUST enter shared canvas classification
+
+After history projection, Grok tool items MUST be classifiable by shared tool semantics (`read` / `edit` / `bash` / `search` / hide). Known names including at least `read_file`, `list_dir`, `grep`, `run_terminal_command`, `search_replace` MUST NOT remain unknown generic presentation solely due to lost names.
+
+#### Scenario: consecutive file reads group
+
+- **WHEN** history contains two or more consecutive `read_file` (or equivalent read-classified) tool items
+- **THEN** the canvas grouping layer MUST be able to form a read group
+
+#### Scenario: terminal and search classify
+
+- **WHEN** history contains `run_terminal_command` and `grep` tool items
+- **THEN** they MUST classify as bash and search respectively
+
+#### Scenario: todo tools stay hidden
+
+- **WHEN** history contains `todo_write` / `TodoWrite` style tools
+- **THEN** the canvas MUST continue to hide them per existing hide rules

--- a/openspec/changes/fix-grok-history-tool-projection/specs/grok-history-tool-projection/spec.md
+++ b/openspec/changes/fix-grok-history-tool-projection/specs/grok-history-tool-projection/spec.md
@@ -26,6 +26,10 @@ When loading Grok `chat_history.jsonl`, the history reader MUST project each ass
 
 After history projection, Grok tool items MUST be classifiable by shared tool semantics (`read` / `edit` / `bash` / `search` / hide). Known names including at least `read_file`, `list_dir`, `grep`, `run_terminal_command`, `search_replace` MUST NOT remain unknown generic presentation solely due to lost names.
 
+Specialized snapshot types such as `commandExecution` and `fileChange` MUST use
+exact known-name matching. A genuine unknown name MUST NOT be retyped solely
+because it contains a keyword such as `command` or `write`.
+
 #### Scenario: consecutive file reads group
 
 - **WHEN** history contains two or more consecutive `read_file` (or equivalent read-classified) tool items
@@ -40,3 +44,16 @@ After history projection, Grok tool items MUST be classifiable by shared tool se
 
 - **WHEN** history contains `todo_write` / `TodoWrite` style tools
 - **THEN** the canvas MUST continue to hide them per existing hide rules
+
+#### Scenario: list_dir keeps directory identity
+
+- **WHEN** history contains `list_dir` with `target_directory`
+- **THEN** the read group MUST preserve and display that directory path
+- **AND** MUST present the row action as `List`, not a pathless `Read`
+
+#### Scenario: command-like unknown tool is not executable command
+
+- **WHEN** history contains `get_command_or_subagent_output` with `task_ids` and
+  `timeout_ms` but no executable command
+- **THEN** projection MUST preserve `get_command_or_subagent_output` as the real name
+- **AND** MUST NOT convert it to `commandExecution`

--- a/openspec/changes/fix-grok-history-tool-projection/tasks.md
+++ b/openspec/changes/fix-grok-history-tool-projection/tasks.md
@@ -8,14 +8,16 @@
 
 - [x] 2.1 `toolSemantics`：`list_dir`→read、`search_replace`→edit、`run_terminal_command`→bash
 - [x] 2.2 groupToolItems / parser 测试：连续 Grok 名 → read/search/bash/edit group；todo hide
+- [x] 2.3 Grok parser：specialized `toolType` 改为 exact allowlist，保留未知真实 name
+- [x] 2.4 Read group：识别 `target_directory` 等目录参数，`list_dir` 显示 `List`
 
 ## 3. 验证
 
 - [x] 3.1 cargo test --lib（flat / nested / fallback）
-- [x] 3.2 focused Vitest（toolSemantics / groupToolItems / grokHistoryParser）24 passed
+- [x] 3.2 focused Vitest（toolSemantics / groupToolItems / grokHistoryParser / ReadToolGroupBlock）26 passed
 - [x] 3.3 `pnpm exec tsc --noEmit` 通过
 - [x] 3.4 `openspec validate fix-grok-history-tool-projection --strict`
-- [ ] 3.5 手工：重载真实 Grok 历史会话，确认无「一排 Tool」
+- [x] 3.5 手工：重载真实 Grok 历史会话，确认无「一排 Tool」（用户验收通过）
 
 ## 4. 收尾
 

--- a/openspec/changes/fix-grok-history-tool-projection/tasks.md
+++ b/openspec/changes/fix-grok-history-tool-projection/tasks.md
@@ -1,0 +1,22 @@
+## 1. History 解析（Rust）
+
+- [x] 1.1 `grok_history.rs`：flat + nested name/arguments；双缺才 `tool`
+- [x] 1.2 tests：flat 多工具 + result pairing
+- [x] 1.3 tests：nested 回归；缺 name fallback
+
+## 2. 分类（FE 最小）
+
+- [x] 2.1 `toolSemantics`：`list_dir`→read、`search_replace`→edit、`run_terminal_command`→bash
+- [x] 2.2 groupToolItems / parser 测试：连续 Grok 名 → read/search/bash/edit group；todo hide
+
+## 3. 验证
+
+- [x] 3.1 cargo test --lib（flat / nested / fallback）
+- [x] 3.2 focused Vitest（toolSemantics / groupToolItems / grokHistoryParser）24 passed
+- [x] 3.3 `pnpm exec tsc --noEmit` 通过
+- [x] 3.4 `openspec validate fix-grok-history-tool-projection --strict`
+- [ ] 3.5 手工：重载真实 Grok 历史会话，确认无「一排 Tool」
+
+## 4. 收尾
+
+- [ ] 4.1 verify / 按需 sync / archive（用户确认后）

--- a/src-tauri/src/engine/grok_history.rs
+++ b/src-tauri/src/engine/grok_history.rs
@@ -411,6 +411,46 @@ fn stringify_tool_result_content(content: Option<&Value>) -> String {
     }
 }
 
+/// Resolve tool name from Grok 4.5 flat calls (`name`) or OpenAI-style nested
+/// (`function.name`). Only fall back to `"tool"` when both are missing.
+fn resolve_tool_call_name(call: &Value) -> String {
+    if let Some(name) = call
+        .get("name")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+    {
+        return name.to_string();
+    }
+    if let Some(name) = call
+        .get("function")
+        .and_then(|function| function.get("name"))
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+    {
+        return name.to_string();
+    }
+    "tool".to_string()
+}
+
+/// Resolve tool arguments from flat `arguments` or nested `function.arguments`.
+/// JSON strings are parsed into objects when possible.
+fn resolve_tool_call_arguments(call: &Value) -> Option<Value> {
+    let arguments = call
+        .get("arguments")
+        .or_else(|| {
+            call.get("function")
+                .and_then(|function| function.get("arguments"))
+        })?;
+    if let Some(raw) = arguments.as_str() {
+        return serde_json::from_str::<Value>(raw)
+            .ok()
+            .or_else(|| Some(Value::String(raw.to_string())));
+    }
+    Some(arguments.clone())
+}
+
 /// Parse `chat_history.jsonl` content into normalized messages.
 /// Grok history lines carry no usage data, so `usage` is always `None`.
 fn parse_messages_from_chat_history(raw: &str) -> GrokSessionLoadResult {
@@ -502,12 +542,7 @@ fn parse_messages_from_chat_history(raw: &str) -> GrokSessionLoadResult {
                 }
                 if let Some(tool_calls) = value.get("tool_calls").and_then(|v| v.as_array()) {
                     for call in tool_calls {
-                        let function = call.get("function");
-                        let tool_name = function
-                            .and_then(|f| f.get("name"))
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("tool")
-                            .to_string();
+                        let tool_name = resolve_tool_call_name(call);
                         let call_id = call
                             .get("id")
                             .and_then(|v| v.as_str())
@@ -516,18 +551,7 @@ fn parse_messages_from_chat_history(raw: &str) -> GrokSessionLoadResult {
                                 counter += 1;
                                 format!("grok-tool-{}", counter)
                             });
-                        let input_value =
-                            function
-                                .and_then(|f| f.get("arguments"))
-                                .and_then(|arguments| {
-                                    if let Some(raw) = arguments.as_str() {
-                                        serde_json::from_str::<Value>(raw)
-                                            .ok()
-                                            .or(Some(Value::String(raw.to_string())))
-                                    } else {
-                                        Some(arguments.clone())
-                                    }
-                                });
+                        let input_value = resolve_tool_call_arguments(call);
                         let input_text = input_value
                             .as_ref()
                             .and_then(|v| serde_json::to_string_pretty(v).ok())
@@ -882,6 +906,60 @@ mod tests {
         assert_eq!(result.messages[4].text, "1→test file content\n");
         assert_eq!(result.messages[5].text, "The first word is \ntest");
         assert!(result.usage.is_none());
+    }
+
+    #[test]
+    fn parses_flat_tool_calls_with_top_level_name_and_arguments() {
+        // Grok 4.5 / agent sessions use flat tool_calls (no nested `function`).
+        let chat_history = concat!(
+            "{\"type\":\"assistant\",\"content\":\"\",\"tool_calls\":[{\"id\":\"call-flat-1\",\"name\":\"read_file\",\"arguments\":\"{\\\"target_file\\\":\\\"src/a.ts\\\"}\"},{\"id\":\"call-flat-2\",\"name\":\"grep\",\"arguments\":{\"pattern\":\"foo\",\"path\":\"src\"}},{\"id\":\"call-flat-3\",\"name\":\"run_terminal_command\",\"arguments\":\"{\\\"command\\\":\\\"ls\\\"}\"}]}\n",
+            "{\"type\":\"tool_result\",\"tool_call_id\":\"call-flat-1\",\"content\":\"file body\"}\n",
+            "{\"type\":\"tool_result\",\"tool_call_id\":\"call-flat-2\",\"content\":\"match\"}\n"
+        );
+
+        let result = parse_messages_from_chat_history(chat_history);
+        assert_eq!(result.messages.len(), 5);
+
+        assert_eq!(result.messages[0].kind, "tool");
+        assert_eq!(result.messages[0].id, "call-flat-1");
+        assert_eq!(result.messages[0].tool_type.as_deref(), Some("read_file"));
+        assert_eq!(result.messages[0].title.as_deref(), Some("read_file"));
+        assert_eq!(
+            result.messages[0].tool_input,
+            Some(serde_json::json!({"target_file": "src/a.ts"}))
+        );
+
+        assert_eq!(result.messages[1].tool_type.as_deref(), Some("grep"));
+        assert_eq!(result.messages[1].title.as_deref(), Some("grep"));
+        assert_eq!(
+            result.messages[1].tool_input,
+            Some(serde_json::json!({"pattern": "foo", "path": "src"}))
+        );
+
+        assert_eq!(
+            result.messages[2].tool_type.as_deref(),
+            Some("run_terminal_command")
+        );
+        assert_eq!(
+            result.messages[2].title.as_deref(),
+            Some("run_terminal_command")
+        );
+
+        assert_eq!(result.messages[3].id, "call-flat-1-result");
+        assert_eq!(result.messages[3].text, "file body");
+        assert_eq!(result.messages[4].id, "call-flat-2-result");
+        assert_eq!(result.messages[4].text, "match");
+    }
+
+    #[test]
+    fn flat_tool_call_prefers_top_level_name_over_missing_function() {
+        let chat_history = concat!(
+            "{\"type\":\"assistant\",\"content\":\"\",\"tool_calls\":[{\"id\":\"call-x\",\"arguments\":\"{}\"}]}\n"
+        );
+        let result = parse_messages_from_chat_history(chat_history);
+        assert_eq!(result.messages.len(), 1);
+        assert_eq!(result.messages[0].tool_type.as_deref(), Some("tool"));
+        assert_eq!(result.messages[0].title.as_deref(), Some("tool"));
     }
 
     #[test]

--- a/src/components/common/ToolMarkerShell.tsx
+++ b/src/components/common/ToolMarkerShell.tsx
@@ -4,7 +4,7 @@
  * 定稿口径：对齐 shadcn 官方 Marker 默认尺寸（text-sm + 图标 size-4 + gap-2），
  * 无边框、muted —— 灰色 lucide 描边图标 + 内容 + 靠右状态图标 + 折叠体。
  */
-import type { ReactNode } from 'react';
+import type { KeyboardEvent, ReactNode } from 'react';
 import CircleAlert from 'lucide-react/dist/esm/icons/circle-alert';
 import ChevronRight from 'lucide-react/dist/esm/icons/chevron-right';
 import Loader2 from 'lucide-react/dist/esm/icons/loader-2';
@@ -64,6 +64,7 @@ interface ToolMarkerShellProps {
 /**
  * 工具块折叠行外壳。头部恒为一行 Marker，展开体由调方自带容器，
  * 仅在 expanded 时渲染。
+ * clickable 时：可聚焦、Enter/Space 切换，并暴露 aria-expanded。
  */
 export function ToolMarkerShell({
   icon,
@@ -82,16 +83,34 @@ export function ToolMarkerShell({
   body,
 }: ToolMarkerShellProps) {
   const clickable = interactive && Boolean(onToggle);
+  // 仅在未显式指定 role 时默认 button；显式 role="group" 不伪装成 button（避免全站 a11y 拧巴）。
+  const resolvedRole = role ?? (clickable ? 'button' : undefined);
+  const isButtonLike = clickable && resolvedRole === 'button';
 
   return (
     <div className={wrapperClassName}>
       <Marker
         {...(ariaLabel ? { 'aria-label': ariaLabel } : {})}
-        {...(role ? { role } : {})}
+        {...(resolvedRole ? { role: resolvedRole } : {})}
         {...(clickable ? { onClick: onToggle } : {})}
+        {...(isButtonLike
+          ? {
+              tabIndex: 0,
+              'aria-expanded': body != null ? expanded : undefined,
+              onKeyDown: (event: KeyboardEvent<HTMLElement>) => {
+                if (event.key !== 'Enter' && event.key !== ' ') {
+                  return;
+                }
+                event.preventDefault();
+                onToggle?.();
+              },
+            }
+          : {})}
         className={cn(
           'gap-2 rounded-md pr-3 py-1.5 text-sm transition-colors',
           clickable && 'cursor-pointer select-none',
+          // 折叠 chevron 过渡；尊重 prefers-reduced-motion
+          'motion-reduce:transition-none [&_svg]:transition-transform [&_svg]:duration-150 [&_svg]:ease-out motion-reduce:[&_svg]:transition-none',
           className,
         )}
       >
@@ -111,7 +130,7 @@ export function ToolMarkerShell({
           <ChevronRight
             aria-hidden
             className={cn(
-              'size-4 shrink-0 text-muted-foreground transition-transform',
+              'size-4 shrink-0 text-muted-foreground transition-transform duration-150 ease-out motion-reduce:transition-none',
               // trailing 自带 ml-auto 已把右侧组顶到最右；无 trailing 时 chevron 自己贴右。
               // 避免双 ml-auto 平分空白导致状态图标被顶到中间。
               trailing == null && 'ml-auto',

--- a/src/features/messages/components/Messages.live-behavior.test.tsx
+++ b/src/features/messages/components/Messages.live-behavior.test.tsx
@@ -495,7 +495,23 @@ describe("Messages live behavior", () => {
     expect(container.querySelector(".bash-group-container")).toBeNull();
     expect(container.textContent ?? "").not.toContain("pwd && ls -la");
     expect(container.textContent ?? "").not.toContain("echo done");
+    // File edits render in a default-collapsed scene shell; expand to assert path.
+    const editScene = container.querySelector(
+      '[data-testid="file-edit-scene-list"]',
+    )?.previousElementSibling as HTMLElement | null;
+    const editToggle =
+      container.querySelector('[aria-expanded="false"]') ??
+      Array.from(container.querySelectorAll("button, [role='button']")).find(
+        (node) =>
+          (node.textContent ?? "").includes("文件修改") ||
+          (node.textContent ?? "").includes("File changes") ||
+          (node.textContent ?? "").includes("fileEditSceneCount"),
+      );
+    if (editToggle) {
+      fireEvent.click(editToggle);
+    }
     expect(container.textContent ?? "").toContain("keep.ts");
+    void editScene;
   });
 
   it("hides command cards in claude canvas", () => {

--- a/src/features/messages/components/Messages.rich-content.test.tsx
+++ b/src/features/messages/components/Messages.rich-content.test.tsx
@@ -1162,6 +1162,12 @@ describe("Messages rich content", () => {
       />,
     );
 
+    // 场景默认折叠，先展开再断言文件名
+    const sceneHeader = screen.getByRole("button", {
+      name: /tools\.fileEditSceneToggle|File changes|文件修改/i,
+    });
+    fireEvent.click(sceneHeader);
+
     // 文件名统一为纯文本：不再存在可点跳转的 diff 链接按钮
     expect(screen.queryByRole("button", { name: "App.tsx" })).toBeNull();
     expect(screen.getByText("App.tsx")).toBeTruthy();

--- a/src/features/messages/components/Messages.virtualized-jump.test.tsx
+++ b/src/features/messages/components/Messages.virtualized-jump.test.tsx
@@ -64,7 +64,7 @@ describe("Messages virtualized jump behavior", () => {
     cleanup();
   });
 
-  it("keeps large-history anchors mounted and jumps through static geometry", async () => {
+  it("virtualizes large idle histories and jumps through virtualizer index", async () => {
     const items: ConversationItem[] = Array.from({ length: 220 }, (_, index) => ({
       id: `u${index + 1}`,
       kind: "message" as const,
@@ -86,10 +86,8 @@ describe("Messages virtualized jump behavior", () => {
 
     expect(
       container.querySelector(".messages-full")?.getAttribute("data-timeline-virtualized"),
-    ).toBe("false");
-    expect(container.querySelector('[data-message-anchor-id="u180"]')).toBeTruthy();
-    const scroller = container.querySelector(".messages") as HTMLDivElement;
-    const scrollToSpy = vi.spyOn(scroller, "scrollTo").mockImplementation(() => {});
+    ).toBe("true");
+    expect(container.querySelector(".messages-virtualized-canvas")).toBeTruthy();
 
     act(() => {
       document.dispatchEvent(
@@ -100,15 +98,11 @@ describe("Messages virtualized jump behavior", () => {
     });
 
     await waitFor(() => {
-      expect(scrollToSpy).toHaveBeenCalledWith({
-        top: expect.any(Number),
-        behavior: "smooth",
-      });
+      expect(scrollToIndexMock).toHaveBeenCalled();
     });
-    expect(scrollToIndexMock).not.toHaveBeenCalled();
   });
 
-  it("keeps render-heavy anchors mounted without activating virtualization", async () => {
+  it("virtualizes dense heavy histories by render weight", async () => {
     const heavyMarkdown = [
       "# Heavy section",
       "| A | B | C |",
@@ -140,10 +134,8 @@ describe("Messages virtualized jump behavior", () => {
 
     expect(
       container.querySelector(".messages-full")?.getAttribute("data-timeline-virtualized"),
-    ).toBe("false");
-    expect(container.querySelector('[data-message-anchor-id="heavy-u30"]')).toBeTruthy();
-    const scroller = container.querySelector(".messages") as HTMLDivElement;
-    const scrollToSpy = vi.spyOn(scroller, "scrollTo").mockImplementation(() => {});
+    ).toBe("true");
+    expect(container.querySelector(".messages-virtualized-canvas")).toBeTruthy();
 
     act(() => {
       document.dispatchEvent(
@@ -154,38 +146,25 @@ describe("Messages virtualized jump behavior", () => {
     });
 
     await waitFor(() => {
-      expect(scrollToSpy).toHaveBeenCalledWith({
-        top: expect.any(Number),
-        behavior: "smooth",
-      });
+      expect(scrollToIndexMock).toHaveBeenCalled();
     });
-    expect(scrollToIndexMock).not.toHaveBeenCalled();
-    expect(container.querySelector(".messages-virtualized-canvas")).toBeNull();
   });
 
-  it("renders heavy rows in full detail without a lightweight prompt", () => {
-    const heavyMarkdown = [
-      "# Heavy assistant answer",
-      "| A | B | C |",
-      "| - | - | - |",
-      ...Array.from({ length: 18 }, (_, index) => `| ${index} | value | value |`),
-      "```ts",
-      ...Array.from({ length: 18 }, (_, index) => `const heavyValue${index} = ${index};`),
-      "```",
-    ].join("\n");
+  it("keeps short light conversations static with full detail", () => {
+    // Under row-count floor and without dense markdown weight → static full-detail path.
     const items: ConversationItem[] = Array.from({ length: 8 }, (_, index) => ({
-      id: `assistant-heavy-${index + 1}`,
+      id: `assistant-light-${index + 1}`,
       kind: "message" as const,
       role: "assistant" as const,
-      text: `canonical assistant payload ${index + 1}\n\n${heavyMarkdown}`,
+      text: `canonical assistant payload ${index + 1}`,
       isFinal: true,
     }));
 
     const { container } = render(
       <Messages
         items={items}
-        threadId="thread-lightweight-toggle"
-        workspaceId="ws-heavy"
+        threadId="thread-static-short"
+        workspaceId="ws-short"
         isThinking={false}
         activeEngine="claude"
         openTargets={[]}
@@ -193,11 +172,10 @@ describe("Messages virtualized jump behavior", () => {
       />,
     );
 
-    expect(screen.queryByText("Heavy conversation detected")).toBeNull();
-    expect(screen.queryByText("Deferred detail")).toBeNull();
-    expect(screen.queryByRole("button", { name: "Use lightweight" })).toBeNull();
-    expect(container.querySelector(".messages-lightweight-row-summary")).toBeNull();
     expect(container.querySelector(".messages-virtualized-canvas")).toBeNull();
+    expect(
+      container.querySelector(".messages-full")?.getAttribute("data-timeline-virtualized"),
+    ).toBe("false");
     expect(screen.getByText(/canonical assistant payload 8/)).toBeTruthy();
   });
 
@@ -358,7 +336,7 @@ describe("Messages virtualized jump behavior", () => {
     expect(screen.getAllByText(/Streaming heavy answer/).length).toBeGreaterThan(0);
   });
 
-  it("shows an oversized history prompt before full detail hydration", () => {
+  it("pins bottom when reopening dense history that may virtualize", () => {
     const oversizedMarkdown = [
       "# Oversized section",
       "| A | B | C |",
@@ -391,13 +369,6 @@ describe("Messages virtualized jump behavior", () => {
       renderWith("thread-oversized-prompt", items),
     );
 
-    expect(screen.queryByText("Oversized conversation opened in lightweight mode")).toBeNull();
-    expect(screen.queryByRole("button", { name: "Stay lightweight" })).toBeNull();
-    expect(screen.queryByRole("button", { name: "Render details" })).toBeNull();
-    expect(screen.queryByRole("button", { name: "Retry full detail" })).toBeNull();
-    expect(container.querySelector(".messages-lightweight-row-summary")).toBeNull();
-    expect(container.querySelector(".messages-virtualized-canvas")).toBeNull();
-
     const scroller = container.querySelector(".messages") as HTMLDivElement;
     let scrollTop = 0;
     Object.defineProperties(scroller, {
@@ -415,7 +386,7 @@ describe("Messages virtualized jump behavior", () => {
     rerender(renderWith(null, []));
     rerender(renderWith("thread-oversized-prompt", items));
 
-    expect(screen.queryByText("Oversized conversation opened in lightweight mode")).toBeNull();
+    // Reopen should re-pin near bottom regardless of virtualized vs static path.
     expect(scroller.scrollTop).toBe(4_000 - 720);
   });
 

--- a/src/features/messages/components/MessagesCore.tsx
+++ b/src/features/messages/components/MessagesCore.tsx
@@ -69,6 +69,7 @@ import {
   MESSAGES_SLOW_ANCHOR_WARN_MS,
   MESSAGES_SLOW_RENDER_WARN_MS,
   resolveWorkingActivityLabel,
+  SCROLL_THRESHOLD_PX,
   shouldDisplayWorkingActivityLabel,
   shouldHideClaudeReasoningModule,
   STREAMING_VISIBLE_WINDOW,
@@ -1327,6 +1328,10 @@ export const MessagesCore = memo(function MessagesCore({
     }
     const now = performance.now();
     const userOwnsScroll = hasRecentUserScrollIntent();
+    const previousGeometry = {
+      scrollTop: container.scrollTop,
+      maxScrollTop: Math.max(0, container.scrollHeight - container.clientHeight),
+    };
     recordCurrentScrollGeometry(container);
     const activeProgrammaticEdge = activeProgrammaticScrollEdgeRef.current;
     const activeProgrammaticMotion = activeProgrammaticScrollMotionRef.current;
@@ -1363,10 +1368,30 @@ export const MessagesCore = memo(function MessagesCore({
       scheduleAnchorUpdate("scroll");
       return;
     }
+    const nearBottom = isNearBottom(container);
+    // 回合结束 / 打开历史 settle 窗口：live 尾窗→全量、static→virtual 会让
+    // scrollHeight 暴涨而 scrollTop 尚未追上，nearBottom 瞬时 false。不得因此解除
+    // autoScroll。若用户已主动上滚离开底部（scrollTop 明显低于 max），仍释放跟随。
+    const settleIntent = stickToBottomIntentRef.current;
+    const settleWindowOpen =
+      settleIntent !== null && Date.now() <= stickToBottomDeadlineRef.current;
+    const userLeftBottom =
+      !nearBottom &&
+      previousGeometry.maxScrollTop - previousGeometry.scrollTop >
+        SCROLL_THRESHOLD_PX;
+    const settleArmed =
+      settleWindowOpen &&
+      !userOwnsScroll &&
+      (autoScrollRef.current || activeProgrammaticEdge === "bottom") &&
+      !userLeftBottom;
+    if (settleArmed) {
+      autoScrollRef.current = true;
+      scheduleAnchorUpdate("scroll");
+      return;
+    }
     // Auto-follow tracks the user's real scroll position: stick to the bottom
     // only while the viewport is actually near the bottom. Scrolling up cancels
     // the follow; scrolling back to the bottom re-enables it.
-    const nearBottom = isNearBottom(container);
     if (nearBottom && userOwnsScroll) {
       // 用户已明确回到底部，输入租约完成；后续同 tick 的 content resize 可立即恢复跟随。
       clearUserScrollIntent();
@@ -1388,6 +1413,8 @@ export const MessagesCore = memo(function MessagesCore({
     programmaticScrollTopEchoRef,
     recordCurrentScrollGeometry,
     scheduleAnchorUpdate,
+    stickToBottomDeadlineRef,
+    stickToBottomIntentRef,
   ]);
   const clearTransientUiState = useCallback(() => {
     if (anchorUpdateRafRef.current !== null) {

--- a/src/features/messages/components/toolBlocks/EditToolGroupBlock.test.tsx
+++ b/src/features/messages/components/toolBlocks/EditToolGroupBlock.test.tsx
@@ -1,8 +1,13 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ConversationItem } from "../../../../types";
+import * as diffUtils from "../../../../utils/diff";
 import { EditToolGroupBlock } from "./EditToolGroupBlock";
+import {
+  mergeEditSceneStatus,
+  normalizeEditScenePath,
+} from "./fileEditSceneUtils";
 
 function createEditToolItem(
   id: string,
@@ -18,12 +23,18 @@ function createEditToolItem(
   };
 }
 
+function sceneHeader() {
+  return screen.getByRole("button", {
+    name: /tools\.fileEditSceneToggle|File changes|文件修改/i,
+  });
+}
+
 describe("EditToolGroupBlock", () => {
   afterEach(() => {
     cleanup();
   });
 
-  it("renders batch title, file list and aggregated diff", () => {
+  it("defaults to collapsed scene summary without file paths", () => {
     render(
       <EditToolGroupBlock
         items={[
@@ -41,15 +52,120 @@ describe("EditToolGroupBlock", () => {
       />,
     );
 
-    expect(screen.getByText("tools.batchEditFile")).toBeTruthy();
-    expect(screen.getByText("(2)")).toBeTruthy();
+    // i18n in tests returns key or interpolated fallback depending on setup
+    expect(
+      screen.getByText(/tools\.fileEditSceneCount|File changes \(2\)|文件修改（2 个）/),
+    ).toBeTruthy();
+    expect(screen.queryByText("release.yml")).toBeNull();
+    expect(screen.queryByText("app.ts")).toBeNull();
+    expect(screen.queryByTestId("file-edit-scene-list")).toBeNull();
+
+    const header = sceneHeader();
+    expect(header.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("expands on header click and shows full file list", () => {
+    render(
+      <EditToolGroupBlock
+        items={[
+          createEditToolItem("tool-1", {
+            file_path: "src/release.yml",
+            old_string: "line1\nline2",
+            new_string: "line1\nline2\nline3",
+          }),
+          createEditToolItem("tool-2", {
+            file_path: "src/app.ts",
+            old_string: "a\nb\nc",
+            new_string: "a\nc",
+          }),
+        ]}
+      />,
+    );
+
+    fireEvent.click(sceneHeader());
+
+    expect(sceneHeader().getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByTestId("file-edit-scene-list")).toBeTruthy();
     expect(screen.getByText("release.yml")).toBeTruthy();
     expect(screen.getByText("app.ts")).toBeTruthy();
     expect(screen.getAllByText("+1").length).toBeGreaterThan(0);
     expect(screen.getAllByText("-1").length).toBeGreaterThan(0);
   });
 
-  it("supports nested input and camelCase edit fields", () => {
+  it("toggles with Enter and Space on the scene header", () => {
+    render(
+      <EditToolGroupBlock
+        items={[
+          createEditToolItem("tool-1", {
+            file_path: "src/a.ts",
+            old_string: "a",
+            new_string: "b",
+          }),
+          createEditToolItem("tool-2", {
+            file_path: "src/b.ts",
+            old_string: "c",
+            new_string: "d",
+          }),
+        ]}
+      />,
+    );
+
+    const header = sceneHeader();
+    fireEvent.keyDown(header, { key: "Enter" });
+    expect(header.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByText("a.ts")).toBeTruthy();
+
+    fireEvent.keyDown(header, { key: " " });
+    expect(header.getAttribute("aria-expanded")).toBe("false");
+    expect(screen.queryByText("a.ts")).toBeNull();
+  });
+
+  it("keeps scenes independent when two groups are mounted", () => {
+    render(
+      <>
+        <EditToolGroupBlock
+          items={[
+            createEditToolItem("a1", {
+              file_path: "src/a1.ts",
+              old_string: "x",
+              new_string: "y",
+            }),
+            createEditToolItem("a2", {
+              file_path: "src/a2.ts",
+              old_string: "x",
+              new_string: "y",
+            }),
+          ]}
+        />
+        <EditToolGroupBlock
+          items={[
+            createEditToolItem("b1", {
+              file_path: "src/b1.ts",
+              old_string: "x",
+              new_string: "y",
+            }),
+            createEditToolItem("b2", {
+              file_path: "src/b2.ts",
+              old_string: "x",
+              new_string: "y",
+            }),
+          ]}
+        />
+      </>,
+    );
+
+    const headers = screen.getAllByRole("button", {
+      name: /tools\.fileEditSceneToggle|File changes|文件修改/i,
+    });
+    expect(headers).toHaveLength(2);
+
+    fireEvent.click(headers[0]!);
+    expect(screen.getByText("a1.ts")).toBeTruthy();
+    expect(screen.queryByText("b1.ts")).toBeNull();
+    expect(headers[1]!.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("supports nested input and camelCase edit fields after expand", () => {
     render(
       <EditToolGroupBlock
         items={[
@@ -71,13 +187,14 @@ describe("EditToolGroupBlock", () => {
       />,
     );
 
+    fireEvent.click(sceneHeader());
     expect(screen.getByText("release.yml")).toBeTruthy();
     expect(screen.getByText("app.ts")).toBeTruthy();
     expect(screen.getAllByText("+1").length).toBeGreaterThan(0);
     expect(screen.getAllByText("-1").length).toBeGreaterThan(0);
   });
 
-  it("expands an individual grouped row to reveal its diff", () => {
+  it("expands an individual grouped row to reveal its diff after scene expand", () => {
     const view = render(
       <EditToolGroupBlock
         items={[
@@ -90,10 +207,10 @@ describe("EditToolGroupBlock", () => {
       />,
     );
 
-    // 折叠态：分组内的行还没展开 diff
     expect(view.container.querySelector(".tool-change-inline-diff")).toBeNull();
 
-    // markers[0] = 分组头，最后一个 marker = 文件行；点击文件行展开
+    fireEvent.click(sceneHeader());
+    // markers[0] = 场景头，最后一个 marker = 文件行
     const markers = view.container.querySelectorAll('[data-slot="marker"]');
     fireEvent.click(markers[markers.length - 1]!);
 
@@ -114,5 +231,156 @@ describe("EditToolGroupBlock", () => {
       />,
     );
     expect(container.firstChild).toBeNull();
+  });
+
+  it("respects defaultCollapsed=false for expanded initial state", () => {
+    render(
+      <EditToolGroupBlock
+        defaultCollapsed={false}
+        items={[
+          createEditToolItem("tool-1", {
+            file_path: "src/open.ts",
+            old_string: "a",
+            new_string: "b",
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("open.ts")).toBeTruthy();
+    expect(sceneHeader().getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("expands multi-file fileChange tools and merges unique paths into one scene count", () => {
+    const fileChange = (
+      id: string,
+      changes: Array<{ path: string; kind?: string; diff?: string }>,
+    ): Extract<ConversationItem, { kind: "tool" }> => ({
+      id,
+      kind: "tool",
+      toolType: "fileChange",
+      title: "File changes",
+      detail: "",
+      status: "completed",
+      changes: changes.map((change) => ({
+        path: change.path,
+        kind: change.kind ?? "modified",
+        diff: change.diff ?? "@@ -1 +1 @@\n-old\n+new",
+      })),
+    });
+
+    render(
+      <EditToolGroupBlock
+        items={[
+          fileChange("fc-1", [{ path: "docs/design.md" }]),
+          fileChange("fc-2", [
+            { path: "docs/spec.md" },
+            { path: "docs/tasks.md" },
+          ]),
+          // 同路径再次出现：count 去重，保留最后一次
+          fileChange("fc-3", [{ path: "docs/design.md", diff: "@@ -1 +1 @@\n-a\n+b\n+c" }]),
+          // ./ 前缀归一到同一 path
+          fileChange("fc-4", [{ path: "./docs/spec.md" }]),
+        ]}
+      />,
+    );
+
+    // 3 个唯一路径
+    expect(
+      screen.getByText(/tools\.fileEditSceneCount|File changes \(3\)|文件修改（3 个）/),
+    ).toBeTruthy();
+
+    fireEvent.click(sceneHeader());
+    expect(screen.getByText("design.md")).toBeTruthy();
+    expect(screen.getByText("spec.md")).toBeTruthy();
+    expect(screen.getByText("tasks.md")).toBeTruthy();
+  });
+
+  it("does not parse diffs while the scene is collapsed", () => {
+    const computeDiffSpy = vi.spyOn(diffUtils, "computeDiff");
+    const computePatchSpy = vi.spyOn(diffUtils, "computeDiffFromUnifiedPatch");
+    const parseDiffSpy = vi.spyOn(diffUtils, "parseDiff");
+
+    render(
+      <EditToolGroupBlock
+        items={[
+          createEditToolItem("tool-1", {
+            file_path: "src/a.ts",
+            old_string: "a",
+            new_string: "b",
+          }),
+          {
+            id: "fc-1",
+            kind: "tool",
+            toolType: "fileChange",
+            title: "File changes",
+            detail: "",
+            status: "completed",
+            changes: [
+              {
+                path: "src/b.ts",
+                kind: "modified",
+                diff: "@@ -1 +1 @@\n-old\n+new",
+              },
+            ],
+          },
+        ]}
+      />,
+    );
+
+    expect(computeDiffSpy).not.toHaveBeenCalled();
+    expect(computePatchSpy).not.toHaveBeenCalled();
+    expect(parseDiffSpy).not.toHaveBeenCalled();
+
+    fireEvent.click(sceneHeader());
+    // 场景展开后才算 stats；行内 preview 仍等 FileChangeRow 再展开
+    expect(computeDiffSpy).toHaveBeenCalled();
+    expect(computePatchSpy).toHaveBeenCalled();
+
+    computeDiffSpy.mockRestore();
+    computePatchSpy.mockRestore();
+    parseDiffSpy.mockRestore();
+  });
+
+  it("surfaces failed status on the collapsed scene header", () => {
+    const { container } = render(
+      <EditToolGroupBlock
+        items={[
+          {
+            ...createEditToolItem("ok", {
+              file_path: "src/ok.ts",
+              old_string: "a",
+              new_string: "b",
+            }),
+            status: "completed",
+          },
+          {
+            ...createEditToolItem("bad", {
+              file_path: "src/bad.ts",
+              old_string: "a",
+              new_string: "b",
+            }),
+            status: "failed",
+          },
+        ]}
+      />,
+    );
+
+    // collapsed：列表不可见，但 header trailing 有失败图标
+    expect(screen.queryByText("ok.ts")).toBeNull();
+    expect(container.querySelector(".text-destructive")).toBeTruthy();
+  });
+});
+
+describe("edit scene helpers", () => {
+  it("normalizes relative path prefixes", () => {
+    expect(normalizeEditScenePath("  ./src/a.ts ")).toBe("src/a.ts");
+    expect(normalizeEditScenePath("src/a.ts")).toBe("src/a.ts");
+  });
+
+  it("merges scene status with failed > processing > completed", () => {
+    expect(mergeEditSceneStatus(["completed", "processing"])).toBe("processing");
+    expect(mergeEditSceneStatus(["processing", "failed"])).toBe("failed");
+    expect(mergeEditSceneStatus(["completed", "completed"])).toBe("completed");
   });
 });

--- a/src/features/messages/components/toolBlocks/EditToolGroupBlock.tsx
+++ b/src/features/messages/components/toolBlocks/EditToolGroupBlock.tsx
@@ -1,6 +1,7 @@
 /**
- * 批量编辑文件分组组件
- * 统一 Marker 风格折叠行：灰色描边图标 + 批量标题 + 计数 + 总统计；展开体为文件列表与 diff 统计
+ * 批量编辑文件分组组件（文件修改场景）
+ * 默认折叠：极简 header（icon + 文件修改（N 个）+ 聚合 status）；展开体为无边框文件列表。
+ * 入参可混排 edit / write / fileChange；折叠态不解析 diff 正文，仅在展开后按行懒加载。
  */
 import { memo, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -18,172 +19,223 @@ import {
   EDIT_CONTENT_KEYS,
 } from './toolConstants';
 import { computeDiff, computeDiffFromUnifiedPatch, type DiffStats } from '../../../../utils/diff';
-import { ToolMarkerShell } from './ToolMarkerShell';
+import { ToolMarkerShell, ToolStatusIcon } from './ToolMarkerShell';
 import {
   FileChangeRow,
   structuredDiffToLines,
   unifiedDiffToPreview,
   type FileChangeDiffLine,
+  type FileChangeDiffPreview,
 } from './FileChangeRow';
+import {
+  mergeEditSceneStatus,
+  normalizeEditScenePath,
+} from './fileEditSceneUtils';
+
+export { mergeEditSceneStatus, normalizeEditScenePath } from './fileEditSceneUtils';
 
 type ToolItem = Extract<ConversationItem, { kind: 'tool' }>;
 
 interface EditToolGroupBlockProps {
   items: ToolItem[];
   onOpenDiffPath?: (path: string) => void;
+  /** 默认折叠；测试或未来设置可覆盖 */
+  defaultCollapsed?: boolean;
 }
 
-interface ParsedEditItem {
+/** 折叠态只保留 path/status；stats/diff 在场景展开后按行解析。 */
+interface ParsedEditSceneItem {
   id: string;
   filePath: string;
-  diff: DiffStats;
-  diffLines: FileChangeDiffLine[];
   status: ToolStatusTone;
+  resolveStats: () => DiffStats;
+  loadDiff?: () => FileChangeDiffPreview;
 }
 
-const MAX_VISIBLE_ITEMS = 3;
+const MAX_VISIBLE_ITEMS = 6;
 const ITEM_HEIGHT = 32;
 
-function parseEditItem(item: ToolItem): ParsedEditItem | null {
-  const args = parseToolArgs(item.detail);
-  const nestedInput = asRecord(args?.input);
-  const nestedArgs = asRecord(args?.arguments);
-  let filePath = '';
-  let diff: DiffStats;
-  let diffLines: FileChangeDiffLine[] = [];
-  if (item.toolType === 'fileChange' && item.changes?.length) {
-    filePath = item.changes[0]?.path ?? '';
-    diff = item.changes.reduce(
-      (acc, change) => {
-        const stats = computeDiffFromUnifiedPatch(change.diff ?? '');
-        return { additions: acc.additions + stats.additions, deletions: acc.deletions + stats.deletions };
-      },
-      { additions: 0, deletions: 0 },
-    );
-    const unified = item.changes
-      .map((change) => change.diff ?? '')
-      .filter(Boolean)
-      .join('\n');
-    diffLines = unified ? unifiedDiffToPreview(unified).lines : [];
-  } else {
-    filePath = pickStringField(args, nestedInput, nestedArgs, EDIT_PATH_KEYS);
-    const oldString = pickStringField(args, nestedInput, nestedArgs, EDIT_OLD_KEYS);
-    const newString = pickStringField(args, nestedInput, nestedArgs, EDIT_NEW_KEYS);
-    if (oldString || newString) {
-      const result = computeDiff(oldString, newString);
-      diff = { additions: result.additions, deletions: result.deletions };
-      diffLines = structuredDiffToLines(result.lines);
-    } else {
-      const content = pickStringField(args, nestedInput, nestedArgs, EDIT_CONTENT_KEYS);
-      if (content) {
-        const result = computeDiff('', content);
-        diff = { additions: result.additions, deletions: result.deletions };
-        diffLines = structuredDiffToLines(result.lines);
-      } else {
-        diff = { additions: 0, deletions: 0 };
-      }
-    }
+/** 同一路径多次修改时保留最后一次（count 按唯一文件计）。 */
+function dedupeParsedEditsByPath(entries: ParsedEditSceneItem[]): ParsedEditSceneItem[] {
+  const byPath = new Map<string, ParsedEditSceneItem>();
+  for (const entry of entries) {
+    byPath.set(entry.filePath, entry);
   }
+  return Array.from(byPath.values());
+}
 
-  if (!filePath) {
-    return null;
-  }
-
+function parseEditSceneItems(item: ToolItem): ParsedEditSceneItem[] {
   const hasOutput = Boolean(item.output) || Boolean(item.changes?.length);
   const status = resolveToolStatus(item.status, hasOutput);
 
-  return {
-    id: item.id,
-    filePath,
-    diff,
-    diffLines,
-    status,
+  if (item.toolType === 'fileChange' && item.changes?.length) {
+    const rows: ParsedEditSceneItem[] = [];
+    item.changes.forEach((change, index) => {
+      const filePath = normalizeEditScenePath(change.path ?? '');
+      if (!filePath) {
+        return;
+      }
+      const diffText = change.diff ?? '';
+      rows.push({
+        id: `${item.id}::${filePath}::${index}`,
+        filePath,
+        status,
+        resolveStats: () => computeDiffFromUnifiedPatch(diffText),
+        loadDiff: diffText
+          ? () => unifiedDiffToPreview(diffText)
+          : undefined,
+      });
+    });
+    return rows;
+  }
+
+  const args = parseToolArgs(item.detail);
+  const nestedInput = asRecord(args?.input);
+  const nestedArgs = asRecord(args?.arguments);
+  const filePath = normalizeEditScenePath(
+    pickStringField(args, nestedInput, nestedArgs, EDIT_PATH_KEYS),
+  );
+  if (!filePath) {
+    return [];
+  }
+
+  const oldString = pickStringField(args, nestedInput, nestedArgs, EDIT_OLD_KEYS);
+  const newString = pickStringField(args, nestedInput, nestedArgs, EDIT_NEW_KEYS);
+  const content = pickStringField(args, nestedInput, nestedArgs, EDIT_CONTENT_KEYS);
+  const hasInlineDiff = Boolean(oldString || newString || content);
+
+  let cachedStructured: { stats: DiffStats; lines: FileChangeDiffLine[] } | null = null;
+  const resolveStructured = (): { stats: DiffStats; lines: FileChangeDiffLine[] } => {
+    if (cachedStructured) {
+      return cachedStructured;
+    }
+    if (oldString || newString) {
+      const result = computeDiff(oldString, newString);
+      cachedStructured = {
+        stats: { additions: result.additions, deletions: result.deletions },
+        lines: structuredDiffToLines(result.lines),
+      };
+      return cachedStructured;
+    }
+    if (content) {
+      const result = computeDiff('', content);
+      cachedStructured = {
+        stats: { additions: result.additions, deletions: result.deletions },
+        lines: structuredDiffToLines(result.lines),
+      };
+      return cachedStructured;
+    }
+    cachedStructured = { stats: { additions: 0, deletions: 0 }, lines: [] };
+    return cachedStructured;
   };
+
+  return [
+    {
+      id: item.id,
+      filePath,
+      status,
+      resolveStats: () => resolveStructured().stats,
+      loadDiff: hasInlineDiff
+        ? () => ({ lines: resolveStructured().lines })
+        : undefined,
+    },
+  ];
 }
 
 export const EditToolGroupBlock = memo(function EditToolGroupBlock({
   items,
   onOpenDiffPath,
+  defaultCollapsed = true,
 }: EditToolGroupBlockProps) {
   const { t } = useTranslation();
-  const [isExpanded, setIsExpanded] = useState(true);
+  const [isExpanded, setIsExpanded] = useState(!defaultCollapsed);
   const listRef = useRef<HTMLDivElement | null>(null);
-  const previousCountRef = useRef(items.length);
+  const previousCountRef = useRef(0);
 
-  const parsedItems = useMemo(
-    () => items.map(parseEditItem).filter((entry): entry is ParsedEditItem => Boolean(entry)),
+  // 折叠态只建轻量索引（path/status + 懒闭包），不触发 diff 正文解析。
+  const sceneItems = useMemo(
+    () => dedupeParsedEditsByPath(items.flatMap(parseEditSceneItems)),
     [items],
   );
 
+  const sceneStatus = useMemo(
+    () => mergeEditSceneStatus(sceneItems.map((entry) => entry.status)),
+    [sceneItems],
+  );
+
+  // 仅在场景展开后解析 per-file stats，避免折叠付全量 diff 成本。
+  const expandedRows = useMemo(() => {
+    if (!isExpanded) {
+      return [];
+    }
+    return sceneItems.map((entry) => {
+      const stats = entry.resolveStats();
+      return {
+        id: entry.id,
+        filePath: entry.filePath,
+        status: entry.status,
+        additions: stats.additions,
+        deletions: stats.deletions,
+        loadDiff: entry.loadDiff,
+      };
+    });
+  }, [isExpanded, sceneItems]);
+
   useEffect(() => {
-    if (parsedItems.length > previousCountRef.current && listRef.current) {
+    if (
+      isExpanded &&
+      sceneItems.length > previousCountRef.current &&
+      listRef.current
+    ) {
       listRef.current.scrollTop = listRef.current.scrollHeight;
     }
-    previousCountRef.current = parsedItems.length;
-  }, [parsedItems.length]);
+    previousCountRef.current = sceneItems.length;
+  }, [sceneItems.length, isExpanded]);
 
-  if (!parsedItems.length) {
+  if (!sceneItems.length) {
     return null;
   }
 
-  const totalDiff = parsedItems.reduce(
-    (acc, item) => ({
-      additions: acc.additions + item.diff.additions,
-      deletions: acc.deletions + item.diff.deletions,
-    }),
-    { additions: 0, deletions: 0 },
-  );
-  const needsScroll = parsedItems.length > MAX_VISIBLE_ITEMS;
-  const listHeight = Math.min(parsedItems.length, MAX_VISIBLE_ITEMS) * ITEM_HEIGHT;
+  const fileCount = sceneItems.length;
+  const needsScroll = expandedRows.length > MAX_VISIBLE_ITEMS;
+  const listHeight = Math.min(expandedRows.length, MAX_VISIBLE_ITEMS) * ITEM_HEIGHT;
+  const sceneLabel = t('tools.fileEditSceneCount', { count: fileCount });
+  const sceneAriaLabel = t('tools.fileEditSceneToggle', { count: fileCount });
 
   return (
     <ToolMarkerShell
       icon={<FilePen />}
-      label={t('tools.batchEditFile')}
+      label={sceneLabel}
+      ariaLabel={sceneAriaLabel}
       expanded={isExpanded}
       onToggle={() => setIsExpanded((previous) => !previous)}
+      trailing={<ToolStatusIcon status={sceneStatus} />}
       body={
         <div
           ref={listRef}
-          className="file-list-container mt-1 overflow-hidden rounded-md"
+          className="file-list-container file-edit-scene-list mt-1 ml-4 overflow-hidden"
+          data-testid="file-edit-scene-list"
           style={{
-            padding: '6px 8px',
             maxHeight: needsScroll ? `${listHeight + 12}px` : undefined,
             overflowY: needsScroll ? 'auto' : 'hidden',
             overflowX: 'hidden',
           }}
         >
-          {parsedItems.map((entry) => (
+          {expandedRows.map((entry) => (
             <FileChangeRow
               key={entry.id}
               filePath={entry.filePath}
-              additions={entry.diff.additions}
-              deletions={entry.diff.deletions}
+              additions={entry.additions}
+              deletions={entry.deletions}
               status={entry.status}
-              canExpand={entry.diffLines.length > 0}
-              loadDiff={
-                entry.diffLines.length > 0
-                  ? () => ({ lines: entry.diffLines })
-                  : undefined
-              }
+              canExpand={Boolean(entry.loadDiff)}
+              loadDiff={entry.loadDiff}
               onOpenDiffPath={onOpenDiffPath}
             />
           ))}
         </div>
       }
-    >
-      <span className="shrink-0 text-muted-foreground">({parsedItems.length})</span>
-      {(totalDiff.additions > 0 || totalDiff.deletions > 0) && (
-        <span className="flex shrink-0 items-center gap-1 tabular-nums">
-          {totalDiff.additions > 0 && (
-            <span className="text-emerald-600 dark:text-emerald-400">+{totalDiff.additions}</span>
-          )}
-          {totalDiff.deletions > 0 && (
-            <span className="text-red-500 dark:text-red-400">-{totalDiff.deletions}</span>
-          )}
-        </span>
-      )}
-    </ToolMarkerShell>
+    />
   );
 });
 

--- a/src/features/messages/components/toolBlocks/FileChangeToolContent.test.tsx
+++ b/src/features/messages/components/toolBlocks/FileChangeToolContent.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { FileChangeToolContent } from "./FileChangeToolContent";
+import type { GenericToolDisplayChange } from "./genericToolPresentation";
+
+function change(path: string, additions = 1, deletions = 0): GenericToolDisplayChange {
+  return {
+    path,
+    normalizedKind: "modified",
+    kindCode: "M",
+    diffText: `@@\n-old\n+new\n`,
+    diffStats: { additions, deletions },
+  };
+}
+
+describe("FileChangeToolContent", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("defaults to collapsed scene and expands to list all files", () => {
+    render(
+      <FileChangeToolContent
+        status="completed"
+        changes={[change("docs/a.md"), change("src/b.ts", 2, 1)]}
+      />,
+    );
+
+    expect(screen.queryByText("a.md")).toBeNull();
+    expect(screen.queryByText("b.ts")).toBeNull();
+
+    const header = screen.getByRole("button", {
+      name: /tools\.fileEditSceneToggle|File changes|文件修改/i,
+    });
+    expect(header.getAttribute("aria-expanded")).toBe("false");
+
+    fireEvent.click(header);
+    expect(header.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByText("a.md")).toBeTruthy();
+    expect(screen.getByText("b.ts")).toBeTruthy();
+  });
+
+  it("returns null for empty changes", () => {
+    const { container } = render(
+      <FileChangeToolContent status="completed" changes={[]} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/features/messages/components/toolBlocks/FileChangeToolContent.tsx
+++ b/src/features/messages/components/toolBlocks/FileChangeToolContent.tsx
@@ -1,38 +1,92 @@
+/**
+ * fileChange 工具的多文件列表（GenericToolBlock 旁路）。
+ * 幕布主路径连续 fileChange 已并入 EditToolGroupBlock；本组件保持同款折叠契约作 fallback。
+ */
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import FilePen from "lucide-react/dist/esm/icons/file-pen";
 import type { GenericToolDisplayChange, GenericToolMarkerStatus } from "./genericToolPresentation";
 import { FileChangeRow, unifiedDiffToPreview } from "./FileChangeRow";
+import { ToolMarkerShell, ToolStatusIcon } from "./ToolMarkerShell";
+import {
+  mergeEditSceneStatus,
+  normalizeEditScenePath,
+} from "./fileEditSceneUtils";
+import type { ToolStatusTone } from "./toolConstants";
 
 type FileChangeToolContentProps = {
   changes: GenericToolDisplayChange[];
   status: GenericToolMarkerStatus;
   onOpenDiffPath?: (path: string) => void;
+  defaultCollapsed?: boolean;
 };
 
 export function FileChangeToolContent({
   changes,
   status,
   onOpenDiffPath,
+  defaultCollapsed = true,
 }: FileChangeToolContentProps) {
+  const { t } = useTranslation();
+  const [isExpanded, setIsExpanded] = useState(!defaultCollapsed);
+
+  const normalizedChanges = useMemo(() => {
+    const byPath = new Map<string, GenericToolDisplayChange>();
+    for (const change of changes) {
+      const path = normalizeEditScenePath(change.path);
+      if (!path) {
+        continue;
+      }
+      byPath.set(path, { ...change, path });
+    }
+    return Array.from(byPath.values());
+  }, [changes]);
+
+  if (normalizedChanges.length === 0) {
+    return null;
+  }
+
+  const fileCount = normalizedChanges.length;
+  const sceneLabel = t("tools.fileEditSceneCount", { count: fileCount });
+  const sceneAriaLabel = t("tools.fileEditSceneToggle", { count: fileCount });
+  const sceneStatus = mergeEditSceneStatus([status as ToolStatusTone]);
+
   return (
-    <div className="tool-change-stack" role="group" aria-label="File changes">
-      {changes.map((change, index) => {
-        const diffText = change.diffText;
-        return (
-          <FileChangeRow
-            key={`${change.path}::${index}`}
-            filePath={change.path}
-            additions={change.diffStats.additions}
-            deletions={change.diffStats.deletions}
-            status={status}
-            canExpand={Boolean(diffText)}
-            loadDiff={diffText ? () => unifiedDiffToPreview(diffText) : undefined}
-            onOpenDiffPath={
-              change.normalizedKind === "added" && !diffText
-                ? onOpenDiffPath
-                : undefined
-            }
-          />
-        );
-      })}
-    </div>
+    <ToolMarkerShell
+      icon={<FilePen />}
+      label={sceneLabel}
+      ariaLabel={sceneAriaLabel}
+      expanded={isExpanded}
+      onToggle={() => setIsExpanded((previous) => !previous)}
+      trailing={<ToolStatusIcon status={sceneStatus} />}
+      body={
+        <div
+          className="file-list-container file-edit-scene-list mt-1 ml-4"
+          data-testid="file-edit-scene-list"
+          role="group"
+          aria-label={sceneLabel}
+        >
+          {normalizedChanges.map((change, index) => {
+            const diffText = change.diffText;
+            return (
+              <FileChangeRow
+                key={`${change.path}::${index}`}
+                filePath={change.path}
+                additions={change.diffStats.additions}
+                deletions={change.diffStats.deletions}
+                status={status}
+                canExpand={Boolean(diffText)}
+                loadDiff={diffText ? () => unifiedDiffToPreview(diffText) : undefined}
+                onOpenDiffPath={
+                  change.normalizedKind === "added" && !diffText
+                    ? onOpenDiffPath
+                    : undefined
+                }
+              />
+            );
+          })}
+        </div>
+      }
+    />
   );
 }

--- a/src/features/messages/components/toolBlocks/GenericToolBlock.test.tsx
+++ b/src/features/messages/components/toolBlocks/GenericToolBlock.test.tsx
@@ -1,9 +1,21 @@
 // @vitest-environment jsdom
-import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ConversationItem } from "../../../../types";
 import * as diffParser from "../../../../utils/diff";
 import { GenericToolBlock } from "./GenericToolBlock";
+
+/** 展开 fileChange 场景级折叠壳，返回场景 header */
+function expandFileEditScene(container: HTMLElement = document.body) {
+  const header =
+    within(container).queryByRole("button", {
+      name: /tools\.fileEditSceneToggle|File changes|文件修改/i,
+    }) ??
+    (container.querySelector('[data-slot="marker"][aria-expanded="false"]') as HTMLElement | null);
+  expect(header).toBeTruthy();
+  fireEvent.click(header!);
+  return header!;
+}
 
 const askUserItem: Extract<ConversationItem, { kind: "tool" }> = {
   id: "tool-1",
@@ -339,9 +351,10 @@ describe("GenericToolBlock", () => {
       />,
     );
 
-    // 每文件一行（共享 FileChangeRow），无聚合「N files」计数、无 A/M/D 徽标
-    expect(view.container.querySelectorAll('[data-slot="marker"]').length).toBe(2);
-    expect(screen.queryByText("2 files")).toBeNull();
+    // 场景默认折叠；展开后每文件一行（共享 FileChangeRow）
+    expandFileEditScene(view.container);
+    // 1 场景头 + 2 文件行
+    expect(view.container.querySelectorAll('[data-slot="marker"]').length).toBe(3);
     expect(view.container.querySelector(".tool-change-kind-badge")).toBeNull();
     expect(screen.getByText("App.tsx")).toBeTruthy();
     expect(screen.getByText("New.tsx")).toBeTruthy();
@@ -370,10 +383,12 @@ describe("GenericToolBlock", () => {
       />,
     );
 
+    expandFileEditScene(view.container);
     const rows = view.container.querySelectorAll('[data-slot="marker"]');
-    expect(rows).toHaveLength(2);
-    fireEvent.click(rows[0] as HTMLElement);
+    // scene + 2 file rows
+    expect(rows.length).toBeGreaterThanOrEqual(3);
     fireEvent.click(rows[1] as HTMLElement);
+    fireEvent.click(rows[2] as HTMLElement);
 
     expect(onOpenDiffPath).toHaveBeenCalledOnce();
     expect(onOpenDiffPath).toHaveBeenCalledWith("src/New.tsx");
@@ -397,7 +412,9 @@ describe("GenericToolBlock", () => {
       />,
     );
 
-    fireEvent.click(view.container.querySelector('[data-slot="marker"]') as HTMLElement);
+    expandFileEditScene(view.container);
+    const markers = view.container.querySelectorAll('[data-slot="marker"]');
+    fireEvent.click(markers[markers.length - 1] as HTMLElement);
 
     expect(onOpenDiffPath).not.toHaveBeenCalled();
     expect(screen.getByText("const x = 1;")).toBeTruthy();
@@ -428,13 +445,15 @@ describe("GenericToolBlock", () => {
       />,
     );
 
-    fireEvent.click(view.container.querySelector('[data-slot="marker"]') as HTMLElement);
+    expandFileEditScene(view.container);
+    const markers = view.container.querySelectorAll('[data-slot="marker"]');
+    fireEvent.click(markers[markers.length - 1] as HTMLElement);
 
     expect(onOpenDiffPath).not.toHaveBeenCalled();
     expect(screen.getByText("const value = 1;")).toBeTruthy();
   });
 
-  it("omits file-count label for single file changes", () => {
+  it("shows scene summary for single file changes until expanded", () => {
     render(
       <GenericToolBlock
         item={fileChangeWithOutputItem}
@@ -443,8 +462,9 @@ describe("GenericToolBlock", () => {
       />,
     );
 
+    expect(screen.queryByText("App.tsx")).toBeNull();
+    expandFileEditScene();
     expect(screen.getByText("App.tsx")).toBeTruthy();
-    expect(screen.queryByText(/\d+\s+files?/i)).toBeNull();
   });
 
   it("shows each changed file as its own collapsed row without overflow summary", () => {
@@ -457,6 +477,7 @@ describe("GenericToolBlock", () => {
       />,
     );
 
+    expandFileEditScene(view.container);
     expect(screen.getByText("App.tsx")).toBeTruthy();
     expect(screen.getByText("New.tsx")).toBeTruthy();
     expect(screen.getByText("Home.tsx")).toBeTruthy();
@@ -466,7 +487,8 @@ describe("GenericToolBlock", () => {
     expect(screen.getByText("app.css")).toBeTruthy();
     expect(screen.getByText("package.json")).toBeTruthy();
     expect(screen.queryByText(/\+\d+\s+more files/i)).toBeNull();
-    expect(view.container.querySelectorAll('[data-slot="marker"]').length).toBe(8);
+    // scene header + 8 file rows
+    expect(view.container.querySelectorAll('[data-slot="marker"]').length).toBe(9);
     expect(parseDiffSpy).not.toHaveBeenCalled();
     parseDiffSpy.mockRestore();
   });
@@ -480,19 +502,21 @@ describe("GenericToolBlock", () => {
       />,
     );
 
+    expandFileEditScene(view.container);
     const headers = Array.from(
       view.container.querySelectorAll('[data-slot="marker"]'),
     );
-    expect(headers.length).toBe(8);
+    // scene + 8 files
+    expect(headers.length).toBe(9);
     expect(view.container.querySelectorAll(".tool-change-inline-diff").length).toBe(0);
 
-    fireEvent.click(headers[0]!);
+    fireEvent.click(headers[1]!);
     expect(view.container.querySelectorAll(".tool-change-inline-diff").length).toBe(1);
 
-    fireEvent.click(headers[1]!);
+    fireEvent.click(headers[2]!);
     expect(view.container.querySelectorAll(".tool-change-inline-diff").length).toBe(2);
 
-    fireEvent.click(headers[0]!);
+    fireEvent.click(headers[1]!);
     expect(view.container.querySelectorAll(".tool-change-inline-diff").length).toBe(1);
   });
 
@@ -505,14 +529,15 @@ describe("GenericToolBlock", () => {
       />,
     );
 
+    expandFileEditScene(view.container);
     const headers = Array.from(
       view.container.querySelectorAll('[data-slot="marker"]'),
     );
-    expect(headers.length).toBe(2);
+    expect(headers.length).toBe(3);
     // 折叠态不渲染 diff，逐行展开后每行各自一个 inline diff 卡片
     expect(view.container.querySelector(".tool-change-inline-diff")).toBeNull();
-    fireEvent.click(headers[0]!);
     fireEvent.click(headers[1]!);
+    fireEvent.click(headers[2]!);
     expect(view.container.querySelectorAll(".tool-change-inline-diff").length).toBe(2);
   });
 
@@ -525,11 +550,13 @@ describe("GenericToolBlock", () => {
       />,
     );
 
+    expandFileEditScene(view.container);
     expect(screen.getByText("App.tsx")).toBeTruthy();
     expect(document.querySelector(".tool-output-raw-pre")).toBeNull();
     // diff 仅在展开该行后出现，且不回退到原始输出面板
     expect(document.querySelector(".tool-change-inline-diff")).toBeNull();
-    fireEvent.click(view.container.querySelector('[data-slot="marker"]')!);
+    const markers = view.container.querySelectorAll('[data-slot="marker"]');
+    fireEvent.click(markers[markers.length - 1]!);
     expect(screen.getByText("old")).toBeTruthy();
     expect(screen.getByText("new")).toBeTruthy();
     expect(document.querySelector(".tool-change-inline-diff")).toBeTruthy();
@@ -545,15 +572,17 @@ describe("GenericToolBlock", () => {
       />,
     );
 
-    // 8 行折叠紧凑行，折叠态不渲染任何 diff（天然延迟）
-    expect(view.container.querySelectorAll('[data-slot="marker"]').length).toBe(8);
+    expandFileEditScene(view.container);
+    // scene + 8 行折叠紧凑行，折叠态不渲染任何 diff（天然延迟）
+    expect(view.container.querySelectorAll('[data-slot="marker"]').length).toBe(9);
     expect(view.container.querySelector(".tool-change-inline-diff")).toBeNull();
 
     // 文件名为纯文本，不再是可点跳转链接
     expect(screen.queryByRole("button", { name: "heavy-0.ts" })).toBeNull();
 
-    // 点击行头展开后才渲染该行 diff
-    fireEvent.click(view.container.querySelector('[data-slot="marker"]')!);
+    // 点击文件行头展开后才渲染该行 diff（跳过场景头）
+    const markers = view.container.querySelectorAll('[data-slot="marker"]');
+    fireEvent.click(markers[1]!);
     expect(view.container.querySelector(".tool-change-inline-diff")).toBeTruthy();
   });
 
@@ -566,17 +595,19 @@ describe("GenericToolBlock", () => {
       />,
     );
 
+    expandFileEditScene(view.container);
     // 折叠行即显示来自输出回退的统计，不显示原始输出面板
     expect(screen.getAllByText("+1").length).toBeGreaterThan(0);
     expect(screen.getAllByText("-1").length).toBeGreaterThan(0);
     expect(document.querySelector(".tool-output-raw-pre")).toBeNull();
-    fireEvent.click(view.container.querySelector('[data-slot="marker"]')!);
+    const markers = view.container.querySelectorAll('[data-slot="marker"]');
+    fireEvent.click(markers[markers.length - 1]!);
     expect(screen.getByText("old")).toBeTruthy();
     expect(screen.getByText("new")).toBeTruthy();
   });
 
   it("matches path hints with absolute/relative compatibility for stats fallback", () => {
-    render(
+    const view = render(
       <GenericToolBlock
         item={fileChangePathHintCompatItem}
         isExpanded
@@ -584,6 +615,7 @@ describe("GenericToolBlock", () => {
       />,
     );
 
+    expandFileEditScene(view.container);
     expect(screen.getAllByText("+1").length).toBeGreaterThan(0);
     expect(screen.getAllByText("-1").length).toBeGreaterThan(0);
   });

--- a/src/features/messages/components/toolBlocks/ReadToolGroupBlock.test.tsx
+++ b/src/features/messages/components/toolBlocks/ReadToolGroupBlock.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import type { ConversationItem } from "../../../../types";
+import { ReadToolGroupBlock } from "./ReadToolGroupBlock";
+
+type ToolItem = Extract<ConversationItem, { kind: "tool" }>;
+
+function createReadItem(
+  id: string,
+  title: string,
+  detail: Record<string, unknown>,
+): ToolItem {
+  return {
+    id,
+    kind: "tool",
+    toolType: title,
+    title,
+    detail: JSON.stringify(detail),
+    status: "completed",
+  };
+}
+
+describe("ReadToolGroupBlock", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders Grok list_dir with its target directory", () => {
+    render(
+      <ReadToolGroupBlock
+        items={[
+          createReadItem("list-1", "list_dir", {
+            target_directory: "src/features/messages",
+          }),
+          createReadItem("read-1", "read_file", {
+            target_file: "src/features/messages/index.ts",
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("List")).toBeTruthy();
+    expect(screen.getByText("messages")).toBeTruthy();
+    expect(screen.getByText("Read")).toBeTruthy();
+    expect(screen.getByText("index.ts")).toBeTruthy();
+    expect(screen.getByTitle("src/features/messages")).toBeTruthy();
+  });
+});

--- a/src/features/messages/components/toolBlocks/ReadToolGroupBlock.tsx
+++ b/src/features/messages/components/toolBlocks/ReadToolGroupBlock.tsx
@@ -7,7 +7,12 @@ import { memo, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import FileText from 'lucide-react/dist/esm/icons/file-text';
 import type { ConversationItem } from '../../../../types';
-import { parseToolArgs, getFirstStringField, getFileName } from './toolConstants';
+import {
+  extractToolName,
+  parseToolArgs,
+  getFirstStringField,
+  getFileName,
+} from './toolConstants';
 
 type ToolItem = Extract<ConversationItem, { kind: 'tool' }>;
 
@@ -22,6 +27,25 @@ interface ParsedReadItem {
   isDirectory: boolean;
   lineInfo: string;
 }
+
+const FILE_PATH_KEYS = [
+  'file_path',
+  'filePath',
+  'filepath',
+  'path',
+  'target_file',
+  'targetFile',
+  'filename',
+  'file',
+];
+const DIRECTORY_PATH_KEYS = [
+  'target_directory',
+  'targetDirectory',
+  'directory',
+  'dir',
+];
+const LIST_KEYS = ['files', 'file_paths', 'filePaths', 'paths'];
+const DIRECTORY_TOOL_NAMES = new Set(['list_dir', 'listdir', 'list_directory']);
 
 function asRecord(value: unknown): Record<string, unknown> | null {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
@@ -48,26 +72,25 @@ function parseReadItem(item: ToolItem): ParsedReadItem {
   const args = parseToolArgs(item.detail);
   const nestedInput = asRecord(args?.input);
   const nestedArgs = asRecord(args?.arguments);
-  const pathKeys = [
-    'file_path',
-    'filePath',
-    'filepath',
-    'path',
-    'target_file',
-    'targetFile',
-    'filename',
-    'file',
-  ];
-  const listKeys = ['files', 'file_paths', 'filePaths', 'paths'];
+  const directoryPath =
+    getFirstStringField(args, DIRECTORY_PATH_KEYS) ||
+    getFirstStringField(nestedInput, DIRECTORY_PATH_KEYS) ||
+    getFirstStringField(nestedArgs, DIRECTORY_PATH_KEYS);
   const filePath =
-    getFirstStringField(args, pathKeys) ||
-    getFirstStringField(nestedInput, pathKeys) ||
-    getFirstStringField(nestedArgs, pathKeys) ||
-    getFirstStringInArray(args, listKeys) ||
-    getFirstStringInArray(nestedInput, listKeys) ||
-    getFirstStringInArray(nestedArgs, listKeys);
+    getFirstStringField(args, FILE_PATH_KEYS) ||
+    getFirstStringField(nestedInput, FILE_PATH_KEYS) ||
+    getFirstStringField(nestedArgs, FILE_PATH_KEYS) ||
+    directoryPath ||
+    getFirstStringInArray(args, LIST_KEYS) ||
+    getFirstStringInArray(nestedInput, LIST_KEYS) ||
+    getFirstStringInArray(nestedArgs, LIST_KEYS);
   const fileName = getFileName(filePath);
-  const isDirectory = filePath === '.' || filePath === '..' || (filePath?.endsWith('/') ?? false);
+  const isDirectory =
+    Boolean(directoryPath) ||
+    DIRECTORY_TOOL_NAMES.has(extractToolName(item.title)) ||
+    filePath === '.' ||
+    filePath === '..' ||
+    (filePath?.endsWith('/') ?? false);
 
   const offset = args?.offset as number | undefined;
   const limit = args?.limit as number | undefined;

--- a/src/features/messages/components/toolBlocks/fileEditSceneUtils.ts
+++ b/src/features/messages/components/toolBlocks/fileEditSceneUtils.ts
@@ -1,0 +1,23 @@
+/**
+ * 文件修改场景共享工具：path 归一、status 聚合。
+ * 供 EditToolGroupBlock / FileChangeToolContent 共用，避免组件互相 import。
+ */
+import type { ToolStatusTone } from "./toolConstants";
+
+/** 轻量 path 归一：trim + 去 ./ 前缀，降低重复计数噪音。 */
+export function normalizeEditScenePath(path: string): string {
+  return path.trim().replace(/^\.\//, "");
+}
+
+/** 场景级 status：failed > processing > completed。 */
+export function mergeEditSceneStatus(
+  statuses: readonly ToolStatusTone[],
+): ToolStatusTone {
+  if (statuses.some((status) => status === "failed")) {
+    return "failed";
+  }
+  if (statuses.some((status) => status === "processing")) {
+    return "processing";
+  }
+  return "completed";
+}

--- a/src/features/messages/orchestration/hooks/useMessagesScrollController.ts
+++ b/src/features/messages/orchestration/hooks/useMessagesScrollController.ts
@@ -285,14 +285,6 @@ export function useMessagesScrollController({
         Date.now() <= stickToBottomDeadlineRef.current,
     });
   }, [hasRecentUserScrollIntent, requestScrollConvergence]);
-  const requestTimelineLayoutBottomConvergence = useCallback(() => {
-    if (!autoScrollRef.current) {
-      return;
-    }
-    stickToBottomIntentRef.current = "history-open";
-    stickToBottomDeadlineRef.current = Date.now() + SETTLE_REPIN_WINDOW_MS;
-    requestHistoryBottomConvergence();
-  }, [requestHistoryBottomConvergence]);
   const requestTurnBoundaryBottomConvergence = useCallback(() => {
     const intent = stickToBottomIntentRef.current;
     if (!isTurnBoundaryScrollIntent(intent)) {
@@ -307,6 +299,40 @@ export function useMessagesScrollController({
         Date.now() <= stickToBottomDeadlineRef.current,
     });
   }, [hasRecentUserScrollIntent, requestScrollConvergence]);
+  const requestTimelineLayoutBottomConvergence = useCallback(() => {
+    // Virtualization/static layout flips may call this while autoScroll was briefly
+    // disarmed by a nearBottom false-negative during scrollHeight growth. If the
+    // user is not actively scrolling, re-arm and pin so turn-settle still lands
+    // on the latest messages.
+    if (hasRecentUserScrollIntent()) {
+      return;
+    }
+    if (!autoScrollRef.current) {
+      // Only re-arm when a settle/open pin window is already active.
+      // Mid-history readers who scrolled up stay put.
+      const settleActive =
+        stickToBottomIntentRef.current !== null &&
+        Date.now() <= stickToBottomDeadlineRef.current;
+      if (!settleActive) {
+        return;
+      }
+      autoScrollRef.current = true;
+    }
+    // Preserve an active turn boundary intent; only default to history-open.
+    if (!isTurnBoundaryScrollIntent(stickToBottomIntentRef.current)) {
+      stickToBottomIntentRef.current = "history-open";
+    }
+    stickToBottomDeadlineRef.current = Date.now() + SETTLE_REPIN_WINDOW_MS;
+    if (isTurnBoundaryScrollIntent(stickToBottomIntentRef.current)) {
+      requestTurnBoundaryBottomConvergence();
+      return;
+    }
+    requestHistoryBottomConvergence();
+  }, [
+    hasRecentUserScrollIntent,
+    requestHistoryBottomConvergence,
+    requestTurnBoundaryBottomConvergence,
+  ]);
   const beginTurnBoundaryBottomConvergence = useCallback(
     (intent: "turn-send" | "turn-settle") => {
       clearUserScrollIntent();

--- a/src/features/messages/presentation/messagesConversationLightweightMode.test.ts
+++ b/src/features/messages/presentation/messagesConversationLightweightMode.test.ts
@@ -10,44 +10,44 @@ import {
 } from "./messagesConversationLightweightMode";
 
 describe("messagesConversationLightweightMode", () => {
-  it("does not suggest lightweight mode for render-heavy timelines", () => {
+  it("suggests lightweight mode for render-heavy timelines", () => {
     const policy = resolveConversationLightweightPolicy({
       rowCount: 24,
       renderWeight: CONVERSATION_LIGHTWEIGHT_SUGGEST_RENDER_WEIGHT,
       heavyRowCount: 1,
     });
 
-    expect(policy).toEqual({ suggested: false, oversized: false });
+    expect(policy).toEqual({ suggested: true, oversized: false });
   });
 
-  it("does not suggest lightweight mode for repeated heavy rows", () => {
+  it("suggests lightweight mode for repeated heavy rows", () => {
     const policy = resolveConversationLightweightPolicy({
       rowCount: 24,
       renderWeight: 64,
       heavyRowCount: CONVERSATION_LIGHTWEIGHT_SUGGEST_HEAVY_ROWS,
     });
 
-    expect(policy).toEqual({ suggested: false, oversized: false });
+    expect(policy).toEqual({ suggested: true, oversized: false });
   });
 
-  it("does not activate oversized policy by row count or render weight", () => {
+  it("marks oversized policy by row count or render weight", () => {
     expect(
       resolveConversationLightweightPolicy({
         rowCount: CONVERSATION_OVERSIZED_HISTORY_ROWS,
         renderWeight: 1,
         heavyRowCount: 0,
       }),
-    ).toEqual({ suggested: false, oversized: false });
+    ).toEqual({ suggested: true, oversized: true });
     expect(
       resolveConversationLightweightPolicy({
         rowCount: 1,
         renderWeight: CONVERSATION_OVERSIZED_HISTORY_RENDER_WEIGHT,
         heavyRowCount: 0,
       }),
-    ).toEqual({ suggested: false, oversized: false });
+    ).toEqual({ suggested: true, oversized: true });
   });
 
-  it("keeps legacy oversized policy inactive", () => {
+  it("activates oversized policy until detail hydration is requested", () => {
     const policy = { suggested: true, oversized: true };
 
     expect(
@@ -56,7 +56,7 @@ describe("messagesConversationLightweightMode", () => {
         manualEnabled: false,
         detailHydrationRequested: false,
       }),
-    ).toEqual({ active: false, reason: "inactive" });
+    ).toEqual({ active: true, reason: "oversized" });
     expect(
       resolveConversationLightweightModeState({
         policy,
@@ -66,14 +66,14 @@ describe("messagesConversationLightweightMode", () => {
     ).toEqual({ active: false, reason: "inactive" });
   });
 
-  it("ignores legacy manual lightweight state", () => {
+  it("honors manual lightweight mode", () => {
     expect(
       resolveConversationLightweightModeState({
         policy: { suggested: false, oversized: false },
         manualEnabled: true,
         detailHydrationRequested: true,
       }),
-    ).toEqual({ active: false, reason: "inactive" });
+    ).toEqual({ active: true, reason: "manual" });
   });
 
   it("bounds remembered conversation render mode keys", () => {

--- a/src/features/messages/timeline/hooks/useMessagesTimelineVirtualizer.ts
+++ b/src/features/messages/timeline/hooks/useMessagesTimelineVirtualizer.ts
@@ -52,6 +52,9 @@ export function useMessagesTimelineVirtualizer(input: {
   const timelineVirtualizer = useVirtualizer({
     count: shouldVirtualizeTimeline ? timelineProjectionRows.length : 0,
     enabled: shouldVirtualizeTimeline,
+    // Preserve viewport when static → virtual attaches; default initialOffset=0
+    // was the main reason adaptive rendering was hard-disabled.
+    initialOffset: () => scrollElementRef.current?.scrollTop ?? 0,
     estimateSize: (index) => {
       const projectionRow = timelineProjectionRows[index];
       if (!projectionRow) {

--- a/src/features/messages/timeline/projection/messagesTimelineProjection.test.ts
+++ b/src/features/messages/timeline/projection/messagesTimelineProjection.test.ts
@@ -32,6 +32,34 @@ describe("messagesTimelineProjection", () => {
     expect(rows.at(-1)?.kind).toBe("bottomAnchor");
   });
 
+  it("keeps editGroup projection key stable when the group grows", () => {
+    const first = {
+      id: "edit-1",
+      kind: "tool" as const,
+      toolType: "edit" as const,
+      title: "Tool: edit",
+      detail: JSON.stringify({ file_path: "a.ts", old_string: "a", new_string: "b" }),
+      status: "completed" as const,
+    };
+    const second = {
+      id: "edit-2",
+      kind: "tool" as const,
+      toolType: "edit" as const,
+      title: "Tool: edit",
+      detail: JSON.stringify({ file_path: "b.ts", old_string: "a", new_string: "b" }),
+      status: "completed" as const,
+    };
+
+    const small = groupToolItems([first]);
+    const grown = groupToolItems([first, second]);
+    expect(small[0]?.kind).toBe("editGroup");
+    expect(grown[0]?.kind).toBe("editGroup");
+    expect(getGroupedEntryProjectionKey(small[0]!)).toBe(
+      getGroupedEntryProjectionKey(grown[0]!),
+    );
+    expect(getGroupedEntryProjectionKey(grown[0]!)).toBe("editGroup:edit-1");
+  });
+
   it("marks active user input anchor without moving the owning entry", () => {
     const entries = groupToolItems(buildLongListFixture(9));
     const rows = buildTimelineProjectionRows({

--- a/src/features/messages/timeline/projection/messagesTimelineProjection.ts
+++ b/src/features/messages/timeline/projection/messagesTimelineProjection.ts
@@ -72,6 +72,11 @@ export function getGroupedEntryProjectionKey(entry: GroupedEntry): string {
     return `${entry.kind}:${entry.item.kind}:${entry.item.id}:${task?.taskId ?? task?.toolUseId ?? ""}`;
   }
   const firstId = entry.items[0]?.id ?? "empty";
+  // editGroup：仅用 firstId 锚定投影 identity。
+  // streaming 时文件数增长若写入 lastId/length，会 remount 并丢掉用户展开态。
+  if (entry.kind === "editGroup") {
+    return `${entry.kind}:${firstId}`;
+  }
   const lastId = entry.items.at(-1)?.id ?? firstId;
   return `${entry.kind}:${firstId}:${lastId}:${entry.items.length}`;
 }

--- a/src/features/messages/timeline/virtualization/messagesTimelineVirtualization.test.ts
+++ b/src/features/messages/timeline/virtualization/messagesTimelineVirtualization.test.ts
@@ -39,12 +39,19 @@ describe("messagesTimelineVirtualization", () => {
     globalThis.localStorage.removeItem(TIMELINE_RENDER_WEIGHT_BASELINE_FLAG_KEY);
   });
 
-  it("keeps adaptive rendering disabled for stable and streaming timelines", () => {
-    expect(TIMELINE_ADAPTIVE_RENDERING_ENABLED).toBe(false);
+  it("virtualizes idle long timelines but keeps streaming static", () => {
+    expect(TIMELINE_ADAPTIVE_RENDERING_ENABLED).toBe(true);
+    // Idle stable history at/above min rows → virtualize.
     expect(shouldVirtualizeTimelineRows({
       isThinking: false,
       rowCount: TIMELINE_VIRTUALIZATION_MIN_ROWS,
+    })).toBe(true);
+    // Short idle history stays static.
+    expect(shouldVirtualizeTimelineRows({
+      isThinking: false,
+      rowCount: Math.max(1, TIMELINE_VIRTUALIZATION_MIN_ROWS - 1),
     })).toBe(false);
+    // Streaming / working stay static (STREAMING virtualization off).
     expect(shouldVirtualizeTimelineRows({
       isThinking: true,
       rowCount: TIMELINE_VIRTUALIZATION_STREAMING_MIN_ROWS * 100,
@@ -58,14 +65,14 @@ describe("messagesTimelineVirtualization", () => {
     })).toBe(false);
   });
 
-  it("does not let extreme row count bypass the adaptive-rendering kill switch", () => {
+  it("does not virtualize streaming timelines even at extreme row counts", () => {
     expect(shouldVirtualizeTimelineRows({
       isThinking: true,
       rowCount: 1_000,
     })).toBe(false);
   });
 
-  it("does not virtualize active streaming timelines by render weight below the row-count threshold", () => {
+  it("does not virtualize active streaming timelines by render weight alone", () => {
     expect(shouldVirtualizeTimelineRows({
       isThinking: true,
       rowCount: 12,
@@ -135,7 +142,7 @@ describe("messagesTimelineVirtualization", () => {
     })).toBe(false);
   });
 
-  it("reports the render-weight gate disabled when storage is unavailable", () => {
+  it("keeps the render-weight gate on when storage is unavailable", () => {
     const descriptor = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
     Object.defineProperty(globalThis, "localStorage", {
       configurable: true,
@@ -145,12 +152,14 @@ describe("messagesTimelineVirtualization", () => {
     });
 
     try {
-      expect(isTimelineRenderWeightGateEnabled()).toBe(false);
+      // Adaptive rendering is on; unavailable storage defaults the weight gate to enabled.
+      expect(isTimelineRenderWeightGateEnabled()).toBe(true);
+      // High density below the row-count floor still virtualizes via weight.
       expect(shouldVirtualizeTimelineRows({
         isThinking: false,
         rowCount: 12,
         renderWeight: TIMELINE_VIRTUALIZATION_MIN_RENDER_WEIGHT * 4,
-      })).toBe(false);
+      })).toBe(true);
     } finally {
       if (descriptor) {
         Object.defineProperty(globalThis, "localStorage", descriptor);
@@ -225,7 +234,7 @@ describe("messagesTimelineVirtualization", () => {
     expect(estimateTimelineProjectionRenderWeight(imageRow)).toBeGreaterThan(40);
   });
 
-  it("keeps #721-class heavy history static despite its render weight", () => {
+  it("virtualizes #721-class heavy history by render density when row count is below the floor", () => {
     const { rows } = createHeavyHistoryFixture("heavy");
     const summary = summarizeTimelineProjectionRenderWeight(rows);
 
@@ -236,11 +245,12 @@ describe("messagesTimelineVirtualization", () => {
     expect(summary.categoryCounts.toolRawPayload).toBeGreaterThan(0);
     expect(summary.categoryCounts.readBatch).toBeGreaterThan(0);
     expect(summary.categoryCounts.diff).toBeGreaterThan(0);
+    // Dense short histories virtualize via render-weight gate (idle only).
     expect(shouldVirtualizeTimelineRows({
       isThinking: false,
       rowCount: summary.rowCount,
       renderWeight: summary.renderWeight,
-    })).toBe(false);
+    })).toBe(true);
   });
 
   it("builds content-safe heavy-history baseline diagnostics", () => {

--- a/src/features/messages/timeline/virtualization/messagesTimelineVirtualization.ts
+++ b/src/features/messages/timeline/virtualization/messagesTimelineVirtualization.ts
@@ -21,11 +21,12 @@ export const TIMELINE_RENDER_WEIGHT_BASELINE_FLAG_KEY =
   "ccgui.perf.timelineRenderWeightBaseline";
 export const TIMELINE_VIRTUALIZER_STABILITY_MAX_REMEASURE_COUNT = 3;
 /**
- * Correctness-first containment：static → virtual attach 会用默认 initialOffset=0
- * 重置既有 viewport。坐标交接 contract 与回归补齐前，所有会话固定使用 static
- * full-detail rendering；lightweight policy 也共享此唯一 authority。
+ * Adaptive timeline rendering：idle 长历史可进入虚拟化，降低全量 DOM 滚动成本。
+ * 流式期仍由 TIMELINE_VIRTUALIZATION_DURING_STREAMING_ENABLED 单独门禁
+ * （默认关闭，继续依赖 STREAMING_VISIBLE_WINDOW 尾窗 + static 行，避免 attach 重叠）。
+ * Virtualizer 须提供 initialOffset=当前 scrollTop，避免 attach 默认 0 把视口拽到顶。
  */
-export const TIMELINE_ADAPTIVE_RENDERING_ENABLED = false;
+export const TIMELINE_ADAPTIVE_RENDERING_ENABLED = true;
 
 export type TimelineRenderWeightCategory =
   | "anchorOutlinePressure"
@@ -54,10 +55,10 @@ export type TimelineRenderWeightSummary = {
 };
 
 /**
- * 历史策略：总开关重新启用后，流式期可按行数门槛启用虚拟化。当前 hard-disable
- * 期间该子策略不可达。
+ * 流式期虚拟化：默认关闭。流式期用 STREAMING_VISIBLE_WINDOW 裁剪 + static DOM，
+ * 避免 enabled 切换时空 size cache 导致行重叠；idle 长历史再走虚拟化。
  */
-export const TIMELINE_VIRTUALIZATION_DURING_STREAMING_ENABLED = true;
+export const TIMELINE_VIRTUALIZATION_DURING_STREAMING_ENABLED = false;
 
 function canReadBaselineFlag() {
   if (typeof globalThis === "undefined") {

--- a/src/features/messages/utils/groupToolItems.test.ts
+++ b/src/features/messages/utils/groupToolItems.test.ts
@@ -34,20 +34,70 @@ describe("groupToolItems", () => {
       createToolItem("tool-2", "Tool: TodoWrite"),
     ]);
 
-    // TodoWrite is hidden by shouldHideToolItem, so only the edit item remains
+    // TodoWrite is hidden by shouldHideToolItem, so only the edit item remains as editGroup
     expect(entries).toHaveLength(1);
-    expect(entries[0]?.kind).toBe("item");
+    expect(entries[0]?.kind).toBe("editGroup");
   });
 
-  it("does not merge fileChange with edit group", () => {
+  it("promotes a single edit tool into an editGroup scene", () => {
+    const entries = groupToolItems([createToolItem("tool-1", "Tool: edit")]);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.kind).toBe("editGroup");
+    if (entries[0]?.kind === "editGroup") {
+      expect(entries[0].items).toHaveLength(1);
+      expect(entries[0].items[0]?.id).toBe("tool-1");
+    }
+  });
+
+  it("merges consecutive edit and fileChange tools into one file-edit scene", () => {
     const entries = groupToolItems([
       createToolItem("tool-1", "Tool: edit"),
       createToolItem("tool-2", "File changes", "fileChange"),
       createToolItem("tool-3", "Tool: edit"),
     ]);
 
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.kind).toBe("editGroup");
+    if (entries[0]?.kind === "editGroup") {
+      expect(entries[0].items.map((item) => item.id)).toEqual([
+        "tool-1",
+        "tool-2",
+        "tool-3",
+      ]);
+    }
+  });
+
+  it("merges consecutive single-file fileChange tools into one editGroup", () => {
+    const entries = groupToolItems([
+      createToolItem("fc-1", "File changes", "fileChange"),
+      createToolItem("fc-2", "File changes", "fileChange"),
+      createToolItem("fc-3", "File changes", "fileChange"),
+    ]);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.kind).toBe("editGroup");
+    if (entries[0]?.kind === "editGroup") {
+      expect(entries[0].items).toHaveLength(3);
+    }
+  });
+
+  it("splits file-edit scenes when explore interrupts", () => {
+    const explore: Extract<ConversationItem, { kind: "explore" }> = {
+      id: "explore-1",
+      kind: "explore",
+      status: "explored",
+      entries: [{ kind: "search", label: "foo" }],
+    };
+    const entries = groupToolItems([
+      createToolItem("fc-1", "File changes", "fileChange"),
+      explore,
+      createToolItem("fc-2", "File changes", "fileChange"),
+    ]);
+
     expect(entries).toHaveLength(3);
-    expect(entries.every((entry) => entry.kind === "item")).toBe(true);
+    expect(entries[0]?.kind).toBe("editGroup");
+    expect(entries[1]?.kind).toBe("item");
+    expect(entries[2]?.kind).toBe("editGroup");
   });
 
   it("hides TodoWrite tool blocks in message stream", () => {
@@ -60,12 +110,12 @@ describe("groupToolItems", () => {
 
     expect(entries).toHaveLength(2);
     expect(entries[0]?.kind).toBe("item");
-    expect(entries[1]?.kind).toBe("item");
+    expect(entries[1]?.kind).toBe("editGroup");
     if (entries[0]?.kind === "item" && entries[0].item.kind === "tool") {
       expect(entries[0].item.title).toBe("Tool: read");
     }
-    if (entries[1]?.kind === "item" && entries[1].item.kind === "tool") {
-      expect(entries[1].item.title).toBe("Tool: edit");
+    if (entries[1]?.kind === "editGroup") {
+      expect(entries[1].items[0]?.title).toBe("Tool: edit");
     }
   });
 

--- a/src/features/messages/utils/groupToolItems.test.ts
+++ b/src/features/messages/utils/groupToolItems.test.ts
@@ -49,6 +49,32 @@ describe("groupToolItems", () => {
     }
   });
 
+  it("groups Grok-style flat tool names into read/search/bash/edit scenes", () => {
+    const entries = groupToolItems([
+      createToolItem("r1", "read_file"),
+      createToolItem("r2", "list_dir"),
+      createToolItem("g1", "grep"),
+      createToolItem("g2", "grep"),
+      createToolItem("b1", "run_terminal_command"),
+      createToolItem("b2", "run_terminal_command"),
+      createToolItem("e1", "search_replace"),
+    ]);
+
+    expect(entries.map((entry) => entry.kind)).toEqual([
+      "readGroup",
+      "searchGroup",
+      "bashGroup",
+      "editGroup",
+    ]);
+    if (entries[0]?.kind === "readGroup") {
+      expect(entries[0].items.map((item) => item.id)).toEqual(["r1", "r2"]);
+    }
+    if (entries[3]?.kind === "editGroup") {
+      expect(entries[3].items).toHaveLength(1);
+      expect(entries[3].items[0]?.title).toBe("search_replace");
+    }
+  });
+
   it("merges consecutive edit and fileChange tools into one file-edit scene", () => {
     const entries = groupToolItems([
       createToolItem("tool-1", "Tool: edit"),

--- a/src/features/messages/utils/groupToolItems.ts
+++ b/src/features/messages/utils/groupToolItems.ts
@@ -50,19 +50,32 @@ function canMergeExploreItems(previous: ExploreItem, next: ExploreItem): boolean
 }
 
 /**
- * 将分类映射到 GroupedEntry 的 kind
+ * 将分类映射到 GroupedEntry 的 kind。
+ * `fileEdit` 是场景桶：连续的 edit + fileChange 合并为同一「文件修改」场景。
+ * （裸 `edit` 不会进入 buffer——resolveSceneCategory 已归一为 fileEdit。）
  */
-type GroupableCategory = 'read' | 'edit' | 'bash' | 'search';
+type GroupableCategory = 'read' | 'fileEdit' | 'bash' | 'search';
 
 const CATEGORY_TO_GROUP_KIND: Record<GroupableCategory, GroupedEntry['kind']> = {
   read: 'readGroup',
-  edit: 'editGroup',
+  fileEdit: 'editGroup',
   bash: 'bashGroup',
   search: 'searchGroup',
 };
 
 function isGroupableCategory(cat: string): cat is GroupableCategory {
   return cat in CATEGORY_TO_GROUP_KIND;
+}
+
+/**
+ * 场景归并桶：Codex 的 fileChange 与 Claude/通用 edit/write 在幕布上同属「文件修改」。
+ * 若不归并，会出现连续多个「文件修改（1 个）」标题。
+ */
+function resolveSceneCategory(category: string): string {
+  if (category === 'edit' || category === 'fileChange') {
+    return 'fileEdit';
+  }
+  return category;
 }
 
 export function shouldHideToolItemForRender(item: ToolItem): boolean {
@@ -79,8 +92,8 @@ function shouldUngroupSearchTools(item: ToolItem): boolean {
 }
 
 /**
- * 对 ConversationItem[] 进行分组，连续 2+ 个同类工具合并为 group entry。
- * 保留 explore 合并逻辑。
+ * 对 ConversationItem[] 进行分组，连续同类工具合并为 group entry。
+ * 保留 explore 合并逻辑；edit/fileChange 归并为 fileEdit → editGroup。
  */
 export function groupToolItems(items: ConversationItem[]): GroupedEntry[] {
   const entries: GroupedEntry[] = [];
@@ -107,10 +120,13 @@ export function groupToolItems(items: ConversationItem[]): GroupedEntry[] {
     const hasUngroupedSearchTool =
       currentCategory === 'search' && toolBuffer.some(shouldUngroupSearchTools);
     // Keep only codex mcp search_query tools line-by-line so each search record can expand.
+    // 文件修改场景：edit + fileChange 归并桶，即使 1 个 tool 也走 editGroup。
+    const shouldGroupFileEditScene =
+      currentCategory === 'fileEdit' && toolBuffer.length >= 1;
     if (
-      toolBuffer.length >= 2 &&
+      !hasUngroupedSearchTool &&
       isGroupableCategory(currentCategory) &&
-      !hasUngroupedSearchTool
+      (shouldGroupFileEditScene || toolBuffer.length >= 2)
     ) {
       entries.push({
         kind: CATEGORY_TO_GROUP_KIND[currentCategory],
@@ -143,13 +159,13 @@ export function groupToolItems(items: ConversationItem[]): GroupedEntry[] {
         flushTools();
         continue;
       }
-      const cat = classifyToolCategory(item);
-      if (toolBuffer.length > 0 && cat === currentCategory) {
+      const sceneCategory = resolveSceneCategory(classifyToolCategory(item));
+      if (toolBuffer.length > 0 && sceneCategory === currentCategory) {
         toolBuffer.push(item);
       } else {
         flushTools();
         toolBuffer = [item];
-        currentCategory = cat;
+        currentCategory = sceneCategory;
       }
       continue;
     }

--- a/src/features/threads/loaders/grokHistoryParser.test.ts
+++ b/src/features/threads/loaders/grokHistoryParser.test.ts
@@ -114,6 +114,64 @@ describe("parseGrokHistoryMessages", () => {
     );
   });
 
+  it("preserves flat Grok tool names for canvas classification", () => {
+    const items = parseGrokHistoryMessages([
+      {
+        id: "call-flat-1",
+        kind: "tool",
+        role: "assistant",
+        toolType: "read_file",
+        title: "read_file",
+        toolInput: {
+          target_file: "src/a.ts",
+        },
+      },
+      {
+        id: "call-flat-1-result",
+        kind: "tool",
+        role: "assistant",
+        toolType: "result",
+        title: "Result",
+        text: "contents",
+        toolOutput: "contents",
+      },
+      {
+        id: "call-flat-2",
+        kind: "tool",
+        role: "assistant",
+        toolType: "search_replace",
+        title: "search_replace",
+        toolInput: {
+          target_file: "src/a.ts",
+          old_string: "a",
+          new_string: "b",
+        },
+      },
+    ]);
+
+    expect(items).toHaveLength(2);
+    expect(items[0]).toEqual(
+      expect.objectContaining({
+        id: "call-flat-1",
+        kind: "tool",
+        title: "read_file",
+        status: "completed",
+        output: "contents",
+      }),
+    );
+    expect(items[1]).toEqual(
+      expect.objectContaining({
+        id: "call-flat-2",
+        kind: "tool",
+        title: "search_replace",
+      }),
+    );
+    // Must not collapse known names into generic Tool
+    expect(items.every((item) => item.kind !== "tool" || item.title !== "Tool")).toBe(
+      true,
+    );
+  });
+
   it("marks error tool results as failed on the source tool call", () => {
     const items = parseGrokHistoryMessages([
       {

--- a/src/features/threads/loaders/grokHistoryParser.test.ts
+++ b/src/features/threads/loaders/grokHistoryParser.test.ts
@@ -172,6 +172,65 @@ describe("parseGrokHistoryMessages", () => {
     );
   });
 
+  it("does not infer specialized tool types from command or write substrings", () => {
+    const items = parseGrokHistoryMessages([
+      {
+        id: "call-output-1",
+        kind: "tool",
+        role: "assistant",
+        toolType: "get_command_or_subagent_output",
+        title: "get_command_or_subagent_output",
+        toolInput: {
+          task_ids: ["task-1"],
+          timeout_ms: 1000,
+        },
+      },
+      {
+        id: "todo-1",
+        kind: "tool",
+        role: "assistant",
+        toolType: "todo_write",
+        title: "todo_write",
+        toolInput: {
+          merge: false,
+          todos: [],
+        },
+      },
+      {
+        id: "command-1",
+        kind: "tool",
+        role: "assistant",
+        toolType: "run_terminal_command",
+        title: "run_terminal_command",
+        toolInput: {
+          command: "pwd",
+          description: "Inspect working directory",
+        },
+      },
+    ]);
+
+    expect(items).toEqual([
+      expect.objectContaining({
+        id: "call-output-1",
+        kind: "tool",
+        toolType: "get_command_or_subagent_output",
+        title: "get_command_or_subagent_output",
+      }),
+      expect.objectContaining({
+        id: "todo-1",
+        kind: "tool",
+        toolType: "todo_write",
+        title: "todo_write",
+      }),
+      expect.objectContaining({
+        id: "command-1",
+        kind: "tool",
+        toolType: "commandExecution",
+        title: "Command: Inspect working directory",
+      }),
+    ]);
+  });
+
   it("marks error tool results as failed on the source tool call", () => {
     const items = parseGrokHistoryMessages([
       {

--- a/src/features/threads/loaders/grokHistoryParser.ts
+++ b/src/features/threads/loaders/grokHistoryParser.ts
@@ -8,15 +8,31 @@ import { asRecord, asString } from "./historyLoaderUtils";
 import { parseClaudeHistoryMessages } from "./claudeHistoryLoader";
 
 const RESULT_TOOL_SUFFIXES = ["-result", ":result", "_result", ".result", "/result"];
-const COMMAND_TOOL_KEYWORDS = [
+const COMMAND_TOOL_TYPES = new Set([
   "exec",
+  "exec_command",
   "bash",
   "shell",
+  "shell_command",
   "terminal",
   "command",
+  "execute_command",
+  "run_command",
+  "run_terminal_cmd",
+  "run_terminal_command",
   "stdin",
-];
-const FILE_CHANGE_TOOL_KEYWORDS = ["apply", "patch", "write", "edit"];
+  "write_stdin",
+]);
+const FILE_CHANGE_TOOL_TYPES = new Set([
+  "apply",
+  "apply_patch",
+  "patch",
+  "write",
+  "write_file",
+  "write_to_file",
+  "edit",
+  "edit_file",
+]);
 
 function mergeAdjacentReasoningText(existing: string, incoming: string): string {
   const normalizedExisting = existing.trim();
@@ -245,14 +261,10 @@ function normalizeGrokToolSnapshotType(rawToolType: string): string {
   if (normalized === "mcptoolcall") {
     return "mcpToolCall";
   }
-  if (COMMAND_TOOL_KEYWORDS.some((keyword) => normalized.includes(keyword))) {
+  if (COMMAND_TOOL_TYPES.has(normalized)) {
     return "commandExecution";
   }
-  if (
-    FILE_CHANGE_TOOL_KEYWORDS.some((keyword) => normalized.includes(keyword)) ||
-    normalized.startsWith("replace-") ||
-    normalized.includes("replace-")
-  ) {
+  if (FILE_CHANGE_TOOL_TYPES.has(normalized)) {
     return "fileChange";
   }
   return rawToolType;

--- a/src/i18n/locales/en/tools.ts
+++ b/src/i18n/locales/en/tools.ts
@@ -29,6 +29,8 @@ const tools = {
     batchSearch: "Batch search",
     batchSearchMatch: "Batch search/match",
     batchEditFile: "Batch edit files",
+    fileEditSceneCount: "File changes ({{count}})",
+    fileEditSceneToggle: "File changes, {{count}} files, toggle details",
     bashGroupBatchRun: "Batch Run Commands",
     bashGroupCompleted: "completed",
     bashGroupAllCompleted: "All completed",

--- a/src/i18n/locales/es/tools.ts
+++ b/src/i18n/locales/es/tools.ts
@@ -32,6 +32,8 @@ const tools = {
     "batchSearch": "Búsqueda por lotes",
     "batchSearchMatch": "Búsqueda/coincidencia por lotes",
     "batchEditFile": "Editar archivos por lotes",
+    "fileEditSceneCount": "Cambios de archivo ({{count}})",
+    "fileEditSceneToggle": "Cambios de archivo, {{count}} archivos, expandir o contraer",
     "bashGroupBatchRun": "Ejecutar comandos por lotes",
     "bashGroupCompleted": "completado",
     "bashGroupAllCompleted": "Todos completados",

--- a/src/i18n/locales/fr/tools.ts
+++ b/src/i18n/locales/fr/tools.ts
@@ -32,6 +32,8 @@ const tools = {
     "batchSearch": "Recherche par lot",
     "batchSearchMatch": "Recherche/Correspondance par lot",
     "batchEditFile": "Modification de fichiers par lot",
+    "fileEditSceneCount": "Modifications de fichiers ({{count}})",
+    "fileEditSceneToggle": "Modifications de fichiers, {{count}} fichiers, afficher ou masquer les détails",
     "bashGroupBatchRun": "Exécuter les commandes par lot",
     "bashGroupCompleted": "terminée",
     "bashGroupAllCompleted": "Toutes terminées",

--- a/src/i18n/locales/hi/tools.ts
+++ b/src/i18n/locales/hi/tools.ts
@@ -32,6 +32,8 @@ const tools = {
     "batchSearch": "बैच खोज",
     "batchSearchMatch": "बैच खोज/मिलान",
     "batchEditFile": "बैच फ़ाइलें संपादित करें",
+    "fileEditSceneCount": "फ़ाइल परिवर्तन ({{count}})",
+    "fileEditSceneToggle": "फ़ाइल परिवर्तन, {{count}} फ़ाइलें, विवरण दिखाएँ/छिपाएँ",
     "bashGroupBatchRun": "बैच रन कमांड",
     "bashGroupCompleted": "पूर्ण",
     "bashGroupAllCompleted": "सभी पूर्ण",

--- a/src/i18n/locales/ja/tools.ts
+++ b/src/i18n/locales/ja/tools.ts
@@ -32,6 +32,8 @@ const tools = {
     "batchSearch": "一括検索",
     "batchSearchMatch": "一括検索/マッチ",
     "batchEditFile": "ファイルを一括編集",
+    "fileEditSceneCount": "ファイル変更（{{count}}）",
+    "fileEditSceneToggle": "ファイル変更 {{count}} 件、詳細を切り替え",
     "bashGroupBatchRun": "コマンドを一括実行",
     "bashGroupCompleted": "完了",
     "bashGroupAllCompleted": "すべて完了",

--- a/src/i18n/locales/ko/tools.ts
+++ b/src/i18n/locales/ko/tools.ts
@@ -32,6 +32,8 @@ const tools = {
     "batchSearch": "일괄 검색",
     "batchSearchMatch": "일괄 검색/일치",
     "batchEditFile": "파일 일괄 편집",
+    "fileEditSceneCount": "파일 수정 ({{count}}개)",
+    "fileEditSceneToggle": "파일 수정 {{count}}개, 상세 펼치기/접기",
     "bashGroupBatchRun": "명령 일괄 실행",
     "bashGroupCompleted": "완료됨",
     "bashGroupAllCompleted": "모두 완료됨",

--- a/src/i18n/locales/pt-BR/tools.ts
+++ b/src/i18n/locales/pt-BR/tools.ts
@@ -32,6 +32,8 @@ const tools = {
     "batchSearch": "Buscar em lote",
     "batchSearchMatch": "Buscar/corresponder em lote",
     "batchEditFile": "Editar arquivos em lote",
+    "fileEditSceneCount": "Alterações de arquivo ({{count}})",
+    "fileEditSceneToggle": "Alterações de arquivo, {{count}} arquivos, expandir ou recolher",
     "bashGroupBatchRun": "Executar comandos em lote",
     "bashGroupCompleted": "concluído",
     "bashGroupAllCompleted": "Todos concluídos",

--- a/src/i18n/locales/ru/tools.ts
+++ b/src/i18n/locales/ru/tools.ts
@@ -32,6 +32,8 @@ const tools = {
     "batchSearch": "Пакетный поиск",
     "batchSearchMatch": "Пакетный поиск/совпадение",
     "batchEditFile": "Пакетное редактирование файлов",
+    "fileEditSceneCount": "Изменения файлов ({{count}})",
+    "fileEditSceneToggle": "Изменения файлов, {{count}} шт., развернуть или свернуть",
     "bashGroupBatchRun": "Пакетный запуск команд",
     "bashGroupCompleted": "завершено",
     "bashGroupAllCompleted": "Все завершены",

--- a/src/i18n/locales/zh-TW/tools.ts
+++ b/src/i18n/locales/zh-TW/tools.ts
@@ -32,6 +32,8 @@ const tools = {
     "batchSearch": "批次搜尋",
     "batchSearchMatch": "批次搜尋/比對",
     "batchEditFile": "批次編輯檔案",
+    "fileEditSceneCount": "檔案修改（{{count}} 個）",
+    "fileEditSceneToggle": "檔案修改，共 {{count}} 個，展開或摺疊詳情",
     "bashGroupBatchRun": "批次執行指令",
     "bashGroupCompleted": "已完成",
     "bashGroupAllCompleted": "全部完成",

--- a/src/i18n/locales/zh/tools.ts
+++ b/src/i18n/locales/zh/tools.ts
@@ -29,6 +29,8 @@ const tools = {
     batchSearch: "批量搜索",
     batchSearchMatch: "批量搜索/匹配",
     batchEditFile: "批量编辑文件",
+    fileEditSceneCount: "文件修改（{{count}} 个）",
+    fileEditSceneToggle: "文件修改，共 {{count}} 个，展开或折叠详情",
     bashGroupBatchRun: "批量运行命令",
     bashGroupCompleted: "完成",
     bashGroupAllCompleted: "全部完成",

--- a/src/styles/messages.part1.css
+++ b/src/styles/messages.part1.css
@@ -4,12 +4,10 @@
   display: flex;
   margin-bottom: 12px;
   content-visibility: auto;
-  /* ponytail: 屏外占位兜底高度。仅在「该消息本次会话从未渲染过」(如从历史进入长对话)
-     时生效;一旦渲染过,auto 会缓存真实高度。原值 120px 对常见折叠态工具块(~40px)
-     严重高估,导致历史回放时撑出大空隙。取加权中位 64px:折叠行略高估(空隙≈24px,
-     近乎不可见)、短消息命中、长消息仍靠 auto 缓存修正。
-     ceiling: 仍是静态估值;要根治需接通 messagesTimelineVirtualization 的按类型估高。 */
-  contain-intrinsic-block-size: auto 64px;
+  /* 屏外占位兜底。static 全量路径仍依赖此估值；虚拟化 idle 路径用
+     estimateTimelineProjectionRowSize。48px 更贴近短气泡/折叠工具节奏，
+     减少 content-visibility 进视口时高度跳变导致的滚动阻滞。 */
+  contain-intrinsic-block-size: auto 48px;
 }
 
 .message.assistant.is-live-streaming {
@@ -1934,10 +1932,9 @@
   margin-bottom: 12px;
   background: var(--surface-card);
   color: var(--text-stronger);
-  /* review/diff 等卡片屏幕外跳过渲染/绘制；72px 仅为首次渲染前的
-     占位估值，渲染过后由 auto 缓存真实高度。 */
+  /* review/diff 等卡片屏幕外跳过渲染/绘制；56px 贴近折叠工具/摘要行。 */
   content-visibility: auto;
-  contain-intrinsic-block-size: auto 72px;
+  contain-intrinsic-block-size: auto 56px;
 }
 
 .item-card.review {

--- a/src/utils/toolSemantics.test.ts
+++ b/src/utils/toolSemantics.test.ts
@@ -4,6 +4,9 @@ import {
   extractToolName,
   getFirstStringField,
   isBashTool,
+  isEditTool,
+  isReadTool,
+  isSearchTool,
   parseToolArgs,
   resolveToolStatus,
 } from "./toolSemantics";
@@ -48,7 +51,16 @@ describe("toolSemantics", () => {
   it("treats shared command tools as bash-like", () => {
     expect(isBashTool("exec_command")).toBe(true);
     expect(isBashTool("write_stdin")).toBe(true);
+    expect(isBashTool("run_terminal_command")).toBe(true);
     expect(isBashTool("search")).toBe(false);
+  });
+
+  it("classifies Grok-style agent tool names for canvas grouping", () => {
+    expect(isReadTool("read_file")).toBe(true);
+    expect(isReadTool("list_dir")).toBe(true);
+    expect(isSearchTool("grep")).toBe(true);
+    expect(isEditTool("search_replace")).toBe(true);
+    expect(isEditTool("todo_write")).toBe(false);
   });
 
   it("builds command summaries from structured arguments while ignoring path-only detail", () => {

--- a/src/utils/toolSemantics.ts
+++ b/src/utils/toolSemantics.ts
@@ -3,6 +3,10 @@ export const READ_TOOL_NAMES = new Set([
   "read_file",
   "readfile",
   "file_read",
+  // Grok / agent-style directory browse (group with reads on canvas)
+  "list_dir",
+  "listdir",
+  "list_directory",
 ]);
 
 export const EDIT_TOOL_NAMES = new Set([
@@ -14,6 +18,7 @@ export const EDIT_TOOL_NAMES = new Set([
   "writefile",
   "write_to_file",
   "replace_string",
+  "search_replace",
   "file_edit",
   "file_write",
   "notebookedit",
@@ -25,6 +30,7 @@ export const BASH_TOOL_NAMES = new Set([
   "shell",
   "terminal",
   "run_terminal_cmd",
+  "run_terminal_command",
   "execute_command",
   "shell_command",
   "run_command",
@@ -108,7 +114,13 @@ export function extractToolName(title: unknown): string {
 
 export function isReadTool(toolName: string): boolean {
   const lower = toolName.toLowerCase();
-  return READ_TOOL_NAMES.has(lower) || lower.includes("read");
+  if (READ_TOOL_NAMES.has(lower)) {
+    return true;
+  }
+  if (lower.includes("list_dir") || lower.includes("listdir")) {
+    return true;
+  }
+  return lower.includes("read");
 }
 
 export function isEditTool(toolName: string): boolean {
@@ -118,6 +130,10 @@ export function isEditTool(toolName: string): boolean {
   }
   if (lower === "todowrite" || lower === "todo_write") {
     return false;
+  }
+  // search_replace / str_replace style editors
+  if (lower.includes("replace") && !lower.includes("search_query")) {
+    return true;
   }
   return lower.includes("edit") || lower.includes("write");
 }


### PR DESCRIPTION
## 背景
- 在 `bump-version-0.7.12` 整合分支上落位 `add-message-file-edit-scene-collapse` OpenSpec 提案，并同步收口最近 5 个 Trellis 会话（1243-1247）的 journal 记录。
- 提案目标：让对话幕布内连续 edit / fileChange 工具块默认折叠为「文件修改（N 个）」一行摘要，保留展开后完整文件列表与 diff 预览能力，降低正文阅读噪音；不持久化偏好，不改 file-change 事实抽取与跨 surface 归一化。

## 改动点
- **OpenSpec 新增** `openspec/changes/add-message-file-edit-scene-collapse/`：
  - `proposal.md` / `design.md` / `tasks.md` / `.openspec.yaml`：声明 scene-level collapse contract、`sceneId` 稳定身份（取 first tool item id，避免 render index 漂移）、复用 `ToolMarkerShell` 的方案 A、键盘 Enter/Space + `aria-expanded`、streaming 时 expanded 保持规则、a11y / 动画与 `prefers-reduced-motion` 处理、折叠态懒解析 diff。
  - `specs/message-file-edit-scene-collapse/spec.md`：新增 capability，覆盖默认折叠、单文件 edit 走同壳、`fileChange` 列表默认折叠、多场景独立、展开后内容无损等 requirement 与 scenario。
  - `specs/message-codeblock-filechange-rendering/spec.md`：delta，明确场景折叠容器下 per-file row 仍可读、折叠文案承载文件数量。
- **OpenSpec 索引** `openspec/changes/README.md`：active proposals 27 → 28，登记新提案链接与完成度 4/4（implemented，待人工 smoke / verify / sync / archive）。
- **Trellis 会话记录** `.trellis/workspace/chenxiangning/{index.md,journal-29.md}`：增补 Session 1243-1247，对应 commit `63461ec54` / `0d4765346` / `4e932e672` / `d38d0f9b9` / `ad2cceff8`，覆盖幕布文件修改场景折叠、Grok 历史 tool 扁平解析、长幕布 idle 虚拟化、回合结束滚动贴底、Grok 历史工具投影信息损失。

## 验证
- `openspec validate add-message-file-edit-scene-collapse --strict --no-interactive` 通过。
- `openspec validate --all --strict --no-interactive` 通过，active 28 / archived 741 / main specs 438 与 README 计数一致。
- focused Vitest：Session 1247 跑通 `grokHistoryParser` / `ReadToolGroupBlock` / `toolSemantics` / `groupToolItems` 共 4 files / 26 tests。
- targeted ESLint：1247 触达的 4 个 TypeScript 文件 lint 通过。
- `git diff --check`：无空白 / 冲突哨兵。
- 全量 `npm run test` / `npm run typecheck` 按用户要求本期跳过，仅跑增量回归与 strict validate；后续 verify 阶段再补全量 gate。