### PR TITLE
refactor(threads): 移除 assistant 去重 hook 中的未使用 user 消息代码

### DIFF
--- a/src/features/threads/hooks/useThreadsReducerAssistantDedup.ts
+++ b/src/features/threads/hooks/useThreadsReducerAssistantDedup.ts
@@ -4,7 +4,6 @@ import { mergeAgentMessageText } from "./threadReducerTextMerge";
 
 type MessageItem = Extract<ConversationItem, { kind: "message" }>;
 type AssistantMessageItem = MessageItem & { role: "assistant" };
-type UserMessageItem = MessageItem & { role: "user" };
 
 export type AssistantEquivalenceMatchMode = "settled" | "streaming";
 
@@ -15,10 +14,6 @@ const SETTLED_EQUIVALENCE_MIN_CHARS = 24;
  * If ever re-enabled, keep this floor well above areEquivalent's 8-char prefix rule.
  */
 const STREAMING_EQUIVALENCE_MIN_CHARS = 80;
-
-function isUserMessageItem(item: ConversationItem | undefined): item is UserMessageItem {
-  return item?.kind === "message" && item.role === "user";
-}
 
 function isAssistantMessageItem(
   item: ConversationItem | undefined,


### PR DESCRIPTION
## 背景
- 从 `chore/bump-version-0.7.16` 合并到 `CXN-version-0.7.16`。

## 改动点
- 

## 验证
- [ ] npm run typecheck
- [ ] npm run lint