### PR TITLE
feat(vendors): add Atlas Cloud Codex preset

### DIFF
--- a/.trellis/workspace/binyangzhu000-sudo/index.md
+++ b/.trellis/workspace/binyangzhu000-sudo/index.md
@@ -1,0 +1,41 @@
+# Workspace Index - binyangzhu000-sudo
+
+> Journal tracking for AI development sessions.
+
+---
+
+## Current Status
+
+<!-- @@@auto:current-status -->
+- **Active File**: `journal-1.md`
+- **Total Sessions**: 1
+- **Last Active**: 2026-08-03
+<!-- @@@/auto:current-status -->
+
+---
+
+## Active Documents
+
+<!-- @@@auto:active-documents -->
+| File | Lines | Status |
+|------|-------|--------|
+| `journal-1.md` | ~40 | Active |
+<!-- @@@/auto:active-documents -->
+
+---
+
+## Session History
+
+<!-- @@@auto:session-history -->
+| # | Date | Title | Commits | Branch |
+|---|------|-------|---------|--------|
+| 1 | 2026-08-03 | 添加 Atlas Cloud Codex provider preset | `c5a81f4` | `codex/add-atlas-cloud-codex-preset` |
+<!-- @@@/auto:session-history -->
+
+---
+
+## Notes
+
+- Sessions are appended to journal files
+- New journal file created when current exceeds 2000 lines
+- Use `add_session.py` to record sessions

--- a/.trellis/workspace/binyangzhu000-sudo/journal-1.md
+++ b/.trellis/workspace/binyangzhu000-sudo/journal-1.md
@@ -1,0 +1,45 @@
+# Journal - binyangzhu000-sudo (Part 1)
+
+> AI development session journal
+> Started: 2026-08-03
+
+---
+
+
+
+## Session 1: 添加 Atlas Cloud Codex provider preset
+
+**Date**: 2026-08-03
+**Task**: 添加 Atlas Cloud Codex provider preset
+**Branch**: `codex/add-atlas-cloud-codex-preset`
+
+### Summary
+
+新增 Atlas Cloud Codex provider preset、英中标签与聚焦测试；通过 Vitest、typecheck、production build、OpenSpec strict validation、ESLint、diff/secret 检查和真实 Chat Completions HTTP 200。
+
+### Main Changes
+
+- 在现有 `CODEX_PROVIDER_PRESETS` 中加入 `atlas-cloud`，生成 `https://api.atlascloud.ai/v1`、`deepseek-ai/deepseek-v4-pro` 与 `wire_api = "chat"` 配置。
+- 增加英中 preset 标签和 Codex provider dialog 聚焦回归测试。
+- 按仓库规则增加并严格校验 `add-atlas-cloud-codex-preset` OpenSpec change。
+
+### Git Commits
+
+| Hash | Message |
+|------|---------|
+| `c5a81f4` | (see git log) |
+
+### Testing
+
+- [OK] Codex provider dialog Vitest 6/6。
+- [OK] TypeScript typecheck、production build 与 changed-file ESLint。
+- [OK] OpenSpec strict validation、diff/secret 检查。
+- [OK] 真实 Atlas Cloud Chat Completions HTTP 200，返回 `ATLAS_PRESET_OK`。
+
+### Status
+
+[OK] **Completed**
+
+### Next Steps
+
+- None - task complete

--- a/openspec/changes/add-atlas-cloud-codex-preset/.openspec.yaml
+++ b/openspec/changes/add-atlas-cloud-codex-preset/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-03

