### PR TITLE
fix(analytics): 避免 Linux WebKitGTK 启动崩溃

### DIFF
--- a/.trellis/tasks/archive/2026-08/08-02-fix-linux-startup-webkit-react-loop/check.jsonl
+++ b/.trellis/tasks/archive/2026-08/08-02-fix-linux-startup-webkit-react-loop/check.jsonl
@@ -1,0 +1,5 @@
+{"file": ".claude/commands/trellis/finish-work.md", "reason": "Finish work checklist"}
+{"file": ".claude/commands/trellis/check.md", "reason": "Code quality check spec"}
+{"file": "openspec/changes/fix-linux-startup-webkit-react-loop/", "type": "directory", "reason": "Verify implementation against canonical behavior artifacts"}
+{"file": ".trellis/spec/frontend/hook-guidelines.md", "reason": "Verify hook convergence and cleanup"}
+{"file": ".trellis/spec/frontend/state-management.md", "reason": "Verify semantic no-op/reference stability"}

--- a/.trellis/tasks/archive/2026-08/08-02-fix-linux-startup-webkit-react-loop/debug.jsonl
+++ b/.trellis/tasks/archive/2026-08/08-02-fix-linux-startup-webkit-react-loop/debug.jsonl
@@ -1,0 +1,3 @@
+{"file": ".claude/commands/trellis/check.md", "reason": "Code quality check spec"}
+{"file": "docs/perf/render-jank-knife-experiments-2026-07-08.md", "reason": "Use memoizedUpdaters/source tracing for exact React #185 owner"}
+{"file": "openspec/changes/fix-linux-startup-webkit-react-loop/design.md", "reason": "Two-failure causal chain and single-variable probe plan"}

--- a/.trellis/tasks/archive/2026-08/08-02-fix-linux-startup-webkit-react-loop/implement.jsonl
+++ b/.trellis/tasks/archive/2026-08/08-02-fix-linux-startup-webkit-react-loop/implement.jsonl
@@ -1,0 +1,8 @@
+{"file": ".trellis/workflow.md", "reason": "Project workflow and conventions"}
+{"file": ".trellis/spec/frontend/index.md", "reason": "Frontend development guide"}
+{"file": "openspec/changes/fix-linux-startup-webkit-react-loop/", "type": "directory", "reason": "OpenSpec behavior, design, tasks and acceptance contract"}
+{"file": ".trellis/spec/frontend/hook-guidelines.md", "reason": "Effect convergence, stable contracts and cleanup rules"}
+{"file": ".trellis/spec/frontend/state-management.md", "reason": "Active selection convergence and semantic no-op state rules"}
+{"file": ".trellis/spec/frontend/quality-guidelines.md", "reason": "Required tests, reference stability and no unrelated refactor"}
+{"file": ".trellis/spec/frontend/type-safety.md", "reason": "Strict TypeScript boundary"}
+{"file": "docs/perf/render-jank-knife-experiments-2026-07-08.md", "reason": "AppShell updater tracing method and render-loop hard redlines"}

--- a/.trellis/tasks/archive/2026-08/08-02-fix-linux-startup-webkit-react-loop/prd.md
+++ b/.trellis/tasks/archive/2026-08/08-02-fix-linux-startup-webkit-react-loop/prd.md
@@ -1,0 +1,28 @@
+# 修复 Linux analytics 启动崩溃并核验 React 收敛
+
+## OpenSpec
+
+- Change ID: `fix-linux-startup-webkit-react-loop`
+- Canonical artifacts: `openspec/changes/fix-linux-startup-webkit-react-loop/**`
+
+## 目标
+
+在独立 worktree 中以最小修改修复 production Linux/WebKitGTK 下百度统计请求触发 WebKitNetworkProcess/libsoup 崩溃的问题，并核验阻断统计后曾观测到的 React #185 已由 baseline convergence fixes 覆盖。新增 analytics 修复必须由 pre-fix failing regression test、post-fix targeted gates、production ELF 与 AppImage 真实启动证据共同证明；React 链路在无可重复 real-seam failure 时不增加 speculative guard。
+
+## 边界
+
+- 不修改主工作树、display/PRIME/proxy；用户明确授权的本地 desktop launcher 调整保持在 Git/PR scope 之外。
+- 不升级 dependency，不做 AppShell 无关重构。
+- analytics guard 必须发生在 script/network creation 前，并只影响确认受影响的 Linux WebKitGTK production path。
+- React #185 必须先核对 build identity、source-mapped real owner 与真实 hydration fixture；只有可重复 real-seam failure 才允许新增修复。
+- 初始诊断默认不 commit；2026-08-02 用户完成桌面验收并明确授权修正 review finding 后提交 PR。
+
+## 验收
+
+以 OpenSpec `tasks.md` 与 `verification.md` 为准；至少包括 focused/full gates、direct ELF/AppImage 各 120 秒、renderer markers、ErrorBoundary absence、crash-log delta、screenshot/geometry/pixel statistics，以及 temporary application-list launcher 等价启动验证。
+
+## PR Review Follow-up
+
+- `/review` 发现原 guard 会同时禁用 Linux Web Service browser analytics；最终实现必须仅禁用 Linux native Tauri/WebKitGTK。
+- Regression 必须同时证明 Linux native no-injection 与 Linux Web Service production injection。
+- PR 不包含用户 launcher、wrapper、AppImage binary 或其他 host-local configuration。

--- a/.trellis/tasks/archive/2026-08/08-02-fix-linux-startup-webkit-react-loop/task.json
+++ b/.trellis/tasks/archive/2026-08/08-02-fix-linux-startup-webkit-react-loop/task.json
@@ -1,0 +1,53 @@
+{
+  "id": "fix-linux-startup-webkit-react-loop",
+  "name": "fix-linux-startup-webkit-react-loop",
+  "title": "修复 Linux analytics 启动崩溃并核验 React 收敛",
+  "description": "Linked OpenSpec change: fix-linux-startup-webkit-react-loop. 在独立 worktree 中最小修复 Linux WebKit/libsoup analytics 崩溃，核验 baseline 已有 React #185 convergence fix，并完成 ELF/AppImage/temporary launcher 验证。",
+  "status": "completed",
+  "dev_type": "frontend",
+  "scope": "src/services/baiduTongji.ts; src/services/baiduTongji.test.ts; React baseline verification; OpenSpec verification artifacts",
+  "package": null,
+  "priority": "P0",
+  "creator": "yode",
+  "assignee": "yode",
+  "createdAt": "2026-08-02",
+  "completedAt": "2026-08-02",
+  "branch": "fix/linux-startup-webkit-react-loop",
+  "base_branch": "main",
+  "worktree_path": null,
+  "current_phase": 6,
+  "next_action": [
+    {
+      "phase": 1,
+      "action": "brainstorm"
+    },
+    {
+      "phase": 2,
+      "action": "research"
+    },
+    {
+      "phase": 3,
+      "action": "implement"
+    },
+    {
+      "phase": 4,
+      "action": "check"
+    },
+    {
+      "phase": 5,
+      "action": "update-spec"
+    },
+    {
+      "phase": 6,
+      "action": "record-session"
+    }
+  ],
+  "commit": null,
+  "pr_url": null,
+  "subtasks": [],
+  "children": [],
+  "parent": null,
+  "relatedFiles": [],
+  "notes": "用户已完成初始桌面验收并授权 PR；需先关闭 /review 发现的 Linux Web Service analytics P2 scope finding，再完成 final gates 和 runtime verification。",
+  "meta": {}
+}

