### PR TITLE
fix(sidebar): inset session selection pills for clearer hierarchy

### DIFF
--- a/src/features/app/components/Sidebar.styles.test.ts
+++ b/src/features/app/components/Sidebar.styles.test.ts
@@ -92,10 +92,11 @@ describe("Sidebar styles", () => {
     expect(ruleBody(sidebarCss, ".thread-row.active")).toMatch(
       /background:\s*var\(--sidebar-color-active-primary\);/,
     );
-    // Horizontal inset + radius keep session pills aligned with project rows.
-    // Anchor on the base `.thread-list` rule (not `.worktree-card .thread-list`).
+    // Session pills are intentionally more inset than workspace rows (4px) so
+    // nested selection backgrounds stay narrower and do not flush-align with
+    // the project pill above. Anchor on base `.thread-list` (not worktree).
     expect(sidebarCss).toMatch(
-      /\.thread-list\s*\{[\s\S]*?padding:\s*1px\s+4px\s+2px;/,
+      /\.thread-list\s*\{[\s\S]*?padding:\s*1px\s+8px\s+2px\s+12px;/,
     );
     expect(shellCss).toMatch(/--sidebar-row-radius:\s*6px;/);
   });

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -1969,8 +1969,12 @@
   flex-direction: column;
   gap: 2px;
   margin-left: 0;
-  /* Horizontal inset matches workspace-row (4px) so active pills align */
-  padding: 1px 4px 2px;
+  /*
+   * Session selection pills stay inset vs workspace-row (margin 4px) so nested
+   * session backgrounds are narrower and do not flush-align with the project
+   * pill above. Left is a bit larger for clear tree hierarchy.
+   */
+  padding: 1px 8px 2px 12px;
 }
 
 .thread-list[data-virtualized="true"] {
@@ -2377,10 +2381,11 @@
 }
 
 /* Updated Thread Row Styles — selection geometry aligned with workspace-row */
+/* Session pill geometry is inset via .thread-list padding (not flush with workspace-row). */
 .thread-row {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 2px;
   min-height: var(--sidebar-row-height-thread);
   padding: 2px 6px 2px calc(10px + var(--thread-indent, 0px));
   border-radius: var(--sidebar-row-radius);


### PR DESCRIPTION
Increase `.thread-list` horizontal padding from `1px 4px 2px` to `1px 8px 2px 12px` so session selection backgrounds sit more inset than workspace rows (4px margin) and no longer flush-align with the project pill above.

Left padding is slightly larger than right to reinforce tree hierarchy. Also tighten `.thread-row` gap from 6px to 2px so the denser inset layout stays balanced, and update the Sidebar styles regression test and comments to match the intentional geometry (base `.thread-list`, not worktree overrides).

Impact: nested session active/hover pills read as child items under project rows instead of looking flush-aligned with them; visual hierarchy in the sidebar is clearer with no behavior change.