### PR TITLE
fix(sidebar): fix cold-start thread hydration and shrink first-paint …

### DIFF
--- a/src/app-shell-parts/useWorkspaceThreadListHydration.test.tsx
+++ b/src/app-shell-parts/useWorkspaceThreadListHydration.test.tsx
@@ -521,4 +521,55 @@ describe("useWorkspaceThreadListHydration", () => {
 
     vi.useRealTimers();
   });
+
+  it("retries active workspace hydration once workspacesById gains the workspace", async () => {
+    const workspaces = [createWorkspace("ws-1")];
+    const listThreadsForWorkspace = vi.fn<
+      (
+        workspace: WorkspaceInfo,
+        options?: {
+          preserveState?: boolean;
+          includeOpenCodeSessions?: boolean;
+          startupHydrationMode?: "full-catalog";
+        },
+      ) => Promise<void>
+    >().mockResolvedValue(undefined);
+
+    const { rerender } = renderHook(
+      ({
+        workspacesById,
+      }: {
+        workspacesById: Map<string, WorkspaceInfo>;
+      }) =>
+        useWorkspaceThreadListHydration({
+          activeWorkspaceId: "ws-1",
+          activeWorkspaceProjectionOwnerIds: ["ws-1"],
+          listThreadsForWorkspace,
+          threadListLoadingByWorkspace: {},
+          workspaces,
+          workspacesById,
+        }),
+      {
+        initialProps: {
+          workspacesById: new Map<string, WorkspaceInfo>(),
+        },
+      },
+    );
+
+    expect(listThreadsForWorkspace).not.toHaveBeenCalled();
+
+    rerender({
+      workspacesById: new Map(
+        workspaces.map((workspace) => [workspace.id, workspace]),
+      ),
+    });
+
+    await waitFor(() => {
+      expect(listThreadsForWorkspace).toHaveBeenCalledTimes(1);
+    });
+    expect(listThreadsForWorkspace).toHaveBeenCalledWith(
+      workspaces[0],
+      expect.objectContaining({ preserveState: true }),
+    );
+  });
 });