--- a/.trellis/workspace/yode/index.md
+++ b/.trellis/workspace/yode/index.md
@@ -8,8 +8,8 @@
 
 <!-- @@@auto:current-status -->
 - **Active File**: `journal-1.md`
-- **Total Sessions**: 6
-- **Last Active**: 2026-08-02
+- **Total Sessions**: 7
+- **Last Active**: 2026-08-03
 <!-- @@@/auto:current-status -->
 
 ---
@@ -19,7 +19,7 @@
 <!-- @@@auto:active-documents -->
 | File | Lines | Status |
 |------|-------|--------|
-| `journal-1.md` | ~215 | Active |
+| `journal-1.md` | ~253 | Active |
 <!-- @@@/auto:active-documents -->
 
 ---
@@ -29,6 +29,7 @@
 <!-- @@@auto:session-history -->
 | # | Date | Title | Commits | Branch |
 |---|------|-------|---------|--------|
+| 7 | 2026-08-03 | 更正百度统计引入版本 | `2a2fa7e43` | `fix/linux-startup-webkit-react-loop` |
 | 6 | 2026-08-02 | 修复 Linux WebKitGTK 启动崩溃 | `fa487d0b7`, `5fb262190` | `fix/linux-startup-webkit-react-loop` |
 | 5 | 2026-07-27 | 提交原生会话标题修复 PR | `7b178823b` | `fix/native-session-renamed-titles` |
 | 4 | 2026-07-27 | 显示 Codex 与 Claude 原生重命名标题 | `855e25e99` | `fix/native-session-renamed-titles` |

--- a/.trellis/workspace/yode/index.md
+++ b/.trellis/workspace/yode/index.md
@@ -8,8 +8,8 @@
 
 <!-- @@@auto:current-status -->
 - **Active File**: `journal-1.md`
-- **Total Sessions**: 5
-- **Last Active**: 2026-07-27
+- **Total Sessions**: 6
+- **Last Active**: 2026-08-02
 <!-- @@@/auto:current-status -->
 
 ---
@@ -19,7 +19,7 @@
 <!-- @@@auto:active-documents -->
 | File | Lines | Status |
 |------|-------|--------|
-| `journal-1.md` | ~170 | Active |
+| `journal-1.md` | ~215 | Active |
 <!-- @@@/auto:active-documents -->
 
 ---
@@ -29,6 +29,7 @@
 <!-- @@@auto:session-history -->
 | # | Date | Title | Commits | Branch |
 |---|------|-------|---------|--------|
+| 6 | 2026-08-02 | 修复 Linux WebKitGTK 启动崩溃 | `fa487d0b7`, `5fb262190` | `fix/linux-startup-webkit-react-loop` |
 | 5 | 2026-07-27 | 提交原生会话标题修复 PR | `7b178823b` | `fix/native-session-renamed-titles` |
 | 4 | 2026-07-27 | 显示 Codex 与 Claude 原生重命名标题 | `855e25e99` | `fix/native-session-renamed-titles` |
 | 3 | 2026-07-15 | 修复 Codex 子代理会话侧栏投影 | `a0c82451` | `fix/codex-subagent-sidebar-projection-pr` |

--- a/.trellis/workspace/yode/journal-1.md
+++ b/.trellis/workspace/yode/journal-1.md
@@ -213,3 +213,41 @@
 ### Next Steps
 
 - None - task complete
+
+
+## Session 7: 更正百度统计引入版本
+
+**Date**: 2026-08-03
+**Task**: 更正百度统计引入版本
+**Branch**: `fix/linux-startup-webkit-react-loop`
+
+### Summary
+
+将 PR 与 OpenSpec 中百度统计接入起点由 v0.7.13 更正为经 Git 标签确认的 v0.7.12
+
+### Main Changes
+
+核对 `d4caf1359 feat(analytics): 接入百度统计 PV/UV 埋点` 的 Git ancestry：`v0.7.11` 不包含该提交，`v0.7.12` 已包含，因此原先“v0.7.13 起”的表述晚了一版。
+
+将 `openspec/changes/fix-linux-startup-webkit-react-loop/proposal.md` 的版本起点更正为 `v0.7.12`；未修改生产代码、测试或运行行为。
+
+验证：`git diff --check` 通过；`npx --yes @fission-ai/openspec@1.3.1 validate fix-linux-startup-webkit-react-loop --strict --no-interactive` 通过；change 与 archived task 中已无 `v0.7.13` 残留。此前完成的 lint、typecheck、tests、build 与真实启动验证继续适用于未变化的代码。
+
+
+### Git Commits
+
+| Hash | Message |
+|------|---------|
+| `2a2fa7e43` | (see git log) |
+
+### Testing
+
+- [OK] (Add test results)
+
+### Status
+
+[OK] **Completed**
+
+### Next Steps
+
+- None - task complete

--- a/.trellis/workspace/yode/journal-1.md
+++ b/.trellis/workspace/yode/journal-1.md
@@ -168,3 +168,48 @@
 ### Next Steps
 
 - None - task complete
