### PR TITLE
fix(ui-scale): 用 transform 布局补偿修复 Windows 缩放黑边

### DIFF
--- a/docs/analysis/windows-ccgui-startup-hang-2026-08-05.md
+++ b/docs/analysis/windows-ccgui-startup-hang-2026-08-05.md
@@ -359,6 +359,8 @@ WebView:  %LOCALAPPDATA%\com.zhukunpenglinyutong.ccgui\EBWebView\
 | **诊断误导** | 磁盘只有 `bootstrap/start` 易被当成 preload 故障；真凶是 mount 后 `setZoom`。修 bootstrap 超时 **治不了** 根因。 |
 | **timeout 包 setZoom** | hang 是渲染进程失控，不是 Promise 慢；timeout **无效**。 |
 | **CSS zoom 副作用** | 分割条拖拽等用 `clientX` + `getBoundingClientRect`（如 `DesktopLayout.tsx`）。Chromium 下二者通常同比例缩放，**多数情况仍一致**，但 fixed / canvas / 自定义坐标要手测。 |
+| **CSS zoom + 100vh 壳子** | 仅给 root 设 `zoom` 与 `width/height: 100/scale%` **不够**：若 `#root`/`.app` 仍是 `100vh`/`100vw`，视口单位不跟 parent 放大，**外层壳不随缩放铺满窗口**（缩小留边、放大裁切）。必须把 shell 改成 `html→body→#root→.app` 的 `%` 高度链（`src/styles/base.css`）。 |
+| **CSS zoom 落在 `<html>`** | 在 `overflow: hidden` 下 WebView2 容易 **先裁剪再缩放**：`100/scale%` 扩出来的盒子被视口裁掉后，再 zoom 缩小 → 仍黑边。应让 `<html>` 保持 100% 视口，**zoom + fill 落在 `<body>`**（见 `applyUiScale.ts`）。 |
 
 ### 10.2 三端能力对照（实现选型依据）
 

--- a/openspec/changes/fix-windows-ui-scale-webview2-hang/design.md
+++ b/openspec/changes/fix-windows-ui-scale-webview2-hang/design.md
@@ -16,20 +16,28 @@
 
 - Persist migration of `uiScale`.
 - Rust-side zoom intercept.
-- Full visual parity of CSS zoom vs native zoom.
+- Pixel-perfect parity of every fixed/canvas edge case vs native zoom (letterbox fill is in scope).
 
 ## Decisions
 
 ### 1. Split by `detectRendererPlatform()`
 
-| platform | CSS zoom | native setZoom |
-|----------|----------|----------------|
-| windows / unknown | `String(scale)` | `1` only |
-| macos / linux | clear `""` | `scale` |
+| platform | CSS scale target | layout fill (`width`/`height`) | native setZoom |
+|----------|------------------|--------------------------------|----------------|
+| windows / unknown | `<body>` `transform: scale(s)` + `position:fixed` | `100/scale %` on body when `scale≠1`; clear at `1` | `1` only |
+| macos / linux | clear transform/zoom on html **and** body | clear `""` on html **and** body | `scale` |
 
 **Why not Linux=CSS:** no hang evidence; WebKitGTK CSS zoom weaker than Chromium.
 
 **Why pin native 1 on Windows:** clear residual ZoomFactor from older builds; prevent double scale.