--- a/src/app-shell-parts/useWorkspaceThreadListHydration.ts
+++ b/src/app-shell-parts/useWorkspaceThreadListHydration.ts
@@ -389,9 +389,16 @@ export function useWorkspaceThreadListHydration({
     if (autoHydratedActiveWorkspaceIdRef.current === activeWorkspaceId) {
       return;
     }
+    // Do not mark the active workspace as auto-hydrated until it exists in the
+    // workspace map. On cold start activeWorkspaceId can land before workspacesById
+    // is populated; marking early permanently skips ensure and leaves the sidebar
+    // on "加载中…".
+    if (!workspacesById.has(activeWorkspaceId)) {
+      return;
+    }
     autoHydratedActiveWorkspaceIdRef.current = activeWorkspaceId;
     ensureWorkspaceThreadListLoaded(activeWorkspaceId, { preserveState: true });
-  }, [activeWorkspaceId, ensureWorkspaceThreadListLoaded]);
+  }, [activeWorkspaceId, ensureWorkspaceThreadListLoaded, workspacesById]);
 
   useEffect(() => {
     if (!activeWorkspaceId || activeWorkspaceProjectionOwnerIds.length <= 1) {
@@ -401,12 +408,16 @@ export function useWorkspaceThreadListHydration({
       if (workspaceId === activeWorkspaceId) {
         return;
       }
+      if (!workspacesById.has(workspaceId)) {
+        return;
+      }
       ensureWorkspaceThreadListLoaded(workspaceId, { preserveState: true });
     });
   }, [
     activeWorkspaceId,
     activeWorkspaceProjectionOwnerIds,
     ensureWorkspaceThreadListLoaded,
+    workspacesById,
   ]);
 
   const nextBackgroundWorkspaceThreadHydrationId =

--- a/src/features/app/components/Sidebar.test.tsx
+++ b/src/features/app/components/Sidebar.test.tsx
@@ -1123,12 +1123,12 @@ describe("Sidebar", () => {
     expect(screen.queryByText("No sessions yet.")).toBeNull();
   });
 
-  it("shows a loading state for an expanded workspace before its sessions hydrate", () => {
+  it("shows a loading state for a connected expanded workspace before its sessions hydrate", () => {
     const workspace = {
       id: "ws-unhydrated",
       name: "unhydrated-workspace",
       path: "/tmp/unhydrated-workspace",
-      connected: false,
+      connected: true,
       kind: "main" as const,
       settings: {
         sidebarCollapsed: false,
@@ -1152,6 +1152,77 @@ describe("Sidebar", () => {
 
     expect(screen.getByText("Loading…")).toBeTruthy();
     expect(screen.queryByText("No sessions yet.")).toBeNull();
+  });
+
+  it("shows cached sessions before hydration finishes instead of masking them with loading", () => {
+    const workspace = {
+      id: "ws-cached",
+      name: "cached-workspace",
+      path: "/tmp/cached-workspace",
+      connected: true,
+      kind: "main" as const,
+      settings: {
+        sidebarCollapsed: false,
+        worktreeSetupScript: null,
+      },
+    };
+
+    render(
+      <Sidebar
+        {...baseProps}
+        workspaces={[workspace]}
+        groupedWorkspaces={[
+          {
+            id: null,
+            name: "Ungrouped",
+            workspaces: [workspace],
+          },
+        ]}
+        threadsByWorkspace={{
+          "ws-cached": [
+            {
+              id: "thread-cached",
+              name: "Cached session",
+              updatedAt: 1,
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Cached session")).toBeTruthy();
+    expect(screen.queryByText("Loading…")).toBeNull();
+  });
+
+  it("shows empty state for disconnected workspaces instead of spinning forever", () => {
+    const workspace = {
+      id: "ws-disconnected",
+      name: "disconnected-workspace",
+      path: "/tmp/disconnected-workspace",
+      connected: false,
+      kind: "main" as const,
+      settings: {
+        sidebarCollapsed: false,
+        worktreeSetupScript: null,
+      },
+    };
+
+    render(
+      <Sidebar
+        {...baseProps}
+        workspaces={[workspace]}
+        groupedWorkspaces={[
+          {
+            id: null,
+            name: "Ungrouped",
+            workspaces: [workspace],
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.queryByText("Loading…")).toBeNull();
+    expect(screen.getByText("No sessions yet.")).toBeTruthy();
   });
 
   it("does not render workspace or worktree session count badges", () => {

--- a/src/features/app/components/Sidebar.tsx
+++ b/src/features/app/components/Sidebar.tsx
@@ -1838,22 +1838,27 @@ function SidebarImpl({
     const isThreadListHydrated = hydratedThreadListWorkspaceIds.has(entry.id);
     const isPaging = threadListPagingByWorkspace[entry.id] ?? false;
     const worktrees = worktreesByParent.get(entry.id) ?? [];
-    // Until a workspace finishes its first hydration, show a loading placeholder
-    // instead of leaving the expanded region blank or leaking stale/fallback-named
-    // ("Agent 1", "Agent 2") preview threads before real data lands.
+    // First-paint / cold start: prefer snapshot or last-good threads immediately.
+    // Only spin when the workspace is connected, has nothing to show yet, and has
+    // not finished its first hydration. Masking cached sessions behind "加载中…"
+    // made the whole sidebar look frozen while orchestrator work ran, and
+    // disconnected workspaces never hydrate so they spun forever.
+    const hasCachedThreadList =
+      threads.length > 0 || Boolean(nextCursor);
     const showThreadLoadingState =
       !isThreadListHydrated &&
-      worktrees.length === 0;
+      worktrees.length === 0 &&
+      !hasCachedThreadList &&
+      entry.connected;
     const showThreadList =
-      !showThreadLoadingState &&
-      (threads.length > 0 || Boolean(nextCursor));
+      !showThreadLoadingState && hasCachedThreadList;
     const isWorktreeSectionCollapsed =
       collapsedWorktreeSections.has(entry.id);
     const showThreadEmptyState =
       !showThreadList &&
       !showThreadLoadingState &&
       worktrees.length === 0 &&
-      isThreadListHydrated;
+      (isThreadListHydrated || !entry.connected);
     const hasPrimaryActiveThread =
       entry.id === activeWorkspaceId && Boolean(activeThreadId);
     const hasRunningSession = hasRunningSessionByProjectId.get(entry.id) ?? false;

--- a/src/features/threads/hooks/useThreadActions.native-session-bridges.test.tsx
+++ b/src/features/threads/hooks/useThreadActions.native-session-bridges.test.tsx
@@ -220,7 +220,7 @@ describe("useThreadActions native session bridges", () => {
     expect(listWorkspaceSessions).toHaveBeenCalledWith("ws-1", {
       query: { status: "active", sessionAttributionMode: "related" },
       cursor: null,
-      limit: 100,
+      limit: 5,
     });
     expectSetThreadsDispatched(dispatch, "ws-1", [
       {

--- a/src/features/threads/hooks/useThreadActions.test.tsx
+++ b/src/features/threads/hooks/useThreadActions.test.tsx
@@ -2413,7 +2413,7 @@ describe("useThreadActions", () => {
     expect(listWorkspaceSessions).toHaveBeenCalledWith("ws-1", {
       query: { status: "active", sessionAttributionMode: "related" },
       cursor: null,
-      limit: 100,
+      limit: 5,
     });
     expectSetThreadsDispatched(dispatch, "ws-1", [
       {
@@ -2532,7 +2532,7 @@ describe("useThreadActions", () => {
       });
     });
 
-    expect(listClaudeSessions).toHaveBeenCalledWith("/tmp/codex", 100);
+    expect(listClaudeSessions).toHaveBeenCalledWith("/tmp/codex", 5);
     expectSetThreadsDispatched(dispatch, "ws-1", [
       {
         id: "claude:claude-visible-200",
@@ -2605,7 +2605,7 @@ describe("useThreadActions", () => {
     expect(listWorkspaceSessions).toHaveBeenCalledWith("ws-1", {
       query: { status: "active", sessionAttributionMode: "related" },
       cursor: null,
-      limit: 100,
+      limit: 5,
     });
     expectSetThreadsDispatched(dispatch, "ws-1", [
       {

--- a/src/features/threads/hooks/useThreadActions.thread-list-recovery.test.tsx
+++ b/src/features/threads/hooks/useThreadActions.thread-list-recovery.test.tsx
@@ -376,6 +376,7 @@ describe("useThreadActions thread list recovery and pagination", () => {
     expect(listWorkspaceSessions).toHaveBeenCalledWith("ws-1", {
       query: { status: "active", sessionAttributionMode: "related" },
       cursor: "offset:200",
+      // Load older keeps the larger catalog page size.
       limit: 100,
     });
     expect(listThreads).not.toHaveBeenCalled();

--- a/src/features/threads/hooks/useThreadActions.threadList.test.ts
+++ b/src/features/threads/hooks/useThreadActions.threadList.test.ts
@@ -2,9 +2,16 @@ import { describe, expect, it } from "vitest";
 
 import { buildWorkspaceSessionSelectionKey } from "../../settings/components/settings-view/hooks/useWorkspaceSessionCatalog";
 import {
+  SESSION_CATALOG_INITIAL_PAGE_SIZE,
+  THREAD_LIST_INITIAL_PAGE_SIZE,
+  THREAD_LIST_INITIAL_TARGET_COUNT,
+  THREAD_LIST_LOAD_OLDER_PAGE_SIZE,
+  THREAD_LIST_LOAD_OLDER_TARGET_COUNT,
   normalizeProjectCatalogSession,
+  resolveInitialThreadListTargetCount,
   resolveThreadListCursorForDisplay,
 } from "./useThreadActions.threadList";
+import type { WorkspaceInfo } from "../../../types";
 
 describe("useThreadActions.threadList", () => {
   it("preserves additive catalog source fields during normalization", () => {
@@ -131,5 +138,22 @@ describe("useThreadActions.threadList", () => {
         runtimeCursor: null,
       }),
     ).toBe("catalog::offset:200");
+  });
+
+  it("first-paint list target defaults to 5 and stays smaller than load-older batches", () => {
+    expect(THREAD_LIST_INITIAL_TARGET_COUNT).toBe(5);
+    expect(THREAD_LIST_INITIAL_PAGE_SIZE).toBe(5);
+    expect(SESSION_CATALOG_INITIAL_PAGE_SIZE).toBe(5);
+    expect(THREAD_LIST_LOAD_OLDER_TARGET_COUNT).toBe(50);
+    expect(THREAD_LIST_LOAD_OLDER_PAGE_SIZE).toBe(50);
+
+    const workspace = {
+      id: "ws-1",
+      name: "ws",
+      path: "/tmp/ws",
+      connected: true,
+      settings: { sidebarCollapsed: false },
+    } as WorkspaceInfo;
+    expect(resolveInitialThreadListTargetCount(workspace)).toBe(5);
   });
 });

--- a/src/features/threads/hooks/useThreadActions.threadList.ts
+++ b/src/features/threads/hooks/useThreadActions.threadList.ts
@@ -9,8 +9,20 @@ import {
 } from "../../app/constants";
 import type { CodexCatalogSessionSummary } from "./useThreadActions.helpers";
 
-export const THREAD_LIST_TARGET_COUNT = 50;
-export const THREAD_LIST_PAGE_SIZE = 50;
+/**
+ * First-paint / startup hydration: only pull a small page so cold start stays
+ * cheap. Aligns with DEFAULT_VISIBLE_THREAD_ROOT_COUNT (5). Users load more
+ * via the sidebar "Load older" control.
+ */
+export const THREAD_LIST_INITIAL_TARGET_COUNT = DEFAULT_VISIBLE_THREAD_ROOT_COUNT;
+export const THREAD_LIST_INITIAL_PAGE_SIZE = DEFAULT_VISIBLE_THREAD_ROOT_COUNT;
+/** @deprecated Prefer THREAD_LIST_INITIAL_*; kept as aliases for initial path. */
+export const THREAD_LIST_TARGET_COUNT = THREAD_LIST_INITIAL_TARGET_COUNT;
+/** @deprecated Prefer THREAD_LIST_INITIAL_*; kept as aliases for initial path. */
+export const THREAD_LIST_PAGE_SIZE = THREAD_LIST_INITIAL_PAGE_SIZE;
+/** "Load older" batch — larger than first paint so fewer clicks for history. */
+export const THREAD_LIST_LOAD_OLDER_TARGET_COUNT = 50;
+export const THREAD_LIST_LOAD_OLDER_PAGE_SIZE = 50;
 export const THREAD_LIST_MAX_EMPTY_PAGES = 5;
 export const THREAD_LIST_MAX_EMPTY_PAGES_WITH_ACTIVITY = 20;
 export const THREAD_LIST_MAX_TOTAL_PAGES = 40;
@@ -35,7 +47,11 @@ export const NATIVE_SESSION_LIST_FETCH_TIMEOUT_MS =
   SIDEBAR_THREAD_LIST_TIMEOUT_MS;
 export const CODEX_SESSION_CATALOG_FETCH_TIMEOUT_MS =
   SIDEBAR_THREAD_LIST_TIMEOUT_MS;
+/** Load-older / recovery catalog page size. */
 export const SESSION_CATALOG_PAGE_SIZE = 100;
+/** First catalog page on startup hydration — matches initial sidebar page. */
+export const SESSION_CATALOG_INITIAL_PAGE_SIZE =
+  DEFAULT_VISIBLE_THREAD_ROOT_COUNT;
 
 const MIN_NATIVE_SESSION_LIST_LIMIT = Math.min(
   SESSION_CATALOG_PAGE_SIZE,
@@ -140,10 +156,19 @@ export function resolveNativeSessionListLimit(
   const visibleRootCount = normalizeVisibleThreadRootCount(
     workspace.settings.visibleThreadRootCount,
   );
+  // First-paint: never pull more than the visible root budget (default 5).
+  // Load-older uses SESSION_CATALOG_PAGE_SIZE / LOAD_OLDER_* separately.
   return Math.min(
-    SESSION_CATALOG_PAGE_SIZE,
+    THREAD_LIST_INITIAL_TARGET_COUNT,
     Math.max(MIN_NATIVE_SESSION_LIST_LIMIT, visibleRootCount),
   );
+}
+
+/** First-page target for a workspace (settings-aware, default 5). */
+export function resolveInitialThreadListTargetCount(
+  workspace: WorkspaceInfo,
+): number {
+  return resolveNativeSessionListLimit(workspace);
 }
 
 export function resolveThreadListCursorForDisplay(params: {

--- a/src/features/threads/hooks/useThreadActions.ts
+++ b/src/features/threads/hooks/useThreadActions.ts
@@ -100,9 +100,9 @@ import {
   THREAD_LIST_MAX_FETCH_DURATION_MS,
   THREAD_LIST_MAX_TOTAL_PAGES,
   THREAD_LIST_PAGE_SIZE,
-  THREAD_LIST_TARGET_COUNT,
   countCatalogSessionsByEngine,
   countSummariesByEngine,
+  resolveInitialThreadListTargetCount,
   resolveNativeSessionListLimit,
   resolveThreadListCursorForDisplay,
   type StartupThreadHydrationMode,
@@ -501,8 +501,9 @@ export function useThreadActions({
           threadActivityRef.current[workspace.id] ?? {};
         const hasKnownActivity = Object.keys(knownActivityByThread).length > 0;
         const matchingThreads: Record<string, unknown>[] = [];
-        const targetCount = THREAD_LIST_TARGET_COUNT;
-        const pageSize = THREAD_LIST_PAGE_SIZE;
+        // First paint: only the visible root budget (default 5). More via Load older.
+        const targetCount = resolveInitialThreadListTargetCount(workspace);
+        const pageSize = Math.max(THREAD_LIST_PAGE_SIZE, targetCount);
         const maxPagesWithoutMatch = hasKnownActivity
           ? THREAD_LIST_MAX_EMPTY_PAGES_WITH_ACTIVITY
           : THREAD_LIST_MAX_EMPTY_PAGES;
@@ -1348,6 +1349,8 @@ export function useThreadActions({
             [workspace.id]: visibleSummaries,
           };
         }
+        // nextCursor from catalog/runtime drives "Load older". First paint only
+        // requested a small page (default 5); more pages load on demand.
         dispatch({
           type: "setThreadListCursor",
           workspaceId: workspace.id,

--- a/src/features/threads/hooks/useThreadActionsLoadOlder.ts
+++ b/src/features/threads/hooks/useThreadActionsLoadOlder.ts
@@ -31,11 +31,11 @@ import {
 import {
   CODEX_SESSION_CATALOG_FETCH_TIMEOUT_MS,
   SESSION_CATALOG_PAGE_SIZE,
+  THREAD_LIST_LOAD_OLDER_PAGE_SIZE,
+  THREAD_LIST_LOAD_OLDER_TARGET_COUNT,
   THREAD_LIST_MAX_EMPTY_PAGES_LOAD_OLDER,
   THREAD_LIST_MAX_FETCH_DURATION_MS,
   THREAD_LIST_MAX_TOTAL_PAGES,
-  THREAD_LIST_PAGE_SIZE,
-  THREAD_LIST_TARGET_COUNT,
   decodeThreadListCursorState,
   normalizeProjectCatalogSession,
   resolveThreadListCursorForDisplay,
@@ -164,8 +164,8 @@ export function useLoadOlderThreadsForWorkspace({
           }
         }
         const matchingThreads: Record<string, unknown>[] = [];
-        const targetCount = THREAD_LIST_TARGET_COUNT;
-        const pageSize = THREAD_LIST_PAGE_SIZE;
+        const targetCount = THREAD_LIST_LOAD_OLDER_TARGET_COUNT;
+        const pageSize = THREAD_LIST_LOAD_OLDER_PAGE_SIZE;
         const maxPagesWithoutMatch = THREAD_LIST_MAX_EMPTY_PAGES_LOAD_OLDER;
         let pagesFetched = 0;
         const fetchStartedAt = Date.now();

--- a/src/features/threads/hooks/useThreadActionsResumeThread.ts
+++ b/src/features/threads/hooks/useThreadActionsResumeThread.ts
@@ -61,7 +61,7 @@ import {
 import { createThreadHistoryLoaderForThread } from "./useThreadActions.historyLoaderFactory";
 import {
   RELATED_THREAD_LOAD_CONCURRENCY,
-  THREAD_LIST_PAGE_SIZE,
+  THREAD_LIST_LOAD_OLDER_PAGE_SIZE,
   THREAD_RECOVERY_HISTORY_MATCH_CANDIDATES,
   THREAD_RECOVERY_MAX_FETCH_DURATION_MS,
   THREAD_RECOVERY_MAX_PAGES,
@@ -612,7 +612,8 @@ export function useThreadActionsResumeThreadForWorkspace(
                 const response = (await listThreadsService(
                   workspaceId,
                   cursor,
-                  THREAD_LIST_PAGE_SIZE,
+                  // Recovery scans need larger pages than first-paint (5).
+                  THREAD_LIST_LOAD_OLDER_PAGE_SIZE,
                 )) as Record<string, unknown>;
                 if (!isCurrentResumeRequest()) {
                   return null;

--- a/src/features/threads/hooks/useThreadActionsSessionCatalog.test.tsx
+++ b/src/features/threads/hooks/useThreadActionsSessionCatalog.test.tsx
@@ -44,7 +44,7 @@ describe("useThreadActionsSessionCatalog", () => {
     expect(listWorkspaceSessionsService).toHaveBeenNthCalledWith(1, "ws-1", {
       query: { status: "active", sessionAttributionMode: "related" },
       cursor: null,
-      limit: 100,
+      limit: 5,
     });
     expect(listWorkspaceSessionsService).toHaveBeenCalledTimes(1);
     expect(catalog?.sessions.map((session) => session.sessionId)).toEqual([
@@ -112,7 +112,7 @@ describe("useThreadActionsSessionCatalog", () => {
     expect(listWorkspaceSessionsService).toHaveBeenCalledWith("ws-1", {
       query: { status: "active", sessionAttributionMode: "workspace-only" },
       cursor: null,
-      limit: 100,
+      limit: 5,
     });
   });
 

--- a/src/features/threads/hooks/useThreadActionsSessionCatalog.ts
+++ b/src/features/threads/hooks/useThreadActionsSessionCatalog.ts
@@ -9,7 +9,7 @@ import type { WorkspaceSessionAttributionMode } from "../../../types";
 import { withTimeout } from "./useThreadActions.helpers";
 import {
   CODEX_SESSION_CATALOG_FETCH_TIMEOUT_MS,
-  SESSION_CATALOG_PAGE_SIZE,
+  SESSION_CATALOG_INITIAL_PAGE_SIZE,
   normalizeProjectCatalogSession,
   type ProjectCatalogSessionSummary,
 } from "./useThreadActions.threadList";
@@ -163,7 +163,8 @@ export function useThreadActionsSessionCatalog({
         listWorkspaceSessionsService(workspaceId, {
           query: { status: "active", sessionAttributionMode },
           cursor: null,
-          limit: SESSION_CATALOG_PAGE_SIZE,
+          // First-paint catalog page matches sidebar initial page (default 5).
+          limit: SESSION_CATALOG_INITIAL_PAGE_SIZE,
         }),
         CODEX_SESSION_CATALOG_FETCH_TIMEOUT_MS,
       );


### PR DESCRIPTION
…loads

Cold start could leave the sidebar stuck on "Loading…" and pull far more sessions than the UI needs. This change fixes the hydration race, prefers cached lists, and separates first-paint page size from load-older batches.

### Content
- useWorkspaceThreadListHydration: do not mark the active workspace as auto-hydrated until it exists in workspacesById; re-run ensure when the map is populated so cold start does not permanently skip list load
- Gate projection-owner hydration on workspace map membership the same way
- Sidebar: show cached/snapshot threads immediately; only show loading when the workspace is connected, has no cached list, and has not finished first hydration; disconnected workspaces get the empty state instead of a forever spinner
- Thread list/session catalog: first paint defaults to 5 items (aligned with DEFAULT_VISIBLE_THREAD_ROOT_COUNT); "Load older" and recovery keep larger pages (50/100); keep deprecated THREAD_LIST_* aliases for the initial path
- Tests cover late workspacesById population, cached vs loading vs disconnected sidebar states, and updated page-size expectations

### Reasons
- activeWorkspaceId could resolve before workspacesById, so auto-hydrate ran too early, set the ref, and never called ensure again
- Loading masked cached sessions during orchestrator work, making the sidebar look frozen; disconnected workspaces never hydrate so they spun forever
- Startup fetched large catalog pages (50–100) when only a small visible root budget is needed for first paint

### Impact
- Sidebar recovers from cold-start races and stops endless loading for disconnected workspaces
- Cached sessions remain visible during hydration
- Startup list/catalog fetches are cheaper; history still loads on demand via Load older / recovery with larger batches