+
+
+## Session 6: 修复 Linux WebKitGTK 启动崩溃
+
+**Date**: 2026-08-02
+**Task**: 修复 Linux WebKitGTK 启动崩溃
+**Branch**: `fix/linux-startup-webkit-react-loop`
+
+### Summary
+
+收窄 Linux analytics guard，完成真实 ELF/AppImage/收藏栏启动验证并通过最终 review
+
+### Main Changes
+
+目标：修复 cc gui 0.7.13+ 在现场 Linux native Tauri/WebKitGTK 环境启动后仅显示菜单栏与标题栏、renderer 内容为空的问题。
+
+主要修改：在百度统计初始化的 script/network creation 前增加最小平台 guard；仅当 detectRendererPlatform() 为 linux 且 window.__MOSSX_WEB_SERVICE__ !== true 时跳过 analytics。Linux Web Service browser、Windows、development、secondary window 均保持既有行为。
+
+回归覆盖：新增 Linux native 禁止加载、Linux Web Service 保留加载，以及既有 development/secondary-window 行为测试。
+
+验证结果：focused Vitest 3 files / 39 tests 通过；reviewer focused 2 files / 7 tests 通过；lint 0 errors（9 条既有 warnings）；typecheck、runtime contracts、production build、OpenSpec strict validation 均通过。完整测试仅有 Sidebar 2 failed / 51 passed，已在 main/fix 双树证明为与本修复无关的 baseline failure，并经用户明确授权跳过。
+
+真实运行：direct ELF 182 秒、direct AppImage 181 秒、收藏栏 .desktop → wrapper → AppImage 209 秒均持续显示有效内容，renderer-ready markers 正常，React ErrorBoundary、Maximum update depth、WebKitNetworkProcess/libsoup crash、coredump、apport 命中均为 0。用户也目视确认窗口内容正常。AppImage 已成功生成；后续只因本机缺少 TAURI_SIGNING_PRIVATE_KEY 在签名 gate 退出，不影响 bundle 产物与运行验证。
+
+审核：最终 codex review --uncommitted 未发现可操作缺陷。
+
+
+### Git Commits
+
+| Hash | Message |
+|------|---------|
+| `fa487d0b7` | (see git log) |
+| `5fb262190` | (see git log) |
+
+### Testing
+
+- [OK] (Add test results)
+
+### Status
+
+[OK] **Completed**
+
+### Next Steps
+
+- None - task complete

--- a/openspec/changes/fix-linux-startup-webkit-react-loop/.openspec.yaml
+++ b/openspec/changes/fix-linux-startup-webkit-react-loop/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-02

--- a/openspec/changes/fix-linux-startup-webkit-react-loop/design.md
+++ b/openspec/changes/fix-linux-startup-webkit-react-loop/design.md
@@ -1,0 +1,64 @@
+## Context
+
+现场证据把 startup failure 分成确定性与一次性两层：原版 `v0.7.15` 在 analytics script 发起 `hm.baidu.com` 请求时，`WebKitNetworkProcess` 同秒在 `libsoup-3.0.so.0 + 0x4b1d5` 崩溃；绕 proxy、AppImage/direct ELF A/B 都复现。临时完全移除 `installBaiduTongji()` 后的一次运行在 render/ready markers 后记录过 React #185。matching source map 将栈定位到 `useModels.applySelectionPlan`，但原 production `App-D-NB5kA4.js` 与当前 baseline 重建产物 SHA-256 同为 `0403d66005420cdd1dc3283952b3f72e901695b7b78c36edfb3916f1c953c9f2`，证明它已包含 `4c5e97c8e`、`e6e964d88` 的 #185 修复。真实 migration fixture 与多个单变量组合均无法让当前 baseline 再次进入 ErrorBoundary，因此新增修复只针对可复现的 analytics owner；React 作为既有 convergence contract 重新验证。
+
+现有 main worktree 有用户改动 `package-lock.json` 与 `.codegraph/`，实现必须在独立 linked worktree 完成。验证使用 temporary XDG desktop entry 指向 worktree artifact，复用既有 launcher 的 GStreamer environment，不覆盖 main-worktree artifact；用户后续选择的本地 launcher 配置不属于 Git/PR scope。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- network request prevention 位于 analytics injection boundary，且 affected runtime 判定可测试。
+- React #185 verification 锚定 source-mapped update owner；复核 baseline 的 semantic no-op、snapshot-ref 与 real-seam regression，不在无法重现时新增 production guard。
+- production verification 能同时证明 process、renderer event、crash delta 与 visible window。
+
+**Non-Goals:**
+
+- 不改变 WebKit host fallback、CSP allowlist、analytics provider/site id 或其他平台 telemetry policy。
+- 不假定最近含 `#185` 的 commit 必然是根因；commit history 仅用于 hypothesis 排序。
+- 不以 dev build、bare Cargo release、单测或存活 PID 单独宣称修复。
+
+## Decisions
+
+### 1. Analytics 在 request creation 前按 affected runtime fail closed
+
+`installBaiduTongji` 继续拥有 production/main-window gating。本 change 在同一 boundary 增加 Linux native Tauri/WebKitGTK guard，使 affected runtime 在创建 `<script>`、初始化 `_hmt` 或接触 NetworkProcess 前 return。`window.__MOSSX_WEB_SERVICE__ === true` 明确标识 daemon 提供的普通 browser runtime；该路径不经过 native `WebKitNetworkProcess`/libsoup，必须保留原 analytics behavior。平台信号复用现有 `detectRendererPlatform` 与 Web Service marker，不新增 async IPC 或 dependency。
+
+为何不只改 `main.tsx`：调用点 guard 会让 unit test 只能证明 caller 条件，无法证明 analytics service 本身不会被其他 caller 误用；service boundary 是唯一 request owner。为何不删除 CSP domain：CSP 只控制 allow/deny，不能阻止 script load attempt，也不能作为 analytics 是否注入的证据。
+
+### 2. React owner 先 source-map 与 build identity 校准，再决定是否改代码
+
+先对原始 minified frames 使用 matching production source map，并用 bundle hash 证明 source 对应关系；随后在 development React build 安装最小 updater/component-stack probe，对 3–5 个 hypotheses 一次只改变一个 variable。只有 real producer/consumer exchange 能在当前 baseline 形成 unbounded update 时，才允许新增 regression 与 production guard。
+
+本次结果是现有 `useModels` 已具备 single selection plan、snapshot-ref 与 semantic no-op；same-value functional setter probe 也证明调用 setter 本身不会形成 loop。由于 `k3/null`、空 sidebar hydration 与真实 workspace hydration 等 fixture 均未复现，不新增“plan equal 就跳过 apply”等 speculative guard。禁止关闭 effect、忽略错误或 broad memoization；若未来新证据能稳定复现，应另开带 failing real-seam regression 的 change。
+
+### 3. Runtime 判定采用四类独立 evidence
+
+每次 production launch 都记录 start timestamp/PID，并在 120 秒窗口检查：
+
+1. `bootstrap/render-committed` 与 `bootstrap/renderer-ready-marked`；
+2. 无 `react/error-boundary`；
+3. timestamp 之后无 kernel/journal/apport WebKit/libsoup crash；
+4. window screenshot + geometry + pixel distribution 证明非空白/error fallback。
+
+ELF 先运行，AppImage 后运行。AppImage 再通过 temporary XDG desktop entry 触发一次 application-list-equivalent launch；entry 与 process 在 evidence 捕获后清理。真实 `.desktop` 和 wrapper 只读核对，不修改。
+
+## Risks / Trade-offs
+
+- [Risk] Runtime platform signal 被 spoof 或缺失 → focused tests 同时覆盖 Linux navigator fact、native marker absence 与 Web Service marker presence；缺失时保持 current non-Linux behavior，不扩大 fail closed 范围。
+- [Risk] Production source map hash 与现场 asset 不同 → fallback 到 development component stack/updater trace，并用同一 release runtime event sequence复验。
+- [Risk] AppImage build 非确定或耗时 → direct ELF 先关闭功能风险；AppImage 仍是 terminal acceptance，不因 ELF green 跳过。
+- [Trade-off] Linux/WebKitGTK 不上报百度统计 PV/UV；相较 deterministic native process crash，startup 可用性优先。
+
+## Migration Plan
+
+1. 为 analytics 创建 pre-fix failing regression；对 React 完成 source-map/build-identity 与 real-seam fixture 核对。
+2. 只为可重复的 analytics owner 落地最小 guard；React 复用并重跑 baseline 已有 convergence tests。
+3. 运行 full gates 和 direct ELF/AppImage/desktop-entry-equivalent runtime verification。
+4. 更新 `verification.md`；满足 human gate 前不 archive，不修改 release launcher。
+
+Rollback 只需回退 analytics guard 与对应 regression test；React production source 未在本 change 修改。无 data/schema migration。
+
+## Open Questions
+
+- 现场一次性 #185 的 source owner 已定位到 `useModels.applySelectionPlan` 链，但当前 baseline 新增触发条件仍未复原；该边界必须在 verification 中明确记录，不能表述为“本 change 新修复了第二个 React bug”。

