### PR TITLE
docs(changelog): 发布 v0.7.15 更新日志

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,72 @@
 
 ---
 
+##### **2026年8月3日（v0.7.15）**
+
+中文：
+
+这一版的主菜是「子代理看得见、会话概览清楚、跨引擎更稳」：幕布上的小队有了独立卡片与详情抽屉，结果区换成会话概览并接上套餐额度，Shared / 续接与冷启动白屏也一并压实。
+
+✨ Features
+- 子代理幕布升级：Agent / Task 从扁条变成带人格的小队卡片，可点开幕布内 inspector 抽屉看子会话全文，不再挤进全局右侧 Tab
+- 跨引擎子代理对齐：Codex Collab、Grok spawn、Kimi Swarm 与 Shared 投影也能识别为子代理；会话树补齐父子层级，交付正文与启动回执分开
+- 会话概览进结果区：默认展示会话静态信息与运行态；官方 runtime 与 Coding Plan 可查 Codex / Kimi / MiniMax / 智谱额度，Shared 会话支持多供应商额度列表
+- Shared 会话可管了：会话管理支持扫描、预览与删除 Shared 会话，列表带 Shared 徽章与引擎筛选
+- AI 提交消息更可控：提交框改为结构化 composer，先选引擎与语言再点「按此配置生成」；支持「沿用上次配置」一键再生成，并修好 Grok 等 managed 引擎接入
+- 供应商新增 Atlas Cloud Codex 预设
+- 侧栏工作区分组：整行单击即可折叠，不再依赖双击或小三角
+
+🔧 Improvements
+- 过程时间线更干净：纯 shell 默认收起，文件读写类命令保留在过程折叠里；单步 / 孤儿思考也会并进 chip，展开动画更顺
+- 结果 Tab 默认只留会话概览，治理证据改为开发者开关 opt-in
+- 下线「会话活动」面板与 Solo 模式，减少常驻入口与派生开销（雷达与底部活动面板不受影响）
+- 弹层与续接反馈更清晰；会话菜单会尊重已禁用的 CLI 引擎
+- 侧栏会话状态指示更克制；隐藏的自动 helper 不再混入侧栏合并
+
+🐛 Fixes
+- 多处收敛 React #185 冷启动 / 折叠动画 / file-ref 引用环导致的白屏
+- 修复 Linux 启动空白页，同时保留百度统计；收紧访客 Cookie 提交时序
+- 修复 Claude managed 渠道模型与进程环境串台；空白幕布可恢复，并去掉多余 skill chips
+- Shared / 跨引擎续接：切渠道立即写执行目标；取消 Provider 续接会还原来源供应商与模型；成功后默认选中目标 catalog 模型
+- 以 `shared:` id 硬闸，避免模型选择误入 Native 续接；稳定 Shared 列表图标与 merge 保护
+- Codex 续接 inject 过滤 control 角色，避免三方 API 反序列化失败；补齐 apply_patch / 文件修改历史投影
+- 兼容 WKWebView：去掉 lookbehind 正则，并持久化 turn 完成元数据
+- 终端 host 重挂后 xterm 能重新附着；过程折叠展开后 bash 组不再空壳
+- Native 会话额度只查当前供应商，避免误打其它账号
+
+English:
+
+The headline of this release is visible subagents, a clearer session overview, and steadier cross-engine work: squad cards open an in-canvas inspector, the results area becomes a session overview with plan quotas, and Shared / continuation / cold-start white screens get hardened.
+
+✨ Features
+- Subagent canvas upgrade: Agent / Task steps become persona squad cards with an in-canvas inspector drawer for the child transcript — no more stuffing into the global right tab
+- Cross-engine subagent parity: Codex Collab, Grok spawn, Kimi Swarm, and Shared projections resolve as subagents; the session tree gets parent–child hierarchy, and delivery text is separated from launch receipts
+- Session overview in the results area: static session info plus runtime state by default; official runtime / Coding Plan quotas for Codex, Kimi, MiniMax, and Zhipu; multi-vendor quota lists on Shared sessions
+- Shared sessions are manageable: session management can scan, preview, and delete Shared sessions, with badges and engine filters
+- Safer AI commit messages: a structured composer — pick engine and language, then “Generate with this config”; “Use last configuration” for one-click regenerate; managed engines such as Grok wired correctly
+- New vendor preset: Atlas Cloud Codex
+- Sidebar workspace groups: single-click the full header row to collapse (no more double-click-only)
+
+🔧 Improvements
+- Quieter process timelines: pure shell stays folded by default while file read/write commands remain in the phase; single-step / orphan reasoning joins the chip, with smoother expand animation
+- Results tab defaults to session overview only; governance evidence is an opt-in developer switch
+- Retired the Session Activity panel and Solo mode to cut permanent chrome and derivation cost (radar and bottom activity panels are unchanged)
+- Clearer popovers and continuation feedback; session menus respect disabled CLI engines
+- Quieter sidebar status indicators; hidden automatic helpers no longer merge into the sidebar
+
+🐛 Fixes
+- Multiple React #185 cold-start / collapse-animation / file-ref cycle white-screen fixes
+- Fixed Linux blank startup while keeping Baidu analytics; tightened visitor cookie submit timing
+- Fixed Claude managed-channel model vs process-env cross-talk; blank curtains recover, and stray skill chips are dropped
+- Shared / cross-engine continuation: write execution target immediately on channel switch; canceling Provider continuation restores the source vendor/model; success selects the target catalog model by default
+- Hard-gate on `shared:` ids so model picks no longer fall into Native resume; stable Shared list icons and merge protection
+- Codex continuation inject filters `control` roles to avoid third-party API deserialize failures; apply_patch / file-edit history projection filled in
+- WKWebView compatibility: remove lookbehind regex and persist turn-final metadata
+- xterm reattaches after terminal host remount; bash groups no longer render empty after expanding a collapsed phase
+- Native session quotas query only the current vendor
+
+---
+
 ##### **2026年8月1日（v0.7.14）**
 
 中文：


### PR DESCRIPTION
## 背景
- 从 `main` 合并到 `cxn-version-0.7.15`。

## 改动点
- 

## 验证
- [ ] npm run typecheck
- [ ] npm run lint