### PR TITLE
fix(composer): 取消附件选择时不再二次弹出文件框

### DIFF
--- a/src/features/composer/components/ChatInputBox/hooks/useAttachmentHandlers.test.tsx
+++ b/src/features/composer/components/ChatInputBox/hooks/useAttachmentHandlers.test.tsx
@@ -115,5 +115,26 @@ describe("useAttachmentHandlers pickFiles bridge", () => {
     expect(onAddAttachment).toHaveBeenCalledTimes(1);
     hook.unmount();
   });
+
+  it("does not open a second picker when the user cancels the native dialog", async () => {
+    mockPickFiles.mockResolvedValueOnce([]);
+    const onAttachPaths = vi.fn(() => true);
+    const onAddAttachment = vi.fn();
+    const hook = renderHook({
+      externalAttachments: undefined,
+      onAttachPaths,
+      onAddAttachment,
+    });
+
+    await act(async () => {
+      hook.result.handleAddAttachment(undefined);
+      await Promise.resolve();
+    });
+
+    expect(mockPickFiles).toHaveBeenCalledTimes(1);
+    expect(onAttachPaths).not.toHaveBeenCalled();
+    expect(onAddAttachment).not.toHaveBeenCalled();
+    hook.unmount();
+  });
 });
 

--- a/src/features/composer/components/ChatInputBox/hooks/useAttachmentHandlers.ts
+++ b/src/features/composer/components/ChatInputBox/hooks/useAttachmentHandlers.ts
@@ -36,12 +36,18 @@ export function useAttachmentHandlers({
       if (!files || files.length === 0) {
         void pickFiles()
           .then((pickedPaths) => {
-            if (pickedPaths.length > 0 && onAttachPaths?.(pickedPaths)) {
+            // User canceled the native dialog — do not fall back to another picker.
+            if (pickedPaths.length === 0) {
               return;
             }
+            if (onAttachPaths?.(pickedPaths)) {
+              return;
+            }
+            // Paths were selected but the path handler did not consume them.
             onAddAttachment?.();
           })
           .catch(() => {
+            // Native picker unavailable (e.g. non-Tauri); allow legacy add path.
             onAddAttachment?.();
           });
         return;


### PR DESCRIPTION
## Summary
- 修复点击「附件」打开原生选文件对话框后，**取消**会再弹出一次文件选择框的问题
- 根因：`useAttachmentHandlers` 在 `pickFiles()` 返回空数组（用户取消）时，仍回退调用 `onAddAttachment`，上层又会打开 `pickImageFiles` 对话框
- 取消时直接返回，仅在有选中路径且 path handler 未消费时才走 legacy fallback

## Test plan
- [x] `vitest run src/features/composer/components/ChatInputBox/hooks/useAttachmentHandlers.test.tsx`（含新增取消场景用例）
- [x] 桌面端：点输入框工具菜单「附件」→ 取消 → 确认不再二次弹框
- [x] 桌面端：点「附件」→ 选择文件 → 确认附件仍可正常添加
- [x] 取消后再次点「附件」→ 选择框仍可正常打开