--- a/openspec/changes/fix-linux-startup-webkit-react-loop/proposal.md
+++ b/openspec/changes/fix-linux-startup-webkit-react-loop/proposal.md
@@ -1,0 +1,57 @@
+## Why
+
+`ccgui@0.7.15` 在本机 Ubuntu 22.04 / X11 / WebKitGTK 2.50.4 / libsoup 3.0.7 的真实 production 启动中首先发生确定性的百度统计崩溃：v0.7.13 起注入的 `hm.baidu.com` 请求会触发 `WebKitNetworkProcess` 在 libsoup 内 `SIGSEGV`，窗口因此只剩菜单栏和标题栏。阻断统计请求的一次诊断运行随后记录过 React `Maximum update depth exceeded`（#185）并落入 ErrorBoundary；production source map 将 owner 映射到 `useModels`，但故障 bundle 与当前 baseline 重建 bundle 的 SHA-256 完全一致，而 baseline 已包含 `4c5e97c8e`、`e6e964d88` 两次 #185 收敛修复。多个隔离 settings/workspace hydration fixture 均未再次触发 #185，因此本 change 只新增可 red/green 证明的 Linux analytics guard，并把既有 #185 修复作为必须重新通过的 startup convergence baseline，而不叠加 speculative state guard。
+
+## 目标与边界
+
+- 在受影响的 Linux/WebKitGTK runtime 中，于 DOM script 创建和 network request 之前阻断百度统计注入。
+- 通过 matching production source map 与窄 instrumentation 核对 React #185 owner，确认当前 bundle 是否已经包含现有 convergence fix；只有能在真实 seam 重现时才新增 state guard。
+- 使用正确的 Tauri `custom-protocol` production build，同时验证 direct ELF、AppImage 与 desktop-entry-equivalent 启动。
+- 保留其他平台、Linux Web Service browser、development build、非主窗口以及相邻 composer/model/session 行为。
+
+## 非目标
+
+- 不升级或替换 WebKitGTK/libsoup，不修改系统 proxy、PRIME/display mode、IME 或用户启动器。
+- 不通过延迟 analytics、吞掉 NetworkProcess failure、关闭 ErrorBoundary、增加 arbitrary timeout 或 broad AppShell refactor 掩盖故障。
+- 不新增 dependency，不改变 analytics site id，不修改持久化 schema。
+- 不把 `cargo build --release` 的 dev-server 黑屏当作 production 对照；production ELF 必须启用 `custom-protocol`。
+
+## What Changes
+
+- 为现有 `installBaiduTongji` 注入边界增加 affected Linux native Tauri/WebKitGTK guard，并扩展 focused Vitest 覆盖 Linux native no-injection、Linux Web Service browser 与 unaffected-platform production behavior。
+- 将 minified React stack 映射回当前源码，并核对故障 bundle 与 baseline build identity；复用已有 `useModels` convergence tests，删除无法重现 failure loop 的临时组合测试与 instrumentation。
+- 增加 Linux renderer startup verification：renderer-ready、无 `react/error-boundary`、无新 WebKit/libsoup crash，以及非空白/非 ErrorBoundary window evidence。
+- 在 OpenSpec verification 中记录 release ELF、AppImage 和 temporary desktop-entry-equivalent 运行证据；真实 launcher 与 main worktree 保持不变。
+
+## Capabilities
+
+### New Capabilities
+
+- `linux-renderer-startup-stability`: 约束 Linux/WebKitGTK external analytics safety、React startup state convergence 与 production artifact runtime evidence。
+
+### Modified Capabilities
+
+- 无。现有 `linux-appimage-startup-compatibility` 主要约束 Wayland/AppImage host fallback；本 change 同时覆盖 X11 与 direct ELF 的 renderer 侧故障，因此建立独立、较窄的 renderer capability。
+
+## 方案对比与取舍
+
+1. **采用：只在已复现 owner 上增加最小 guard。** analytics 在 script injection boundary 按 affected runtime fail closed；React 继续复用 baseline 已有的 single-plan、snapshot-ref 与 semantic no-op contract。该方案避免把一次不可复现的 #185 观察转化成未经证实的第二层状态逻辑。
+2. **备选：升级 WebKitGTK/libsoup 或强制 proxy/display fallback。** 这会改变用户系统且不能解释 React #185，因此拒绝。
+3. **备选：Linux 全面禁网或延后 analytics。** 前者破坏产品功能，后者仍可能触发同一 NetworkProcess crash，因此拒绝。
+4. **备选：ErrorBoundary 自动 reload。** 会把 deterministic update loop 变成 reload loop，丢失根因且无法满足可用性验收，因此拒绝。
+
+## 验收标准
+
+- focused test 证明 fix 前 production Linux native renderer 会注入唯一 site id，fix 后 affected runtime 不创建相关 script/request；Linux Web Service browser、development、secondary window 与 unaffected production platform 行为保持。
+- 现有 React #185 focused tests、AppShell startup tests 与 production runtime 均证明 selection convergence；若不能让当前 baseline 在 real seam 失败，则不得新增声称“修复 #185”的测试或 guard。
+- release ELF 使用 `--features custom-protocol`，与 worktree AppImage 各连续运行至少 120 秒；两者均有 `bootstrap/render-committed`、`bootstrap/renderer-ready-marked`，无 `react/error-boundary`。
+- 每次 launch timestamp 之后没有新的 `WebKitNetworkProcess` / libsoup kernel、journal 或 apport crash。
+- screenshot、window geometry 与 pixel statistics 共同证明 content area 非白屏、非黑屏、非透明、非 ErrorBoundary-only。
+- full lint/typecheck/test/build/runtime-contract/OpenSpec gates 通过；temporary launcher、process、source map 与 instrumentation 全部清理，main worktree 与真实 launcher 未变化。
+
+## Impact
+
+- Frontend: `src/services/baiduTongji.ts` 及其 test；React 路径只做 source-map/build-identity/既有 tests 的验证，不新增 production source diff。
+- Packaging/runtime: Vite production bundle、Tauri release ELF、Linux AppImage；不修改 Rust command contract 或 system config。
+- Specs: 新增 `linux-renderer-startup-stability` delta 与 change-local verification evidence。
+- Dependencies/storage: 无新增 dependency，无 schema migration。

