### PR TITLE
release: bump to v0.8.0 and harden hydration and update-check paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ---
 
+### **2026年8月5日（v0.8.0）**
+
+中文：
+
+这一版将产品线升到 **0.8.0**，并修掉侧栏会话列表在 hydration 完成后仍永久「加载中…」的问题：memo 安全的 Set 身份发布后，Layout / Sidebar 能正确感知列表就绪。
+
+🔧 Improvements
+- 将应用版本号提升到 `0.8.0`（`package.json` / `package-lock.json` / `src-tauri/tauri.conf.json`），为下一轮 minor 发版对齐 SemVer 与打包元数据
+
+🐛 Fixes
+- 修复侧栏会话列表 hydration 完成后仍卡在「加载中…」：`hydratedThreadListWorkspaceIds` 改为发布新的 Set 身份（禁止原地 mutate 共享 Set），使 `memo(Sidebar)` 在完成 / 超时后能重渲染；AppShell 域上下文透传 state 快照；`listThreadTitles` / `listSharedSessions` 拉取加超时，避免超时后列表路径长期半完成
+
+English:
+
+This release moves the product line to **0.8.0** and fixes the sidebar thread list that stayed on "Loading…" forever after hydration finished: publishing a memo-safe Set identity lets Layout / Sidebar notice the list is ready.
+
+🔧 Improvements
+- Bump the app version to `0.8.0` across frontend package metadata, the lockfile, and Tauri bundle configuration so the next minor ship aligns SemVer and packaging metadata
+
+🐛 Fixes
+- Fixed the sidebar thread list stuck on "Loading…" after hydration: `hydratedThreadListWorkspaceIds` now publishes a new Set identity instead of mutating a shared Set in place, so `memo(Sidebar)` re-renders on complete / timeout; AppShell domain contexts pass the state snapshot; `listThreadTitles` / `listSharedSessions` fetches are wrapped with a timeout so a hang no longer leaves partial hydration unresolved
+
+---
+
 ### **2026年8月4日（v0.7.16）**
 
 中文：

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ccgui",
-  "version": "0.7.16",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ccgui",
-      "version": "0.7.16",
+      "version": "0.8.0",
       "hasInstallScript": true,
       "dependencies": {
         "@base-ui/react": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ccgui",
   "private": true,
-  "version": "0.7.16",
+  "version": "0.8.0",
   "type": "module",
   "scripts": {
     "preinstall": "node scripts/enforce-package-manager.mjs npm",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ccgui",
-  "version": "0.7.16",
+  "version": "0.8.0",
   "identifier": "com.zhukunpenglinyutong.ccgui",
   "build": {
     "beforeDevCommand": "node scripts/tauri-dev-frontend.mjs",

--- a/src/features/update/hooks/useUpdater.ts
+++ b/src/features/update/hooks/useUpdater.ts
@@ -4,6 +4,7 @@ import { isTauri } from "@tauri-apps/api/core";
 import { check } from "@tauri-apps/plugin-updater";
 import { relaunch } from "@tauri-apps/plugin-process";
 import type { DownloadEvent, Update } from "@tauri-apps/plugin-updater";
+import { withTimeout } from "../../files/utils/fileViewNavigationUtils";
 import type { DebugEntry } from "../../../types";
 
 type UpdateStage =
@@ -39,6 +40,7 @@ type CheckForUpdatesOptions = {
 };
 
 const AUTO_UPDATE_ENABLED = true;
+const UPDATE_CHECK_TIMEOUT_MS = 15_000;
 
 function normalizeUpdateVersion(value: string | null | undefined): string | null {
   const trimmed = value?.trim();
@@ -176,7 +178,14 @@ export function useUpdater({ enabled = true, onDebug }: UseUpdaterOptions) {
       try {
         clearLatestTimeout();
         setState({ stage: "checking" });
-        update = await check();
+        // plugin-updater 的 check() 走 reqwest 且没有默认超时：更新服务器不可达
+        // 时 Promise 永不 settle，Toast 会永远停在「正在检查更新...」。超时按失败
+        // 处理（catch 里非交互模式回 idle），后台请求继续软忽略。
+        update = await withTimeout(
+          check(),
+          UPDATE_CHECK_TIMEOUT_MS,
+          "update check timed out",
+        );
 
         if (isStaleRequest()) {
           return;


### PR DESCRIPTION
Raise the product line from 0.7.16 to 0.8.0 and ship the fixes that unblock sidebar readiness and updater UX.

Version / packaging
- Align SemVer and bundle metadata at 0.8.0 in package.json, package-lock.json, and src-tauri/tauri.conf.json so frontend, lockfile, and Tauri packaging agree.
- Record the 2026-08-05 (v0.8.0) entry in CHANGELOG.md (zh + en).

Sidebar thread list (documented / release fix)
- hydratedThreadListWorkspaceIds now publishes a new Set identity instead of mutating a shared Set in place, so memo(Sidebar) re-renders when hydration completes or times out and no longer stays on "Loading…" forever.
- AppShell domain contexts pass a state snapshot; listThreadTitles / listSharedSessions fetches are timeout-wrapped so a hang does not leave partial hydration unresolved.

Updater
- Wrap plugin-updater check() with a 15s withTimeout. check() uses reqwest with no default timeout; if the update server is unreachable the Promise never settles and the toast stuck on "Checking for updates…". Timeout is treated as failure (non-interactive flows return to idle); the in-flight request is soft-ignored.

Impact: users see the thread list after workspace hydration, release metadata matches 0.8.0, and update checks fail cleanly instead of hanging the UI when the server is unreachable.