--- a/openspec/changes/add-atlas-cloud-codex-preset/design.md
+++ b/openspec/changes/add-atlas-cloud-codex-preset/design.md
@@ -1,0 +1,44 @@
+## Context
+
+Codex presets are typed data entries that generate a managed `config.toml` and reuse the existing `auth.json` editor. The runtime already supports OpenAI-compatible providers and the `chat` wire API, so Atlas Cloud requires no transport or persistence changes.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Reuse `buildCodexProviderConfigToml` as the single config generator.
+- Make the Atlas Cloud endpoint and default model explicit and testable.
+- Keep the change isolated to provider catalog data and localization.
+
+**Non-Goals:**
+
+- Add a dedicated network client or runtime adapter.
+- Store API keys in the preset.
+- Add marketing assets or documentation.
+
+## Decisions
+
+### 1. Use the existing Codex provider preset catalog
+
+The preset uses id `atlas-cloud` and provider id `atlas_cloud`. This preserves the current dialog, save, and managed session launch flow.
+
+### 2. Use Chat Completions explicitly
+
+Atlas Cloud exposes an OpenAI-compatible Chat Completions API. The generated config therefore sets `wire_api = "chat"` instead of relying on the helper default.
+
+### 3. Keep credentials empty
+
+The preset reuses `DEFAULT_CODEX_AUTH_JSON`, leaving `OPENAI_API_KEY` empty for the user to provide through the existing secure editor.
+
+## Risks / Trade-offs
+
+- [Risk] Atlas Cloud changes a recommended model id -> the preset remains editable after selection, matching all existing third-party presets.
+- [Risk] A generic icon is less recognizable -> no unofficial logo is introduced; visual branding can be added separately if an approved asset exists.
+
+## Migration Plan
+
+No migration is required. Removing the preset fully rolls back the change without affecting saved custom providers.
+
+## Open Questions
+
+无。

--- a/openspec/changes/add-atlas-cloud-codex-preset/proposal.md
+++ b/openspec/changes/add-atlas-cloud-codex-preset/proposal.md
@@ -1,0 +1,44 @@
+## Why
+
+Codex provider management already exposes curated OpenAI-compatible presets, but Atlas Cloud users must currently assemble `config.toml` manually. A first-class preset removes that error-prone setup while preserving the existing managed-provider runtime path.
+
+## 目标与边界
+
+- Add an Atlas Cloud choice to the existing Codex provider preset catalog.
+- Pre-fill the OpenAI-compatible endpoint, provider id, model id, and Chat Completions wire protocol.
+- Keep authentication in the existing `auth.json` editor and never persist a real key in source.
+
+## 非目标
+
+- 不修改 Codex runtime transport、provider switching 或 session binding。
+- 不新增 Atlas Cloud logo、推广文案、依赖或 README 内容。
+- 不改变其他 provider preset 的默认值。
+
+## What Changes
+
+- Add the `atlas-cloud` Codex provider preset with `https://api.atlascloud.ai/v1`, `deepseek-ai/deepseek-v4-pro`, and `wire_api = "chat"`.
+- Add English and Simplified Chinese preset labels.
+- Add a focused dialog regression test for the generated provider config.
+
+## Capabilities
+
+### New Capabilities
+
+- `codex-provider-management`: Codex provider preset management and generated connection configuration.
+
+### Modified Capabilities
+
+无。
+
+## 验收标准
+
+- Selecting Atlas Cloud fills the expected provider name, endpoint, model, provider id, and Chat Completions wire protocol.
+- Existing custom, official, and third-party presets remain unchanged.
+- Focused tests, TypeScript checks, production build, diff/secret checks, and a real Atlas Cloud Chat Completions request pass.
+
+## Impact
+
+- `src/features/vendors/types.ts`
+- `src/features/vendors/components/CodexProviderDialog.test.tsx`
+- `src/i18n/locales/{en,zh}/settings.ts`
+- No dependency, lockfile, README, backend, or storage changes.