--- a/openspec/changes/fix-linux-startup-webkit-react-loop/proposal.md
+++ b/openspec/changes/fix-linux-startup-webkit-react-loop/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-`ccgui@0.7.15` 在本机 Ubuntu 22.04 / X11 / WebKitGTK 2.50.4 / libsoup 3.0.7 的真实 production 启动中首先发生确定性的百度统计崩溃：v0.7.13 起注入的 `hm.baidu.com` 请求会触发 `WebKitNetworkProcess` 在 libsoup 内 `SIGSEGV`，窗口因此只剩菜单栏和标题栏。阻断统计请求的一次诊断运行随后记录过 React `Maximum update depth exceeded`（#185）并落入 ErrorBoundary；production source map 将 owner 映射到 `useModels`，但故障 bundle 与当前 baseline 重建 bundle 的 SHA-256 完全一致，而 baseline 已包含 `4c5e97c8e`、`e6e964d88` 两次 #185 收敛修复。多个隔离 settings/workspace hydration fixture 均未再次触发 #185，因此本 change 只新增可 red/green 证明的 Linux analytics guard，并把既有 #185 修复作为必须重新通过的 startup convergence baseline，而不叠加 speculative state guard。
+`ccgui@0.7.15` 在本机 Ubuntu 22.04 / X11 / WebKitGTK 2.50.4 / libsoup 3.0.7 的真实 production 启动中首先发生确定性的百度统计崩溃：v0.7.12 起注入的 `hm.baidu.com` 请求会触发 `WebKitNetworkProcess` 在 libsoup 内 `SIGSEGV`，窗口因此只剩菜单栏和标题栏。阻断统计请求的一次诊断运行随后记录过 React `Maximum update depth exceeded`（#185）并落入 ErrorBoundary；production source map 将 owner 映射到 `useModels`，但故障 bundle 与当前 baseline 重建 bundle 的 SHA-256 完全一致，而 baseline 已包含 `4c5e97c8e`、`e6e964d88` 两次 #185 收敛修复。多个隔离 settings/workspace hydration fixture 均未再次触发 #185，因此本 change 只新增可 red/green 证明的 Linux analytics guard，并把既有 #185 修复作为必须重新通过的 startup convergence baseline，而不叠加 speculative state guard。
 
 ## 目标与边界
 

--- a/openspec/changes/fix-linux-startup-webkit-react-loop/specs/linux-renderer-startup-stability/spec.md
+++ b/openspec/changes/fix-linux-startup-webkit-react-loop/specs/linux-renderer-startup-stability/spec.md
@@ -1,0 +1,75 @@
+## ADDED Requirements
+
+### Requirement: Linux WebKitGTK Startup MUST Avoid Unsafe External Analytics Injection
+
+The renderer MUST prioritize startup availability over external analytics in an affected Linux/WebKitGTK production runtime. Prevention MUST occur before an analytics script, beacon, or equivalent network request is created.
+
+#### Scenario: production starts in affected Linux WebKitGTK runtime
+
+- **WHEN** the production renderer starts inside the supported Linux Tauri/WebKitGTK runtime
+- **THEN** Baidu analytics script injection MUST be skipped before the unique site id is submitted to `hm.baidu.com`
+- **AND** startup MUST NOT initialize an analytics request that can reach `WebKitNetworkProcess` or libsoup.
+
+#### Scenario: development or secondary window starts
+
+- **WHEN** the renderer is not a production build or the current window is not the main window
+- **THEN** the existing no-injection behavior MUST remain
+- **AND** the Linux guard MUST NOT create a parallel analytics path.
+
+#### Scenario: unaffected production platform starts
+
+- **WHEN** the production main window runs outside the affected Linux/WebKitGTK runtime
+- **THEN** the existing analytics behavior MAY remain enabled
+- **AND** platform gating MUST NOT require a new backend command or dependency.
+
+#### Scenario: Linux Web Service opens in a regular browser
+
+- **WHEN** the production frontend runs with `window.__MOSSX_WEB_SERVICE__ === true` on Linux
+- **THEN** the native WebKitGTK safety guard MUST NOT disable the existing analytics behavior
+- **AND** the Web Service browser path MUST remain distinguishable from the native Tauri renderer without a new backend command.
+
+### Requirement: Renderer Startup State Updates MUST Converge
+
+Every startup-time React state/effect owner MUST converge after catalog, settings, workspace, and persisted selection hydration. A logically equivalent derived value MUST NOT publish a new state/reference that re-triggers the same owner.
+
+#### Scenario: startup derives a selection or state equal to the current value
+
+- **WHEN** a startup effect/layout effect/store subscriber derives a result semantically equal to its current state
+- **THEN** the write MUST be skipped or the previous state reference MUST be retained
+- **AND** the same derivation MUST NOT trigger another synchronous update cycle.
+
+#### Scenario: startup hydration changes a value once
+
+- **WHEN** persisted or runtime facts require one real state correction
+- **THEN** the owner MUST publish the corrected value once
+- **AND** the next render with the same facts MUST be a no-op
+- **AND** the main renderer MUST NOT enter React `Maximum update depth exceeded` or `react/error-boundary`.
+
+#### Scenario: regression coverage exercises the real update seam
+
+- **WHEN** startup convergence logic is changed
+- **THEN** regression coverage MUST mount or otherwise exercise the actual producer/consumer update exchange that previously looped
+- **AND** a pure helper test alone MUST NOT be treated as proof if it cannot reproduce the feedback chain.
+
+### Requirement: Linux Production Startup Verification MUST Prove A Visible Stable Renderer
+
+Release verification MUST test both the direct Tauri ELF and AppImage with the production custom protocol, and MUST distinguish a usable renderer from a live but blank or ErrorBoundary-only process.
+
+#### Scenario: direct release ELF starts
+
+- **WHEN** the Linux release ELF is built with `custom-protocol` and launched
+- **THEN** it MUST remain running with a visible usable content area for at least 120 seconds
+- **AND** diagnostics MUST contain `bootstrap/render-committed` and `bootstrap/renderer-ready-marked`
+- **AND** diagnostics MUST NOT contain `react/error-boundary` for that launch.
+
+#### Scenario: AppImage or desktop-entry-equivalent path starts
+
+- **WHEN** the worktree AppImage is launched directly or through a desktop-entry-equivalent environment
+- **THEN** it MUST satisfy the same 120-second renderer-ready and visible-content evidence
+- **AND** verification MUST NOT overwrite the user's existing launcher or main-worktree AppImage.
+
+#### Scenario: startup completes without a native network-process crash
+
+- **WHEN** either production artifact reaches renderer-ready
+- **THEN** no new kernel, journal, coredump, or apport event after that launch timestamp MAY report `WebKitNetworkProcess` or libsoup crash
+- **AND** screenshot, window geometry, and pixel-distribution evidence MUST rule out white, black, transparent, or ErrorBoundary-only content.