+
+**Why `transform: scale` not CSS `zoom` for fill:** WebView2 was observed applying `width/height: 100/scale%` while CSS `zoom` did **not** re-expand the border box (uiScale 1.3 → ~77% shell + black bars). `transform: scale(s)` with origin `0 0` always scales paint including chrome. Body portals (dialogs/menus) still scale.
+
+**Why layout fill on Windows only:** bare scale shrinks the paint box and leaves letterbox (black over transparent html/body). Expanding layout by `1/scale` restores full-window coverage without calling `SetZoomFactor(≠1)`. macOS/Linux must never keep these CSS dimensions.
+
+**Why scale `<body>` not `<html>`:** keep `<html>` at 100% viewport; put transform + fill on `<body>` so residual html zoom from older builds can be cleared without double-scale.
+
+**Why shell must be `%` not `100vh`/`100vw`:** expanding body only works if `#root` / `.app` inherit from the expanded parent. Viewport units stay tied to the window — fixed in `src/styles/base.css` (html/body/#root/.app → width/height 100%).
 
 ### 2. Platform detection API
 
@@ -44,6 +52,7 @@ Settings still load via `useAppSettings` → controller → hook. No early apply
 - [Risk] CSS zoom vs pane drag coordinates → manual smoke DesktopLayout drag on Windows.
 - [Risk] Linux future hang → switch linux into CSS branch with new evidence only.
 - [Risk] `setZoom(1)` on every Windows apply → catch errors; CSS already applied.
+- [Risk] Subpixel gaps after `100/scale %` fill → rare 1px letterbox; smoke at 0.8 / 1.1 / 1.25 DPI.
 
 ## Migration Plan
 

--- a/openspec/changes/fix-windows-ui-scale-webview2-hang/specs/client-ui-scale-platform-application/spec.md
+++ b/openspec/changes/fix-windows-ui-scale-webview2-hang/specs/client-ui-scale-platform-application/spec.md
@@ -4,11 +4,15 @@
 
 The desktop client MUST apply the persisted `uiScale` setting in a platform-specific way so that Windows WebView2 is never asked to set a non-identity native zoom factor for application UI scale.
 
-#### Scenario: Windows applies CSS zoom and pins native zoom to 1
+#### Scenario: Windows applies CSS page scale, layout fill, and pins native zoom to 1
 
 - **WHEN** the renderer platform is `windows`
 - **AND** the clamped `uiScale` is any value in the supported range (including values other than `1`)
-- **THEN** the client MUST apply page scale via CSS zoom (or equivalent CSS page scale) on the document root
+- **THEN** the client MUST apply page scale via CSS `transform: scale(uiScale)` on `<body>` (not on `<html>`)
+- **AND** when `uiScale ≠ 1`, the client MUST expand body layout width and height to `100/uiScale %` with `position: fixed; top/left: 0; transform-origin: 0 0` so the scaled paint box fills the viewport (no letterbox)
+- **AND** the client MUST NOT rely on CSS `zoom` alone for shell fill (WebView2 may keep the shrunk border box and letterbox)
+- **AND** when `uiScale === 1`, the client MUST clear those layout width/height/transform/position compensations
+- **AND** the client MUST clear any residual CSS zoom / transform / fill left on `<html>` from older builds
 - **AND** if the Tauri webview zoom API is available, the client MUST call native zoom with factor `1` only
 - **AND** the client MUST NOT call native zoom with the non-1 `uiScale` value
 
@@ -17,20 +21,23 @@ The desktop client MUST apply the persisted `uiScale` setting in a platform-spec
 - **WHEN** the renderer platform is `macos`
 - **AND** the clamped `uiScale` is a supported value other than `1`
 - **THEN** the client MUST call native webview zoom with that `uiScale`
-- **AND** the client MUST clear any CSS zoom left on the document root from other platforms
+- **AND** the client MUST clear any CSS zoom left on `<html>` and `<body>` from other platforms
+- **AND** the client MUST clear any CSS zoom layout width/height compensation on both elements (Mac MUST NOT keep Windows letterbox fill styles)
 
 #### Scenario: Linux applies native zoom at uiScale by default
 
 - **WHEN** the renderer platform is `linux`
 - **AND** the clamped `uiScale` is a supported value other than `1`
 - **THEN** the client MUST call native webview zoom with that `uiScale` (WebKitGTK path)
-- **AND** the client MUST clear CSS zoom on the document root
+- **AND** the client MUST clear CSS zoom on `<html>` and `<body>`
+- **AND** the client MUST clear any CSS zoom layout width/height compensation on both
 - **AND** the client MUST NOT force CSS-only zoom solely because Windows uses CSS
 
 #### Scenario: Unknown or non-Tauri preview uses CSS scale safely
 
 - **WHEN** the renderer platform is `unknown` or native webview zoom is unavailable
-- **THEN** the client MUST still apply CSS page scale for the clamped `uiScale`
+- **THEN** the client MUST still apply CSS page scale for the clamped `uiScale` (same body target as Windows when root is `documentElement`)
+- **AND** the client MUST apply the same layout fill rule as Windows (`100/uiScale %` when scale ≠ 1)
 - **AND** missing Tauri metadata MUST NOT throw into a React error boundary
 
 #### Scenario: User uiScale value is not silently rewritten

--- a/openspec/changes/fix-windows-ui-scale-webview2-hang/tasks.md
+++ b/openspec/changes/fix-windows-ui-scale-webview2-hang/tasks.md
@@ -10,11 +10,12 @@
 - [x] 2.3 [P0] 更新 `useUiScaleShortcuts.test.tsx`（Win/Mac/Linux/throw）
 - [x] 2.4 [P0] 残留风险：apply 串行队列 + native pin 一次
 - [x] 2.5 [P0] 右侧面板默认展开 + 一次 migration；essential chrome（topToolControls/rightActivityToolbar）强制可见
+- [x] 2.6 [P0] Windows CSS zoom letterbox：zoom+`width/height = 100/scale %` 落在 **body**（勿 zoom html，overflow 先裁会黑边）；`scale===1` 与 macOS/Linux 清 html+body
 
 ## 3. Verification
 
 - [x] 3.1 [P0] focused Vitest（applyUiScale + uiScale hook + clientUiVisibility）
-- [ ] 3.2 [P1] 本机 dev 冷启动冒烟（**交用户验收**）
+- [ ] 3.2 [P1] 本机 dev 冷启动冒烟（**交用户验收**：Win `uiScale=0.8` 无黑框、可交互；Mac 缩放无 CSS width/height）
 - [x] 3.3 [P2] **不** git commit（用户明确要求）
 
 ## 4. Docs

--- a/src/features/layout/hooks/useUiScaleShortcuts.test.tsx
+++ b/src/features/layout/hooks/useUiScaleShortcuts.test.tsx
@@ -50,7 +50,12 @@ describe("useUiScaleShortcuts", () => {
     resetUiScaleNativePinForTests();
     platformMocks.platform = "macos";
     document.documentElement.style.zoom = "";
+    document.documentElement.style.width = "";
+    document.documentElement.style.height = "";
     document.documentElement.style.removeProperty("--ui-scale");
+    document.body.style.zoom = "";
+    document.body.style.width = "";
+    document.body.style.height = "";
     webviewMocks.setZoom.mockReset();
     webviewMocks.setZoom.mockResolvedValue(undefined);
     webviewMocks.getCurrentWebview.mockReset();
@@ -59,8 +64,14 @@ describe("useUiScaleShortcuts", () => {
     });
   });
 
-  it("macos: applies native zoom at uiScale", async () => {
+  it("macos: applies native zoom at uiScale and strips CSS layout fill", async () => {
     platformMocks.platform = "macos";
+    document.documentElement.style.zoom = "0.8";
+    document.documentElement.style.width = "125%";
+    document.documentElement.style.height = "125%";
+    document.body.style.zoom = "0.8";
+    document.body.style.width = "125%";
+    document.body.style.height = "125%";
     const settings = createSettings({ uiScale: 1.1 });
     renderHook(() =>
       useUiScaleShortcuts({
@@ -74,6 +85,11 @@ describe("useUiScaleShortcuts", () => {
       expect(webviewMocks.setZoom).toHaveBeenCalledWith(1.1);
     });
     expect(document.documentElement.style.zoom).toBe("");
+    expect(document.documentElement.style.width).toBe("");
+    expect(document.documentElement.style.height).toBe("");
+    expect(document.body.style.zoom).toBe("");
+    expect(document.body.style.width).toBe("");
+    expect(document.body.style.height).toBe("");
   });
 
   it("linux: applies native zoom at uiScale (same as macos)", async () => {
@@ -91,21 +107,28 @@ describe("useUiScaleShortcuts", () => {
     });
   });
 
-  it("windows: CSS zoom at uiScale and native zoom pinned to 1", async () => {
+  it("windows: transform scale + layout fill on body and native zoom pinned to 1", async () => {
     platformMocks.platform = "windows";
     renderHook(() =>
       useUiScaleShortcuts({
-        settings: createSettings({ uiScale: 1.1 }),
+        settings: createSettings({ uiScale: 0.8 }),
         setSettings: vi.fn(),
         saveSettings: vi.fn(async (next) => next),
       }),
     );
 
     await waitFor(() => {
-      expect(document.documentElement.style.zoom).toBe("1.1");
+      // Scale lives on <body> via transform; <html> stays viewport-sized.
+      expect(document.documentElement.style.zoom).toBe("");
+      expect(document.documentElement.style.transform).toBe("");
+      expect(document.body.style.zoom).toBe("");
+      expect(document.body.style.transform).toBe("scale(0.8)");
+      expect(document.body.style.width).toBe("125%");
+      expect(document.body.style.height).toBe("125%");
+      expect(document.body.style.position).toBe("fixed");
       expect(webviewMocks.setZoom).toHaveBeenCalledWith(1);
     });
-    expect(webviewMocks.setZoom).not.toHaveBeenCalledWith(1.1);
+    expect(webviewMocks.setZoom).not.toHaveBeenCalledWith(0.8);
   });
 
   it("survives missing Tauri window metadata in browser previews", async () => {
@@ -127,7 +150,7 @@ describe("useUiScaleShortcuts", () => {
     ).not.toThrow();
 
     await waitFor(() => {
-      expect(document.documentElement.style.zoom).toBe("0.9");
+      expect(document.body.style.transform).toBe("scale(0.9)");
     });
   });
 });

--- a/src/features/layout/hooks/useUiScaleShortcuts.ts
+++ b/src/features/layout/hooks/useUiScaleShortcuts.ts
@@ -39,10 +39,11 @@ export function useUiScaleShortcuts({
     if (typeof window === "undefined" || typeof document === "undefined") {
       return;
     }
-    // Platform split: Windows uses CSS zoom + native zoom pinned to 1
-    // (WebView2 SetZoomFactor(≠1) freezes renderer). macOS/Linux keep native
-    // setZoom(uiScale). See docs/analysis/windows-ccgui-startup-hang-2026-08-05.md
-    // and openspec/changes/fix-windows-ui-scale-webview2-hang/.
+    // Platform split: Windows uses CSS transform scale + native zoom pinned to 1
+    // (WebView2 SetZoomFactor(≠1) freezes renderer; CSS zoom alone letterboxes).
+    // macOS/Linux keep native setZoom(uiScale). See
+    // docs/analysis/windows-ccgui-startup-hang-2026-08-05.md and
+    // openspec/changes/fix-windows-ui-scale-webview2-hang/.
     let setNativeZoom: ((factor: number) => Promise<void>) | undefined;
     try {
       // getCurrentWebview() reads window.__TAURI_INTERNALS__.metadata

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -158,21 +158,32 @@ body::-webkit-scrollbar-corner,
   background: transparent;
 }
 
+/*
+ * Full-window shell must use a % size chain (not 100vh/100vw).
+ * Windows uiScale is transform:scale on <body> + layout fill width/height =
+ * 100/scale% (CSS zoom alone left a letterboxed shell on WebView2).
+ * <html> stays 100% viewport. Viewport units ignore parent expansion, so the
+ * outer .app shell would stay letterboxed while only some paint scaled —
+ * see applyUiScale.ts and docs/analysis/windows-ccgui-startup-hang-2026-08-05.md.
+ */
 html,
 body {
   margin: 0;
   background: transparent;
   overflow: hidden;
+  width: 100%;
+  height: 100%;
 }
 
 #root {
-  height: 100vh;
+  width: 100%;
+  height: 100%;
   overflow: hidden;
 }
 
 .app {
-  height: 100vh;
-  width: 100vw;
+  width: 100%;
+  height: 100%;
   display: grid;
   grid-template-columns: var(--sidebar-width, 210px) 1fr;
   background: var(--surface-messages, #0d0f14);

--- a/src/utils/applyUiScale.test.ts
+++ b/src/utils/applyUiScale.test.ts
@@ -2,18 +2,37 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   applyUiScale,
+  cssZoomLayoutFillSize,
   enqueueApplyUiScale,
   resetUiScaleNativePinForTests,
+  resolveCssZoomLayoutTarget,
   usesCssPageZoom,
 } from "./applyUiScale";
 import type { RendererPlatform } from "./rendererPlatform";
 
+/** Detached div — layout styles land on the element itself (no document body hop). */
 function makeRoot(): HTMLElement {
   return document.createElement("div");
 }
 
+function clearEl(el: HTMLElement): void {
+  el.style.zoom = "";
+  el.style.transform = "";
+  el.style.transformOrigin = "";
+  el.style.width = "";
+  el.style.height = "";
+  el.style.position = "";
+  el.style.top = "";
+  el.style.left = "";
+  el.style.right = "";
+  el.style.bottom = "";
+  el.style.removeProperty("--ui-scale");
+}
+
 beforeEach(() => {
   resetUiScaleNativePinForTests();
+  clearEl(document.documentElement);
+  clearEl(document.body);
 });
 
 describe("usesCssPageZoom", () => {
@@ -27,8 +46,39 @@ describe("usesCssPageZoom", () => {
   });
 });
 
+describe("cssZoomLayoutFillSize", () => {
+  it("returns null at identity scale (caller clears layout)", () => {
+    expect(cssZoomLayoutFillSize(1)).toBeNull();
+  });
+
+  it("expands layout by 1/scale for non-identity zoom", () => {
+    expect(cssZoomLayoutFillSize(0.8)).toBe("125%");
+    expect(cssZoomLayoutFillSize(1.25)).toBe("80%");
+    // 100 / 1.1 ≈ 90.909...%
+    expect(cssZoomLayoutFillSize(1.1)).toBe(`${100 / 1.1}%`);
+  });
+
+  it("clamps before computing fill", () => {
+    // UI_SCALE_MIN = 0.8 → 125%
+    expect(cssZoomLayoutFillSize(0.1)).toBe("125%");
+  });
+});
+
+describe("resolveCssZoomLayoutTarget", () => {
+  it("routes documentElement to body", () => {
+    expect(resolveCssZoomLayoutTarget(document.documentElement)).toBe(
+      document.body,
+    );
+  });
+
+  it("keeps non-html roots (unit-test divs)", () => {
+    const root = makeRoot();
+    expect(resolveCssZoomLayoutTarget(root)).toBe(root);
+  });
+});
+
 describe("applyUiScale", () => {
-  it("windows: CSS zoom at uiScale and native zoom pinned to 1 once", async () => {
+  it("windows: transform scale + layout fill, native zoom pinned to 1 once", async () => {
     const root = makeRoot();
     const setNativeZoom = vi.fn(async () => undefined);
     await applyUiScale(1.1, {
@@ -36,7 +86,14 @@ describe("applyUiScale", () => {
       setNativeZoom,
       platform: "windows",
     });
-    expect(root.style.zoom).toBe("1.1");
+    expect(root.style.zoom).toBe("");
+    expect(root.style.transform).toBe("scale(1.1)");
+    expect(root.style.transformOrigin).toBe("0 0");
+    expect(root.style.position).toBe("fixed");
+    expect(root.style.top).toBe("0px");
+    expect(root.style.left).toBe("0px");
+    expect(root.style.width).toBe(`${100 / 1.1}%`);
+    expect(root.style.height).toBe(`${100 / 1.1}%`);
     expect(root.style.getPropertyValue("--ui-scale")).toBe("1.1");
     expect(setNativeZoom).toHaveBeenCalledTimes(1);
     expect(setNativeZoom).toHaveBeenCalledWith(1);
@@ -46,37 +103,85 @@ describe("applyUiScale", () => {
       setNativeZoom,
       platform: "windows",
     });
-    expect(root.style.zoom).toBe("0.8");
+    expect(root.style.zoom).toBe("");
+    expect(root.style.transform).toBe("scale(0.8)");
+    expect(root.style.width).toBe("125%");
+    expect(root.style.height).toBe("125%");
     // Second apply must not call setZoom again.
     expect(setNativeZoom).toHaveBeenCalledTimes(1);
+  });
+
+  it("windows documentElement: scales body and clears residual html zoom", async () => {
+    document.documentElement.style.zoom = "0.8";
+    document.documentElement.style.width = "125%";
+    document.documentElement.style.height = "125%";
+
+    await applyUiScale(0.8, {
+      root: document.documentElement,
+      platform: "windows",
+    });
+
+    expect(document.documentElement.style.zoom).toBe("");
+    expect(document.documentElement.style.width).toBe("");
+    expect(document.documentElement.style.height).toBe("");
+    expect(document.documentElement.style.transform).toBe("");
+    expect(document.documentElement.style.getPropertyValue("--ui-scale")).toBe(
+      "0.8",
+    );
+    expect(document.body.style.zoom).toBe("");
+    expect(document.body.style.transform).toBe("scale(0.8)");
+    expect(document.body.style.width).toBe("125%");
+    expect(document.body.style.height).toBe("125%");
+    expect(document.body.style.position).toBe("fixed");
+  });
+
+  it("windows: scale 1 clears layout fill (no letterbox compensation)", async () => {
+    const root = makeRoot();
+    root.style.width = "125%";
+    root.style.height = "125%";
+    root.style.transform = "scale(0.8)";
+    root.style.position = "fixed";
+    await applyUiScale(1, {
+      root,
+      platform: "windows",
+    });
+    expect(root.style.zoom).toBe("");
+    expect(root.style.transform).toBe("");
+    expect(root.style.width).toBe("");
+    expect(root.style.height).toBe("");
+    expect(root.style.position).toBe("");
   });
 
   it("enqueueApplyUiScale serializes and keeps latest scale", async () => {
     const root = makeRoot();
     const order: number[] = [];
-    const setNativeZoom = vi.fn(async () => undefined);
-    const slow = enqueueApplyUiScale(1.1, {
+    const setNativeZoom = vi.fn(async (factor: number) => {
+      order.push(factor);
+      await new Promise((r) => setTimeout(r, 5));
+    });
+    const slow = enqueueApplyUiScale(1.2, {
       root,
       setNativeZoom,
       platform: "windows",
-    }).then(() => {
-      order.push(1.1);
     });
     const fast = enqueueApplyUiScale(0.8, {
       root,
       setNativeZoom,
       platform: "windows",
-    }).then(() => {
-      order.push(0.8);
     });
     await Promise.all([slow, fast]);
-    expect(root.style.zoom).toBe("0.8");
-    expect(order[order.length - 1]).toBe(0.8);
+    expect(root.style.transform).toBe("scale(0.8)");
+    expect(root.style.width).toBe("125%");
+    expect(order[order.length - 1]).toBe(1);
   });
 
-  it("macos: native zoom at uiScale and clears CSS zoom", async () => {
+  it("macos: native zoom at uiScale and clears CSS scale + layout fill", async () => {
     const root = makeRoot();
     root.style.zoom = "1.2";
+    root.style.width = "125%";
+    root.style.height = "125%";
+    root.style.transform = "scale(1.2)";
+    root.style.position = "fixed";
     const setNativeZoom = vi.fn(async () => undefined);
     await applyUiScale(0.8, {
       root,
@@ -84,12 +189,41 @@ describe("applyUiScale", () => {
       platform: "macos",
     });
     expect(root.style.zoom).toBe("");
+    expect(root.style.transform).toBe("");
+    expect(root.style.width).toBe("");
+    expect(root.style.height).toBe("");
+    expect(root.style.position).toBe("");
     expect(root.style.getPropertyValue("--ui-scale")).toBe("0.8");
     expect(setNativeZoom).toHaveBeenCalledWith(0.8);
+    expect(setNativeZoom).not.toHaveBeenCalledWith(1);
   });
 
-  it("linux: same as macos (native uiScale)", async () => {
+  it("macos documentElement: clears body fill left by Windows path", async () => {
+    document.body.style.zoom = "0.8";
+    document.body.style.width = "125%";
+    document.body.style.height = "125%";
+    document.body.style.transform = "scale(0.8)";
+    document.body.style.position = "fixed";
+    const setNativeZoom = vi.fn(async () => undefined);
+    await applyUiScale(1.1, {
+      root: document.documentElement,
+      setNativeZoom,
+      platform: "macos",
+    });
+    expect(document.documentElement.style.zoom).toBe("");
+    expect(document.body.style.zoom).toBe("");
+    expect(document.body.style.transform).toBe("");
+    expect(document.body.style.width).toBe("");
+    expect(document.body.style.height).toBe("");
+    expect(document.body.style.position).toBe("");
+    expect(setNativeZoom).toHaveBeenCalledWith(1.1);
+  });
+
+  it("linux: same as macos (native uiScale, no CSS fill)", async () => {
     const root = makeRoot();
+    root.style.width = "125%";
+    root.style.height = "125%";
+    root.style.transform = "scale(1.2)";
     const setNativeZoom = vi.fn(async () => undefined);
     await applyUiScale(1.2, {
       root,
@@ -97,16 +231,22 @@ describe("applyUiScale", () => {
       platform: "linux",
     });
     expect(root.style.zoom).toBe("");
+    expect(root.style.transform).toBe("");
+    expect(root.style.width).toBe("");
+    expect(root.style.height).toBe("");
     expect(setNativeZoom).toHaveBeenCalledWith(1.2);
   });
 
-  it("unknown: CSS zoom without requiring native API", async () => {
+  it("unknown: CSS scale + fill without requiring native API", async () => {
     const root = makeRoot();
     await applyUiScale(0.9, {
       root,
       platform: "unknown",
     });
-    expect(root.style.zoom).toBe("0.9");
+    expect(root.style.zoom).toBe("");
+    expect(root.style.transform).toBe("scale(0.9)");
+    expect(root.style.width).toBe(`${100 / 0.9}%`);
+    expect(root.style.height).toBe(`${100 / 0.9}%`);
   });
 
   it("clamps out-of-range scale before apply", async () => {
@@ -118,7 +258,8 @@ describe("applyUiScale", () => {
       platform: "windows",
     });
     // clampUiScale caps to UI_SCALE_MAX 2.6
-    expect(root.style.zoom).toBe("2.6");
+    expect(root.style.transform).toBe("scale(2.6)");
+    expect(root.style.width).toBe(`${100 / 2.6}%`);
     expect(setNativeZoom).toHaveBeenCalledWith(1);
   });
 });

--- a/src/utils/applyUiScale.ts
+++ b/src/utils/applyUiScale.ts
@@ -12,13 +12,123 @@ export type ApplyUiScaleTarget = {
 
 /**
  * Windows WebView2 SetZoomFactor(≠1) can freeze the renderer (see
- * docs/analysis/windows-ccgui-startup-hang-2026-08-05.md). CSS zoom carries
- * scale there; native zoom is pinned to 1 once per page session.
+ * docs/analysis/windows-ccgui-startup-hang-2026-08-05.md). CSS page scale
+ * carries uiScale there; native zoom is pinned to 1 once per page session.
  *
- * macOS / Linux keep native setZoom(uiScale) (WKWebView / WebKitGTK).
+ * Why not CSS `zoom` for fill:
+ * WebView2 has been observed to honor layout `width/height: 100/scale%` while
+ * `zoom` does not re-expand the border box back to the viewport — result is a
+ * permanently letterboxed shell (e.g. uiScale 1.3 → ~77% content, black bars).
+ * `transform: scale()` always scales paint, including backgrounds / chrome.
+ *
+ * Target is <body> when `root` is <html>:
+ * - position:fixed + top/left 0 so % sizes resolve against the viewport
+ * - width/height = 100/scale % (layout box)
+ * - transform: scale(scale) + origin 0 0 → visual box fills the window
+ * - portals mounted on body (dialogs, menus) scale with the shell
+ *
+ * Shell children must size with a % chain under body (see base.css
+ * html/body/#root/.app). 100vh/100vw ignore parent expansion.
+ *
+ * macOS / Linux keep native setZoom(uiScale) (WKWebView / WebKitGTK) and never
+ * keep CSS scale layout compensation.
  */
 export function usesCssPageZoom(platform: RendererPlatform): boolean {
   return platform === "windows" || platform === "unknown";
+}
+
+/**
+ * Layout size so `transform: scale(s)` still fills the viewport.
+ * Returns null when scale is 1 (caller must clear width/height).
+ *
+ * @internal exported for unit tests
+ */
+export function cssZoomLayoutFillSize(scale: number): string | null {
+  const next = clampUiScale(scale);
+  if (next === 1) {
+    return null;
+  }
+  return `${100 / next}%`;
+}
+
+/**
+ * Prefer <body> when root is <html>; keep detached test roots as-is.
+ *
+ * @internal exported for unit tests
+ */
+export function resolveCssZoomLayoutTarget(root: HTMLElement): HTMLElement {
+  const doc = root.ownerDocument;
+  if (doc?.documentElement === root && doc.body) {
+    return doc.body;
+  }
+  return root;
+}
+
+function setScaleLayoutStyles(el: HTMLElement, scale: number): void {
+  // Drop any residual CSS zoom from older builds — never combine with transform.
+  el.style.zoom = "";
+
+  const fill = cssZoomLayoutFillSize(scale);
+  if (fill === null) {
+    el.style.transform = "";
+    el.style.transformOrigin = "";
+    el.style.width = "";
+    el.style.height = "";
+    el.style.position = "";
+    el.style.top = "";
+    el.style.left = "";
+    el.style.right = "";
+    el.style.bottom = "";
+    return;
+  }
+
+  // Fixed against the viewport so % is not clipped by a pre-transform parent box.
+  el.style.position = "fixed";
+  el.style.top = "0px";
+  el.style.left = "0px";
+  el.style.right = "auto";
+  el.style.bottom = "auto";
+  el.style.width = fill;
+  el.style.height = fill;
+  el.style.transformOrigin = "0 0";
+  el.style.transform = `scale(${scale})`;
+}
+
+function clearScaleLayoutStyles(el: HTMLElement): void {
+  el.style.zoom = "";
+  el.style.transform = "";
+  el.style.transformOrigin = "";
+  el.style.width = "";
+  el.style.height = "";
+  el.style.position = "";
+  el.style.top = "";
+  el.style.left = "";
+  el.style.right = "";
+  el.style.bottom = "";
+}
+
+function applyCssPageScaleStyles(root: HTMLElement, scale: number): void {
+  root.style.setProperty("--ui-scale", String(scale));
+
+  const layout = resolveCssZoomLayoutTarget(root);
+  // Older builds zoomed <html>; clear residual so we never double-scale.
+  if (layout !== root) {
+    clearScaleLayoutStyles(root);
+  }
+  setScaleLayoutStyles(layout, scale);
+}
+
+/** Clear CSS scale + letterbox compensation (native path / scale reset). */
+function clearCssPageScaleStyles(root: HTMLElement): void {
+  clearScaleLayoutStyles(root);
+  const layout = resolveCssZoomLayoutTarget(root);
+  if (layout !== root) {
+    clearScaleLayoutStyles(layout);
+  }
+  root.style.removeProperty("--ui-scale");
+  if (layout !== root) {
+    layout.style.removeProperty("--ui-scale");
+  }
 }
 
 /** After first successful pin to 1, skip further setZoom(1) on CSS platforms. */
@@ -60,8 +170,7 @@ export async function applyUiScale(
   const next = clampUiScale(scale);
 
   if (usesCssPageZoom(target.platform)) {
-    target.root.style.zoom = String(next);
-    target.root.style.setProperty("--ui-scale", String(next));
+    applyCssPageScaleStyles(target.root, next);
     // Pin WebView2 ZoomFactor to 1 once so residual ≠1 from older builds is
     // cleared without calling setZoom on every scale change.
     if (target.setNativeZoom && !nativeIdentityPinned) {
@@ -71,7 +180,9 @@ export async function applyUiScale(
     return;
   }
 
-  target.root.style.zoom = "";
+  // macOS / Linux: native zoom only. Strip any CSS scale compensation so a
+  // mistaken residual (or platform switch in tests) cannot letterbox Mac/Linux.
+  clearCssPageScaleStyles(target.root);
   target.root.style.setProperty("--ui-scale", String(next));
   if (target.setNativeZoom) {
     await target.setNativeZoom(next);


### PR DESCRIPTION
WebView2 上 CSS zoom 无法把壳铺满视口，改为 body transform:scale + 100/scale% 填充；macOS/Linux 保持 native setZoom 并清理残留 CSS。