--- a/openspec/changes/add-atlas-cloud-codex-preset/specs/codex-provider-management/spec.md
+++ b/openspec/changes/add-atlas-cloud-codex-preset/specs/codex-provider-management/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Atlas Cloud MUST Be Available As A Codex Provider Preset
+
+Codex provider management MUST offer Atlas Cloud as a selectable OpenAI-compatible preset. Selecting it MUST generate configuration for `https://api.atlascloud.ai/v1`, provider id `atlas_cloud`, default model `deepseek-ai/deepseek-v4-pro`, and the Chat Completions wire API while leaving the API key empty for user input.
+
+#### Scenario: user selects the Atlas Cloud preset
+
+- **WHEN** a user adds a Codex provider and selects Atlas Cloud
+- **THEN** the provider name MUST be `Atlas Cloud`
+- **AND** generated `config.toml` MUST use `https://api.atlascloud.ai/v1`
+- **AND** generated `config.toml` MUST use model `deepseek-ai/deepseek-v4-pro`
+- **AND** generated `config.toml` MUST set `model_provider = "atlas_cloud"`
+- **AND** generated `config.toml` MUST set `wire_api = "chat"`
+- **AND** generated `auth.json` MUST NOT contain a real API key
+
+#### Scenario: existing provider behavior remains unchanged
+
+- **WHEN** a user selects any existing official, custom, or third-party Codex preset
+- **THEN** its existing generated configuration MUST remain unchanged
+- **AND** Atlas Cloud support MUST NOT add a new runtime transport or storage path

--- a/openspec/changes/add-atlas-cloud-codex-preset/tasks.md
+++ b/openspec/changes/add-atlas-cloud-codex-preset/tasks.md
@@ -1,0 +1,13 @@
+## 1. Provider Catalog
+
+- [x] 1.1 [P0, depends: none] Add the Atlas Cloud Codex preset using the existing typed config builder.
+- [x] 1.2 [P0, depends: 1.1] Add English and Simplified Chinese labels.
+
+## 2. Regression Coverage
+
+- [x] 2.1 [P0, depends: 1.1] Verify the selected preset fills endpoint, model, provider id, and Chat Completions wire protocol.
+
+## 3. Closure
+
+- [x] 3.1 [P0, depends: 2.1] Run focused Vitest, typecheck, production build, strict OpenSpec validation, diff/secret checks, and a real Atlas Cloud request.
+- [x] 3.2 [P1, depends: 3.1] Prepare Trellis session evidence and a signed commit.

--- a/openspec/changes/add-atlas-cloud-codex-preset/verification.md
+++ b/openspec/changes/add-atlas-cloud-codex-preset/verification.md
@@ -1,0 +1,22 @@
+## Verification
+
+Date: 2026-08-03 CST
+
+### Automated
+
+- `npm exec vitest run src/features/vendors/components/CodexProviderDialog.test.tsx` -> 6 passed.
+- `npm run typecheck` -> passed.
+- `npm run build` -> passed with existing Vite chunk/import/CSS warnings.
+- `npx eslint` on all changed TypeScript files -> passed.
+- `npx -y @fission-ai/openspec@1.7.0 validate add-atlas-cloud-codex-preset --strict --no-interactive` -> valid.
+- `git diff --check` -> passed.
+- Diff secret scan -> passed; no dependency, lockfile, or README changes.
+
+### Live API
+
+- Atlas Cloud Chat Completions request using `deepseek-ai/deepseek-v4-pro` -> HTTP 200.
+- Response content matched `ATLAS_PRESET_OK`.
+
+### Residual Risk
+
+- The preset remains editable because endpoint and recommended model ids may evolve, matching the behavior of existing third-party presets.

--- a/src/features/vendors/components/CodexProviderDialog.test.tsx
+++ b/src/features/vendors/components/CodexProviderDialog.test.tsx
@@ -78,6 +78,35 @@ describe("CodexProviderDialog", () => {
     expect(editors[1]?.value).toBe(preset!.authJson);
   });
 