--- a/openspec/changes/fix-linux-startup-webkit-react-loop/tasks.md
+++ b/openspec/changes/fix-linux-startup-webkit-react-loop/tasks.md
@@ -1,0 +1,30 @@
+## 1. Isolation And Diagnosis
+
+- [x] 1.1 [P0, depends: none] 在独立 worktree 核对 baseline、launcher、WebKit/libsoup/runtime facts，读取 frontend hook/state/quality/type-safety 与 render-jank 指南；输出 main/new worktree status evidence。
+- [x] 1.2 [P0, depends: 1.1] 用 matching production source map 与 development updater trace 映射 React #185；完成 build identity、单变量 fixture 与真实 migration hydration 核对。
+- [x] 1.3 [P0, depends: 1.2] 创建 linked Trellis task，记录 OpenSpec change id、worktree boundary、pre-fix signals 与 verification commands。
+
+## 2. Linux Analytics Crash Guard
+
+- [x] 2.1 [P0, depends: 1.1] 在 `src/services/baiduTongji.test.ts` 增加 affected production Linux/WebKitGTK failing regression，并保留 development、secondary-window、unaffected production cases。
+- [x] 2.2 [P0, depends: 2.1] 在现有 analytics service boundary 增加最小 platform/runtime guard，确保在 `_hmt`/script/network creation 前 return；不新增 dependency，不修改 CSP/site id。
+- [x] 2.3 [P0, depends: 2.2] 运行 focused Vitest、typecheck、production build，检查 unique site id 的实际 guarded call path并记录 red/green evidence。
+- [x] 2.4 [P1, depends: 2.3] 根据 `/review` finding 将 Linux guard 收窄到 native Tauri/WebKitGTK；新增 Linux Web Service browser regression，证明普通 browser production 仍保留 analytics。
+
+## 3. React Startup Convergence
+
+- [x] 3.1 [P0, depends: 1.2,2.3] 核对 source-mapped real seam：当前 baseline 已含 #185 fix，组合 fixture 与真实 migration hydration 均未复现 unbounded update；删除 StrictMode-only false-positive 临时测试。
+- [x] 3.2 [P0, depends: 3.1] 不新增 speculative React source guard；复核现有 semantic no-op / snapshot-ref / acyclic dependency fix 与相邻 model/freeform/session tests。
+- [x] 3.3 [P0, depends: 3.2] 运行 focused tests、AppShell runtime contract、typecheck/build，并用 no-analytics production ELF 越过原 failure window；删除全部 temporary instrumentation/source map edits。
+
+## 4. Production Artifact Verification
+
+- [x] 4.1 [P0, depends: 2.3,3.3] 运行 lint、typecheck、full tests、runtime contracts、Vite build 与 `cargo build --release --bin cc-gui --features custom-protocol`，记录 exact exit summaries。
+- [x] 4.2 [P0, depends: 4.1] direct ELF 连续运行至少 120 秒；验证 render/ready markers、无 ErrorBoundary、无 launch timestamp 后的新 WebKit/libsoup crash，并捕获 screenshot/pixel/geometry evidence。
+- [x] 4.3 [P0, depends: 4.2] `npm run build:appimage` 后直接启动 worktree artifact，再用 temporary XDG desktop entry 复用真实 wrapper environment 启动；每条 path 观察至少 120 秒并执行同一 evidence contract。
+- [x] 4.4 [P0, depends: 4.3] 删除 temporary entry/process/source maps/instrumentation，运行 `check`、`check-cross-layer`、`finish-work`，更新 `verification.md`，复核 main worktree/index/HEAD、真实 launcher 与 system settings 未变化。
+
+## 5. PR Readiness
+
+- [x] 5.1 [P0, depends: 2.4,4.4] 重新运行 focused/full gates、OpenSpec validation 与 final AppImage runtime verification，记录收窄 guard 后的 artifact SHA-256 和 launch evidence。
+- [x] 5.2 [P0, depends: 5.1] 执行最终 `/review`、`check`、`check-cross-layer`、`finish-work`，确认 PR 不包含本地 launcher/AppImage artifact，并提交、记录 Trellis session、推送和创建 PR。

--- a/openspec/changes/fix-linux-startup-webkit-react-loop/verification.md
+++ b/openspec/changes/fix-linux-startup-webkit-react-loop/verification.md
@@ -1,0 +1,86 @@
+# Verification
+
+## 1. Scope And Classification
+
+- Verification worktree：独立 linked worktree（不复用 main worktree）
+- Branch：`fix/linux-startup-webkit-react-loop`
+- Production source fix 仅涉及 `src/services/baiduTongji.ts`；regression test 位于同层 `src/services/baiduTongji.test.ts`。
+- Linux native Tauri/WebKitGTK production 在 `_hmt`、`<script>`、`hm.baidu.com` network request 创建前 return；Linux Web Service browser、Windows production、development、secondary window contract 保持不变。
+- React #185 未增加 speculative guard。故障现场 bundle 与当前 baseline 重建 bundle 的 SHA-256 同为 `0403d66005420cdd1dc3283952b3f72e901695b7b78c36edfb3916f1c953c9f2`；baseline 已包含既有 convergence fixes `4c5e97c8e`、`e6e964d88`，多组 fixture 与真实 migration hydration 均未再次复现。
+
+## 2. Regression And Quality Gates
+
+| Command / probe | Result |
+|---|---|
+| baseline source + 新 Linux native analytics test | expected red：`1 failed / 3 passed`，实际创建 `hm.baidu.com` script |
+| `/review` 后新增 Linux Web Service regression（应用收窄前） | expected red：`1 failed / 4 passed`，Linux Web Service 被原 guard 误禁用 |
+| final `baiduTongji.test.ts` | `5 passed`；Linux native 不注入，Linux Web Service/Windows production 保留注入 |
+| final focused Vitest（含 `useModels` 与 real-seam `app-shell.startup.test.tsx`） | `3 files passed / 39 tests passed` |
+| `npm run typecheck` | exit 0 |
+| `npm run lint` | exit 0；0 errors，9 existing warnings |
+| `npm run check:runtime-contracts` | exit 0 |
+| `npm run build` | exit 0 |
+| `cargo build --release --bin cc-gui --features custom-protocol` | exit 0；final AppImage build 内 release compilation `9m45s` |
+| full Vitest | batch 19 only `Sidebar.test.tsx` 2 failures / 51 passed；fix worktree 与 main worktree 精确同样失败，按已授权 baseline exception 继续 |
+
+Full-test baseline failures：
+
+- `creates a new session directly inside a workspace session folder`
+- `moves codex pending folder intent after catalog-backed session exists`
+- 两者均找不到 `menuitemradio /codex-tui\/default-config/`；不在本 change 修改范围。
+
+Production bundle 检查确认 guard 顺序为：
+
+```js
+if (
+  !isMainWindow() ||
+  (window.__MOSSX_WEB_SERVICE__ !== true &&
+    detectRendererPlatform() === "linux")
+) return;
+window._hmt = /* ... */;
+```
+
+## 3. Production Artifact
+
+- `npm run build:appimage` 完成 Rust release build 和 AppImage bundle 生成。
+- Artifact：`src-tauri/target/release/bundle/appimage/ccgui_0.7.15_amd64.AppImage`
+- SHA-256：`d8d2a4e5971c05b056027ceacc9233674fc272a1aad1cdb4710a987222cc600c`
+- Size：`106658296` bytes；mtime `2026-08-02 22:13:12 +0800`。
+- Rust release build：`9m45s`；AppImage bundle 在 signing gate 前成功生成。
+- Bundle 生成后命令因本机只有 Tauri public key、缺少 `TAURI_SIGNING_PRIVATE_KEY` 而 exit 1；这是 post-bundle signing environment failure，不影响本地 artifact runtime verification，也未安装或写入 signing config。
+
+## 4. Runtime Evidence Contract
+
+每条路径都验证：process 持续存活至少 120 秒；window `Map State` 为 `IsViewable`；截图包含真实 sidebar/composer/content，而非 white/black single-color surface；启动 timestamp 后 app error log、user journal、coredump 均无 `react/error-boundary`、`Maximum update depth`、`WebKitNetworkProcess` crash、`libsoup` crash 或 `SIGSEGV`。
+
+| Launch path | Duration | Window / pixel evidence | Result |
+|---|---:|---|---|
+| direct release ELF | 182s | `1552x1043` / `IsViewable`; 6625 colors；mean `0.975070`；stddev `0.065551`；sidebar、workspace、composer、model selector 可见 | pass |
+| direct generated AppImage | 181s | `1552x1043` / `IsViewable`; 6574 colors；mean `0.974618`；stddev `0.065051`；min `3341`，max `65535` | pass |
+| actual application-list launcher (`gtk-launch` → user-local `.desktop` → wrapper → same AppImage) | 209s | `1552x1043` / `IsViewable`; 6574 colors；mean `0.974618`；stddev `0.065051`；min `3341`，max `65535` | pass |
+
+Direct ELF markers：
+
+- `renderer/install`: `1785680038850`
+- `bootstrap/render-committed`: `1785680039429`
+- `bootstrap/renderer-ready-marked`: `1785680040405`
+
+同一 AppImage SHA-256 的 completion-marker recheck：
+
+| Launch path | `renderer/install` | `render-committed` | `renderer-ready-marked` | target errors |
+|---|---:|---:|---:|---:|
+| direct AppImage | `1785680251039` | `1785680251627` | `1785680252656` | app/journal/coredump 均 0 |
+| actual application-list launcher | `1785680775541` | `1785680776174` | `1785680777315` | app/journal/coredump 均 0 |
+
+User-local launcher 复用既有 GStreamer environment，并指向上述同一 AppImage SHA-256；launcher、wrapper 与 AppImage 在最终 209 秒运行前后 checksum 保持一致。该 host-local launcher 配置不属于 Git/PR diff；`ccgui-latest.desktop` 与 `ccgui-latest-appimage` 未修改。
+
+## 5. Review Boundary
+
+- `check`：service/test placement、strict TypeScript、test coverage、forbidden patterns 均无 violation。
+- `check-cross-layer`：change 不跨 3+ layers；复用现有 `detectRendererPlatform`，未创建重复 utility；analytics call site 仅为 `src/main.tsx`，site id 与 script injection 仅有一个 owner。
+- `finish-work`：lint/typecheck/runtime contracts/focused regression/build/manual startup evidence 已完成；full-test 仅保留已在 main/fix 双树证明相同的 baseline exception；无 API、database、infra 或 cross-layer contract 变更，因此无需新增 `.trellis/spec/**` executable contract。
+- Final `codex review --uncommitted`：未发现本次变更引入的可操作缺陷；额外复核 Web Service shim 注入顺序、native/Web Service runtime branch 与 production minified bundle，并再次通过 focused Vitest、typecheck、build 与 targeted ESLint。
+- Cleanup audit：temporary HOME、temporary `.desktop`/wrapper、screenshots、source maps/instrumentation 与全部测试进程均已删除；这些 transient artifacts 不进入 Git/PR。
+- Main worktree HEAD 仍为 `8b2a3a7c2297cff4aa2211057c7bd0926dbb4375`，index empty，原有 `M package-lock.json` 与 `?? .codegraph/` 保持不变。
+- 未触及的 baseline launcher checksum 保持不变：`ccgui-latest.desktop` 为 `bd43af818c396ad76841ffcf593435d19e5caad2eb4ce5b512fcca689dc1acbb`；`ccgui-latest-appimage` 为 `189c05a40d26b6130514ed99bcebb87f9019f71a0f647d518683fe89232eaffe`。
+- 本验证证明 startup white/black screen 与目标 crash 已修复；不把 startup screenshot 扩大解释为所有业务交互均已完成 manual acceptance。