+  it("fills the Atlas Cloud chat completions preset", () => {
+    const { container } = renderDialog();
+    const preset = CODEX_PROVIDER_PRESETS.find(
+      (item) => item.id === "atlas-cloud",
+    );
+    expect(preset).toBeTruthy();
+
+    const presetButton = Array.from(
+      container.querySelectorAll<HTMLButtonElement>(".vendor-preset-btn"),
+    ).find((button) => button.textContent === preset!.nameKey);
+    expect(presetButton).toBeTruthy();
+    fireEvent.click(presetButton!);
+
+    const nameInput = container.querySelector<HTMLInputElement>(
+      "input[placeholder='settings.vendor.codexDialog.namePlaceholder']",
+    );
+    expect(nameInput?.value).toBe("Atlas Cloud");
+
+    const configToml = container.querySelectorAll<HTMLTextAreaElement>(
+      ".vendor-code-editor",
+    )[0]?.value;
+    expect(configToml).toContain(
+      'base_url = "https://api.atlascloud.ai/v1"',
+    );
+    expect(configToml).toContain('model = "deepseek-ai/deepseek-v4-pro"');
+    expect(configToml).toContain('model_provider = "atlas_cloud"');
+    expect(configToml).toContain('wire_api = "chat"');
+  });
+
   it("formats valid JSON and reports formatError for invalid JSON", () => {
     const { container } = renderDialog();
     const editors = container.querySelectorAll<HTMLTextAreaElement>(

--- a/src/features/vendors/types.ts
+++ b/src/features/vendors/types.ts
@@ -503,6 +503,19 @@ export const CODEX_PROVIDER_PRESETS: CodexProviderPreset[] = [
     authJson: DEFAULT_CODEX_AUTH_JSON,
   },
   {
+    id: "atlas-cloud",
+    name: "Atlas Cloud",
+    nameKey: "settings.vendor.presets.atlasCloud",
+    configToml: buildCodexProviderConfigToml(
+      "atlas_cloud",
+      "https://api.atlascloud.ai/v1",
+      "deepseek-ai/deepseek-v4-pro",
+      "chat",
+      "atlas_cloud",
+    ),
+    authJson: DEFAULT_CODEX_AUTH_JSON,
+  },
+  {
     id: "minimax",
     name: "MiniMax",
     nameKey: "settings.vendor.presets.minimax",

--- a/src/i18n/locales/en/settings.ts
+++ b/src/i18n/locales/en/settings.ts
@@ -1395,6 +1395,7 @@ const settings = {
         kimi: "Kimi",
         kimiCoding: "Kimi Coding",
         deepseek: "DeepSeek",
+        atlasCloud: "Atlas Cloud",
         minimax: "MiniMax",
         xiaomi: "Xiaomi MiMo",
         xiaomiPlan: "Xiaomi MiMo Plan",

--- a/src/i18n/locales/zh/settings.ts
+++ b/src/i18n/locales/zh/settings.ts
@@ -1317,6 +1317,7 @@ const settings = {
         kimi: "Kimi",
         kimiCoding: "Kimi Coding",
         deepseek: "DeepSeek",
+        atlasCloud: "Atlas Cloud",
         minimax: "MiniMax",
         xiaomi: "Xiaomi MiMo",
         xiaomiPlan: "Xiaomi MiMo Plan",


### PR DESCRIPTION
## Summary

- add Atlas Cloud to the existing Codex provider preset catalog
- prefill the OpenAI-compatible endpoint, deepseek-ai/deepseek-v4-pro, and Chat Completions wire API
- add English/Chinese labels, focused regression coverage, and the required OpenSpec change

The preset reuses the existing managed-provider path and leaves OPENAI_API_KEY empty for user input. No runtime transport, dependency, lockfile, or README changes are included.

## Validation

- focused CodexProviderDialog Vitest (6 passed)
- TypeScript typecheck
- production build
- changed-file ESLint
- strict OpenSpec validation
- diff and secret checks
- live Atlas Cloud Chat Completions request with deepseek-ai/deepseek-v4-pro (HTTP 200)