--- a/src/services/baiduTongji.test.ts
+++ b/src/services/baiduTongji.test.ts
@@ -14,8 +14,20 @@ const mockWindowLabel = (label: string) => {
 };
 
 describe("installBaiduTongji", () => {
+  const originalNavigatorPlatform = window.navigator.platform;
+  const originalWebServiceRuntime = window.__MOSSX_WEB_SERVICE__;
+
   afterEach(() => {
     vi.unstubAllEnvs();
+    Object.defineProperty(window.navigator, "platform", {
+      configurable: true,
+      value: originalNavigatorPlatform,
+    });
+    if (originalWebServiceRuntime === undefined) {
+      delete window.__MOSSX_WEB_SERVICE__;
+    } else {
+      window.__MOSSX_WEB_SERVICE__ = originalWebServiceRuntime;
+    }
     document
       .querySelectorAll('script[src*="hm.baidu.com"]')
       .forEach((el) => el.remove());
@@ -28,8 +40,12 @@ describe("installBaiduTongji", () => {
     expect(document.querySelector('script[src*="hm.baidu.com"]')).toBeNull();
   });
 
-  it("生产环境注入带站点 ID 的统计脚本", () => {
+  it("Windows production 注入带站点 ID 的统计脚本", () => {
     vi.stubEnv("PROD", true);
+    Object.defineProperty(window.navigator, "platform", {
+      configurable: true,
+      value: "Win32",
+    });
     installBaiduTongji();
     const script = document.querySelector<HTMLScriptElement>(
       'script[src*="hm.baidu.com"]',
@@ -41,8 +57,44 @@ describe("installBaiduTongji", () => {
     expect(window._hmt).toEqual([]);
   });
 
+  it("Linux production 不创建统计脚本或 _hmt", () => {
+    vi.stubEnv("PROD", true);
+    Object.defineProperty(window.navigator, "platform", {
+      configurable: true,
+      value: "Linux x86_64",
+    });
+
+    installBaiduTongji();
+
+    expect(document.querySelector('script[src*="hm.baidu.com"]')).toBeNull();
+    expect(window._hmt).toBeUndefined();
+  });
+
+  it("Linux Web Service production 保留统计脚本", () => {
+    vi.stubEnv("PROD", true);
+    Object.defineProperty(window.navigator, "platform", {
+      configurable: true,
+      value: "Linux x86_64",
+    });
+    window.__MOSSX_WEB_SERVICE__ = true;
+
+    installBaiduTongji();
+
+    const script = document.querySelector<HTMLScriptElement>(
+      'script[src*="hm.baidu.com"]',
+    );
+    expect(script?.src).toContain(
+      "hm.js?daa60bcc45c658ee35054b93be3cf2e4",
+    );
+    expect(window._hmt).toEqual([]);
+  });
+
   it("非主窗口不注入统计脚本，避免开窗虚增 PV", () => {
     vi.stubEnv("PROD", true);
+    Object.defineProperty(window.navigator, "platform", {
+      configurable: true,
+      value: "Win32",
+    });
     mockWindowLabel("about");
     installBaiduTongji();
     expect(document.querySelector('script[src*="hm.baidu.com"]')).toBeNull();

--- a/src/services/baiduTongji.ts
+++ b/src/services/baiduTongji.ts
@@ -1,4 +1,5 @@
 import { getCurrentWindow } from "@tauri-apps/api/window";
+import { detectRendererPlatform } from "../utils/rendererPlatform";
 
 const BAIDU_TONGJI_SITE_ID = "daa60bcc45c658ee35054b93be3cf2e4";
 
@@ -25,16 +26,23 @@ function isMainWindow(): boolean {
  * 注入百度统计（PV/UV）脚本。
  * 仅生产构建生效，避免开发环境的访问污染统计数据。
  *
- * 注意：Tauri 生产环境页面运行在 tauri://（macOS/Linux）或 http://tauri.localhost
- * （Windows），hm.js 探测到非 https 协议会把上报 gif 降级为 http://hm.baidu.com，
- * 因此 tauri.conf.json 的 CSP img-src/connect-src 必须放行 http://hm.baidu.com，
- * 否则 beacon 被拦截、后台永远零数据。
+ * 注意：Linux 原生 Tauri/WebKitGTK 禁止加载 hm.js；现场故障中该请求会触发
+ * WebKitNetworkProcess/libsoup 崩溃并清空 renderer，必须在创建 _hmt/script 前返回。
+ * Web Service 运行在普通 browser，不经过该 native network process，保留原统计行为。
+ * 其余生产 runtime 的非 https 页面会让上报 gif 降级为 http://hm.baidu.com，
+ * 因此 tauri.conf.json 的 CSP img-src/connect-src 仍需放行该地址。
  */
 export function installBaiduTongji(): void {
   if (!import.meta.env.PROD) {
     return;
   }
   if (!isMainWindow()) {
+    return;
+  }
+  if (
+    window.__MOSSX_WEB_SERVICE__ !== true &&
+    detectRendererPlatform() === "linux"
+  ) {
     return;
   }
   window._hmt = window._hmt || [];


### PR DESCRIPTION
## 问题

从 v0.7.12 接入百度统计后，受影响的 Linux native Tauri/WebKitGTK 环境在启动时会由该统计网络请求触发 `WebKitNetworkProcess` / libsoup 崩溃。用户侧表现为窗口只剩菜单栏和标题栏，renderer 区域白屏或黑屏。

现场日志、窄化 A/B 与真实运行验证均指向 analytics 初始化；React `ErrorBoundary` 和 `Maximum update depth` 没有命中。

## 最小修复

在 `src/services/baiduTongji.ts` 创建 analytics script / network request 之前增加平台 guard：

- Linux native Tauri/WebKitGTK：跳过百度统计初始化
- Linux Web Service browser：保留统计
- Windows native：保持原行为
- development、secondary window：保持原有跳过行为

对应测试覆盖了 Linux native 与 Linux Web Service 的差异，避免将修复误扩展到所有 Linux renderer。

## 验证

- focused Vitest：3 files / 39 tests passed
- reviewer focused Vitest：2 files / 7 tests passed
- lint：0 errors（9 条既有 warnings）
- typecheck：passed
- runtime contracts：passed
- production build：passed
- OpenSpec strict validation：passed
- 最终 `codex review --uncommitted`：未发现可操作缺陷

真实启动路径：

- direct ELF：持续运行 182 秒，renderer 内容正常
- direct AppImage：持续运行 181 秒，renderer 内容正常
- 收藏栏 `.desktop → wrapper → AppImage`：持续运行 209 秒，renderer 内容正常

三个路径均观察到 renderer-ready markers 和非单色内容；`WebKitNetworkProcess` / libsoup crash、coredump、apport、React ErrorBoundary、`Maximum update depth` 命中均为 0。用户亦完成目视确认。

## 已知 baseline

完整测试为 2 failed / 51 passed；两个失败均位于 Sidebar，已在未修改的 `main` 与本修复分支上得到相同结果，因此与本变更无关。该 baseline exception 已经人工确认并授权跳过。

AppImage bundle 已成功生成并用于真实启动验证；后续签名步骤因本地没有 `TAURI_SIGNING_PRIVATE_KEY` 退出，这只影响本地 signing gate，不影响 bundle 生成或本次运行验证。

本 PR 不包含本地 launcher、wrapper 或 AppImage binary。

