### PR TITLE
fix(memory): remove ONNX runtime to restore Intel macOS packaging

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -15,9 +15,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom 0.3.4",
  "once_cell",
- "serde",
  "version_check",
  "zerocopy",
 ]
@@ -324,12 +322,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -339,18 +331,6 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "base64"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
-
-[[package]]
-name = "base64ct"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bindgen"
@@ -577,15 +557,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "castaway"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "cc"
 version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -612,7 +583,6 @@ dependencies = [
  "encoding_rs",
  "fix-path-env",
  "flate2",
- "futures-util",
  "git2",
  "hmac",
  "ignore",
@@ -626,7 +596,6 @@ dependencies = [
  "objc2-app-kit",
  "objc2-av-foundation",
  "objc2-foundation",
- "ort",
  "portable-pty",
  "regex",
  "reqwest",
@@ -644,7 +613,6 @@ dependencies = [
  "tauri-plugin-process",
  "tauri-plugin-updater",
  "tauri-plugin-window-state",
- "tokenizers",
  "tokio",
  "toml 0.8.2",
  "trash",
@@ -769,39 +737,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "compact_str"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
-dependencies = [
- "castaway",
- "cfg-if",
- "itoa",
- "rustversion",
- "ryu",
- "serde",
- "static_assertions",
-]
-
-[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
-]
-
-[[package]]
-name = "console"
-version = "0.16.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
-dependencies = [
- "encode_unicode",
- "libc",
- "unicode-width",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -855,7 +796,7 @@ dependencies = [
  "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "core-graphics-types",
- "foreign-types 0.5.0",
+ "foreign-types",
  "libc",
 ]
 
@@ -1013,43 +954,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "daachorse"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f55d7153ba3b507595872a3874803f07a8a81d1e888abed8e5db7da0597d6e2"
-
-[[package]]
-name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
 name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.117",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1068,33 +979,13 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core 0.21.3",
+ "darling_core",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "dary_heap"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -1108,16 +999,6 @@ name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
-
-[[package]]
-name = "der"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
-dependencies = [
- "pem-rfc7468",
- "zeroize",
-]
 
 [[package]]
 name = "deranged"
@@ -1137,37 +1018,6 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "derive_builder"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
-dependencies = [
- "derive_builder_macro",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
-dependencies = [
- "derive_builder_core",
  "syn 2.0.117",
 ]
 
@@ -1374,12 +1224,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
-name = "encode_unicode"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
-
-[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1446,15 +1290,6 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "esaxx-rs"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -1577,21 +1412,12 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared 0.1.1",
-]
-
-[[package]]
-name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared 0.3.1",
+ "foreign-types-shared",
 ]
 
 [[package]]
@@ -1604,12 +1430,6 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -1946,7 +1766,7 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
- "openssl-probe 0.1.6",
+ "openssl-probe",
  "openssl-sys",
  "url",
 ]
@@ -2151,12 +1971,6 @@ checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
 ]
-
-[[package]]
-name = "hmac-sha256"
-version = "1.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
 
 [[package]]
 name = "home"
@@ -2531,19 +2345,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indicatif"
-version = "0.18.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
-dependencies = [
- "console",
- "portable-atomic",
- "unicode-width",
- "unit-prefix",
- "web-time",
-]
-
-[[package]]
 name = "infer"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2630,15 +2431,6 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -2977,12 +2769,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
-name = "lzma-rust2"
-version = "0.15.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e20f57f9918e5bd7bc58c22cdd70a6afc7375d4dd9683af5f2b34bd3d2bba619"
-
-[[package]]
 name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3008,22 +2794,6 @@ checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "macro_rules_attribute"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3ae8f6d608c795738406608304d30a2dfbdc8e58e44f7ba43236da5208ded3c"
-dependencies = [
- "macro_rules_attribute-proc_macro",
- "pastey",
-]
-
-[[package]]
-name = "macro_rules_attribute-proc_macro"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc04a4c58212d57930a24bf47d3fa87485264a3a054e9c10e042eb373573ad3c"
 
 [[package]]
 name = "mailparse"
@@ -3072,16 +2842,6 @@ name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
-
-[[package]]
-name = "matrixmultiply"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f607c237553f086e7043417a51df26b2eb899d3caff94e6a67592ff992fedc7"
-dependencies = [
- "autocfg",
- "rawpointer",
-]
 
 [[package]]
 name = "memchr"
@@ -3159,28 +2919,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "monostate"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3341a273f6c9d5bef1908f17b7267bbab0e95c9bf69a0d4dcf8e9e1b2c76ef67"
-dependencies = [
- "monostate-impl",
- "serde",
- "serde_core",
-]
-
-[[package]]
-name = "monostate-impl"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "moxcms"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3209,38 +2947,6 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe 0.2.1",
- "openssl-sys",
- "schannel",
- "security-framework 3.7.0",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
-name = "ndarray"
-version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
-dependencies = [
- "matrixmultiply",
- "num-complex",
- "num-integer",
- "num-traits",
- "portable-atomic",
- "portable-atomic-util",
- "rawpointer",
 ]
 
 [[package]]
@@ -3375,15 +3081,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-complex"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3398,15 +3095,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -3786,28 +3474,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
-name = "onig"
-version = "6.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
-dependencies = [
- "bitflags 2.11.1",
- "libc",
- "once_cell",
- "onig_sys",
-]
-
-[[package]]
-name = "onig_sys"
-version = "69.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e68317604e77e53b85896388e1a803c1d21b74c899ec9e5e1112db90735edd7"
-dependencies = [
- "cc",
- "pkg-config",
-]
-
-[[package]]
 name = "open"
 version = "5.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3820,41 +3486,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
-dependencies = [
- "bitflags 2.11.1",
- "cfg-if",
- "foreign-types 0.3.2",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-probe"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
@@ -3882,30 +3517,6 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
-]
-
-[[package]]
-name = "ort"
-version = "2.0.0-rc.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4336a1e2b38848325241c72889086886004e589b7c74f335e60a8e8db5138a0b"
-dependencies = [
- "ndarray",
- "ort-sys",
- "smallvec",
- "tracing",
- "ureq",
-]
-
-[[package]]
-name = "ort-sys"
-version = "2.0.0-rc.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf211e3776eea6aec988552fa118dd746d70e1b1e5e244058d1c98015f3e5872"
-dependencies = [
- "hmac-sha256",
- "lzma-rust2",
- "ureq",
 ]
 
 [[package]]
@@ -4001,31 +3612,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "pastey"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
-
-[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
-
-[[package]]
-name = "pem-rfc7468"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
-dependencies = [
- "base64ct",
-]
 
 [[package]]
 name = "percent-encoding"
@@ -4247,21 +3837,6 @@ dependencies = [
  "pin-project-lite",
  "rustix 1.1.3",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "portable-atomic"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
-dependencies = [
- "portable-atomic",
 ]
 
 [[package]]
@@ -4629,43 +4204,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
-name = "rawpointer"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
-
-[[package]]
-name = "rayon"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-cond"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
-dependencies = [
- "either",
- "itertools 0.14.0",
- "rayon",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4942,11 +4480,11 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
 dependencies = [
- "openssl-probe 0.1.6",
+ "openssl-probe",
  "rustls-pemfile",
  "rustls-pki-types",
  "schannel",
- "security-framework 2.11.1",
+ "security-framework",
 ]
 
 [[package]]
@@ -5085,19 +4623,6 @@ checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.11.1",
  "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework"
-version = "3.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
-dependencies = [
- "bitflags 2.11.1",
- "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -5284,7 +4809,7 @@ version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5472,17 +4997,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "socks"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
-dependencies = [
- "byteorder",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "softbuffer"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5528,18 +5042,6 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
-]
-
-[[package]]
-name = "spm_precompiled"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5851699c4033c63636f7ea4cf7b7c1f1bf06d0cc03cfb42e711de5a5c46cf326"
-dependencies = [
- "base64 0.13.1",
- "nom 7.1.3",
- "serde",
- "unicode-segmentation",
 ]
 
 [[package]]
@@ -6248,40 +5750,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
-name = "tokenizers"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44e5bea67576e04b6ff8564c5d9e09c2ef0cf476502245f2f120e497769d3112"
-dependencies = [
- "ahash",
- "compact_str",
- "daachorse",
- "dary_heap",
- "derive_builder",
- "esaxx-rs",
- "getrandom 0.3.4",
- "indicatif",
- "itertools 0.14.0",
- "log",
- "macro_rules_attribute",
- "monostate",
- "onig",
- "paste",
- "rand 0.9.2",
- "rayon",
- "rayon-cond",
- "regex",
- "regex-syntax",
- "serde",
- "serde_json",
- "spm_precompiled",
- "thiserror 2.0.18",
- "unicode-normalization-alignments",
- "unicode-segmentation",
- "unicode_categories",
-]
-
-[[package]]
 name = "tokio"
 version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6652,43 +6120,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
-name = "unicode-normalization-alignments"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
-dependencies = [
- "smallvec",
-]
-
-[[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
-name = "unicode-width"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unicode_categories"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
-
-[[package]]
-name = "unit-prefix"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -6701,36 +6142,6 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
-name = "ureq"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d"
-dependencies = [
- "base64 0.23.1",
- "der",
- "log",
- "native-tls",
- "percent-encoding",
- "rustls-pki-types",
- "socks",
- "ureq-proto",
- "utf8-zero",
- "webpki-root-certs",
-]
-
-[[package]]
-name = "ureq-proto"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da5f78b09e6941e1a0f2e30e695e4b120377b54d5e0aec11b594bb57b3971613"
-dependencies = [
- "base64 0.23.1",
- "http",
- "httparse",
- "log",
-]
 
 [[package]]
 name = "url"
@@ -6768,12 +6179,6 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
-name = "utf8-zero"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -7057,15 +6462,6 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
-]
-
-[[package]]
-name = "webpki-root-certs"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -51,7 +51,6 @@ fix-path-env = { git = "https://github.com/tauri-apps/fix-path-env-rs" }
 ignore = "0.4.25"
 portable-pty = "0.8"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream"] }
-futures-util = "0.3"
 zip = { version = "4.6.1", default-features = false, features = ["deflate-flate2"] }
 # flate2 1.1.8 requires an explicit backend; zip pulls it in with default-features off,
 # so select rust_backend (miniz_oxide, no system zlib) here for the target build.
@@ -74,9 +73,8 @@ encoding_rs = "0.8"
 lettre = { version = "0.11.21", default-features = false, features = ["smtp-transport", "builder", "tokio1-rustls-tls", "hostname"] }
 imap = { version = "3.0.0-alpha.15", default-features = false, features = ["rustls-tls"] }
 mailparse = "0.16.1"
-# Phase-3 ONNX embedding（方案 A：本地 ONNX，零用户安装）
-ort = { version = "2.0.0-rc.13", default-features = false, features = ["std", "ndarray", "download-binaries", "copy-dylibs", "tls-native"] }
-tokenizers = "0.23"
+# ONNX embedding（ort）已移除：ort-sys 无 x86_64-apple-darwin 预编译，阻断 Intel macOS 打包。
+# 命令面仍在 project_memory/embed.rs（health=unavailable → lexical）；后续若恢复需另选可跨 Intel 的 runtime。
 
 [target."cfg(not(any(target_os = \"android\", target_os = \"ios\")))".dependencies]
 tauri-plugin-updater = "2"

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -24,38 +24,6 @@ fn main() {
     validate_curated_skills_bundled_in_conf();
     validate_agent_catalog();
     validate_agent_catalog_bundled_in_conf();
-    warn_embedding_model_missing();
-}
-
-/// 编译时检查 embedding 模型是否存在。缺失仅 warn，不阻断构建。
-/// 模型运行时从 `~/.ccgui/models/embedding/` 自动下载（前端触发），无需打包进安装包。
-fn warn_embedding_model_missing() {
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let model_dir = manifest_dir.join("resources").join("models").join("embedding");
-    let onnx = model_dir.join("memory-embed-v1.onnx");
-    let tokenizer = model_dir.join("tokenizer.json");
-
-    let onnx_found = onnx.is_file();
-    let tokenizer_found = tokenizer.is_file();
-
-    if !onnx_found || !tokenizer_found {
-        println!(
-            "cargo:warning=[embed] Embedding model not bundled (expected — now downloaded at runtime)."
-        );
-        println!(
-            "cargo:warning=[embed] Users download the model in Settings → 记忆参考 to ~/.ccgui/models/embedding/."
-        );
-        println!(
-            "cargo:warning=[embed] Without the model, the app falls back to lexical search — that is normal."
-        );
-    }
-
-    if onnx_found {
-        println!(
-            "cargo:warning=[embed] Found ONNX model at {} (dev use; not bundled into installer)",
-            onnx.display()
-        );
-    }
 }
 
 fn validate_agent_catalog_bundled_in_conf() {

--- a/src-tauri/resources/models/embedding/README.md
+++ b/src-tauri/resources/models/embedding/README.md
@@ -1,27 +1,17 @@
 # Embedding Model Directory
 
-模型文件**运行时按需下载**到 `~/.ccgui/models/embedding/`，由用户从记忆参考菜单触发。
+本地 ONNX 语义推理已从当前构建中移除（`ort` 无 `x86_64-apple-darwin` 预编译，阻断 Intel macOS 打包）。
 
-## 开发者预下载
+记忆参考默认走 **关键词（lexical）** 检索。Tauri 命令 `project_memory_embed_*` 仍保留，health 固定返回：
+
+- `status: unavailable`
+- `downloadable: false`
+- `reason: onnx_runtime_removed`
+
+若日后恢复跨平台 embedding，再重新接入 runtime，并评估 Intel / Apple Silicon / Windows / Linux 打包矩阵。
+
+可选开发资源（当前 **不会** 被打包或加载）：
 
 ```bash
-# 下载到 app data dir（应用自动检测）
 bash scripts/download-embed-model.sh
-
-# 或下载到 repo resources/（开发用）
-bash scripts/download-embed-model.sh --dev
 ```
-
-下载 `sentence-transformers/all-MiniLM-L6-v2`（384 维 · ~90MB ONNX + 0.5MB tokenizer · 中英文可用）。
-
-## 模型查找优先级
-
-1. 打包 resource_dir（bundle.resources，如有）
-2. 开发态 `src-tauri/resources/models/embedding/`
-3. 用户 `~/.ccgui/models/embedding/`（运行时下载目标）
-
-## 模型未就绪时
-
-应用自动降级为关键词匹配（lexical），记忆功能不受影响。
-记忆参考菜单显示「下载本地语义模型」入口，点击后自动下载。
-不会弹窗要求用户安装第三方软件。

--- a/src-tauri/src/project_memory/embed.rs
+++ b/src-tauri/src/project_memory/embed.rs
@@ -1,64 +1,42 @@
-//! 本地 ONNX embedding（Phase-3 方案 A）。
+//! 本地 embedding 命令面（当前无 ONNX Runtime）。
 //!
-//! 运行时：`ort`（ONNX Runtime）+ `tokenizers`（HuggingFace tokenizer）。
-//! 模型文件查找优先级：
-//!   1. **客户端默认家目录** `~/.ccgui/models/embedding/`（下载目标；与 project-memory 同根）
-//!   2. 打包 resource_dir（若未来随包装载）
-//!   3. 开发态仓库内路径
-//!   4. 兼容旧路径：Tauri app_data_dir/models/embedding/（自动迁移到 ~/.ccgui）
+//! 背景：`ort` / ONNX Runtime 预编译不提供 `x86_64-apple-darwin`，会导致 Intel macOS
+//! 线上打包失败。按产品决策移除 `ort` 依赖，命令面保持兼容，health 诚实返回
+//! unavailable，检索路径回退 lexical。
 //!
-//! 降级合约：
-//! - 模型/tokenizer 缺失 → health = unavailable + downloadable=true → 前端可触发下载
-//! - 下载到 `~/.ccgui/models/embedding/`（不污染安装包；用户零独立装软件）
-//! - 推理失败 → 错误传播至 worker/retrieve 各自 catch，不抛到发送路径
-//! - Mutex 中毒 → recover（unwrap_or_else），不 panic
-//! - health 调用自动触发懒加载（首次 health / embed 调用均可初始化 runtime）
+//! 合约：
+//! - health → status=unavailable, downloadable=false, reason=onnx_runtime_removed
+//! - embed_text → Err（调用方 catch 后走 lexical）
+//! - download → 拒绝（不再拉取模型文件）
+//! - remove → 仍清理历史残留文件（若有）
 
 use std::path::{Path, PathBuf};
-use std::sync::{LazyLock, Mutex};
 
-use ort::session::Session;
-use ort::value::Tensor;
 use serde::Serialize;
-use tauri::Emitter;
 use tauri::Manager;
-use tokenizers::tokenizer::{PaddingParams, Tokenizer, TruncationParams};
-use tokenizers::EncodeInput;
-
-// ── 常量 ──
 
 const EMBEDDING_VERSION: &str = "memory-embed-v1";
 const MODEL_ID: &str = "memory-embed-v1";
 const PROVIDER_ID: &str = "mossx-bundled-onnx";
-/// all-MiniLM-L6-v2 hidden_size；模型落地后按真实输出校正。
 const DEFAULT_DIMENSIONS: usize = 384;
-/// 最大输入 token 数，防止超长文本导致 OOM / 推理超时。
-const MAX_SEQ_LENGTH: usize = 256;
+/// 与前端/设置页对齐的稳定 reason code。
+const REASON_ONNX_RUNTIME_REMOVED: &str = "onnx_runtime_removed";
 
-/// HuggingFace 模型下载 URL（all-MiniLM-L6-v2，384 维，~90MB）。
-const HF_ONNX_URL: &str =
-    "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/onnx/model.onnx";
-const HF_TOKENIZER_URL: &str =
-    "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/tokenizer.json";
-/// 下载进度事件名
-const DOWNLOAD_PROGRESS_EVENT: &str = "embed-download-progress";
-
-// ── 数据结构 ──
+const ONNX_FILE_NAME: &str = "memory-embed-v1.onnx";
+const TOKENIZER_FILE_NAME: &str = "tokenizer.json";
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProjectMemoryEmbedHealth {
     pub status: String,
     pub reason: Option<String>,
-    /// 模型文件缺失时 true：前端可以触发下载到 ~/.ccgui/models/embedding/
+    /// 固定 false：当前构建不提供 ONNX 下载/推理。
     pub downloadable: bool,
     pub provider_id: String,
     pub model_id: String,
     pub embedding_version: String,
     pub dimensions: usize,
-    /// 已解析到的 onnx 路径（就绪时）
     pub model_path: Option<String>,
-    /// 标准存放/下载目录（始终给出，便于 UI 展示）
     pub model_dir: Option<String>,
 }
 
@@ -71,54 +49,22 @@ pub struct ProjectMemoryEmbedResult {
     pub model_id: String,
 }
 
+/// 保留结构体以兼容事件契约；当前构建不再 emit 下载进度。
+#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EmbedDownloadProgress {
-    pub phase: String, // "tokenizer" | "model"
+    pub phase: String,
     pub downloaded_bytes: u64,
     pub total_bytes: u64,
 }
 
-// ── 运行时（lazy init · 允许重试） ──
-
-struct EmbeddingRuntime {
-    session: Session,
-    tokenizer: Tokenizer,
-}
-
-static EMBEDDING_RUNTIME: LazyLock<Mutex<Option<EmbeddingRuntime>>> =
-    LazyLock::new(|| Mutex::new(None));
-
-/// 锁守卫：毒化时 recovery（取回内部 Option，不 panic）。
-fn lock_runtime() -> std::sync::MutexGuard<'static, Option<EmbeddingRuntime>> {
-    EMBEDDING_RUNTIME
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
-}
-
-// ── 模型路径探测 ──
-
-const ONNX_FILE_NAME: &str = "memory-embed-v1.onnx";
-const TOKENIZER_FILE_NAME: &str = "tokenizer.json";
-
-/// resource / 开发目录下的相对路径候选（root 为 resource_dir 或 resources/）
-fn model_relative_candidates() -> Vec<&'static str> {
-    vec![
-        "models/embedding/memory-embed-v1.onnx",
-        "resources/models/embedding/memory-embed-v1.onnx",
-        "embedding/memory-embed-v1.onnx",
-    ]
-}
-
-/// 客户端默认家目录下的模型目录：`~/.ccgui/models/embedding/`
-/// （与 project-memory / config 同根；**不是** macOS Application Support bundle id 路径）
 fn embed_model_ccgui_dir() -> Option<PathBuf> {
     crate::app_paths::app_home_dir()
         .ok()
         .map(|home| home.join("models").join("embedding"))
 }
 
-/// 旧版误用的 Tauri app_data 路径（仅迁移用）
 fn embed_model_legacy_app_data_dir(app: &tauri::AppHandle) -> Option<PathBuf> {
     app.path()
         .app_data_dir()
@@ -126,541 +72,19 @@ fn embed_model_legacy_app_data_dir(app: &tauri::AppHandle) -> Option<PathBuf> {
         .map(|d| d.join("models").join("embedding"))
 }
 
-/// 下载与查找的权威目录：始终 `~/.ccgui/models/embedding/`
 fn embed_model_data_dir(app: &tauri::AppHandle) -> Option<PathBuf> {
-    let _ = app; // 保留签名与调用点一致
+    let _ = app;
     embed_model_ccgui_dir()
 }
 
-/// 若旧 Application Support 路径有模型而 ~/.ccgui 没有，复制过去（一次性兼容）。
-fn migrate_legacy_model_dir_if_needed(app: &tauri::AppHandle) {
-    let Some(dest_dir) = embed_model_ccgui_dir() else {
-        return;
-    };
-    let dest_onnx = dest_dir.join(ONNX_FILE_NAME);
-    let dest_tok = dest_dir.join(TOKENIZER_FILE_NAME);
-    if dest_onnx.is_file() && dest_tok.is_file() {
-        return;
-    }
-    let Some(src_dir) = embed_model_legacy_app_data_dir(app) else {
-        return;
-    };
-    let src_onnx = src_dir.join(ONNX_FILE_NAME);
-    let src_tok = src_dir.join(TOKENIZER_FILE_NAME);
-    if !src_onnx.is_file() || !src_tok.is_file() {
-        return;
-    }
-    if let Err(e) = std::fs::create_dir_all(&dest_dir) {
-        log::warn!("[embed] migrate mkdir failed: {}", e);
-        return;
-    }
-    for (src, dest) in [(&src_onnx, &dest_onnx), (&src_tok, &dest_tok)] {
-        if dest.is_file() {
-            continue;
-        }
-        match std::fs::copy(src, dest) {
-            Ok(_) => log::info!(
-                "[embed] migrated {} → {}",
-                src.display(),
-                dest.display()
-            ),
-            Err(e) => log::warn!(
-                "[embed] migrate copy failed {} → {}: {}",
-                src.display(),
-                dest.display(),
-                e
-            ),
-        }
-    }
-}
-
-/// 数据目录扁平布局是否完整（下载目标）。
-fn data_dir_model_pair(app: &tauri::AppHandle) -> Option<(PathBuf, PathBuf)> {
-    migrate_legacy_model_dir_if_needed(app);
-    let dir = embed_model_data_dir(app)?;
-    let onnx = dir.join(ONNX_FILE_NAME);
-    let tokenizer = dir.join(TOKENIZER_FILE_NAME);
-    if onnx.is_file() && tokenizer.is_file() {
-        Some((onnx, tokenizer))
-    } else {
-        None
-    }
-}
-
-fn resolve_model_path(app: &tauri::AppHandle) -> Option<PathBuf> {
-    // 优先级 1：~/.ccgui/models/embedding/（扁平）
-    if let Some((onnx, _)) = data_dir_model_pair(app) {
-        log::info!("[embed] found model at {}", onnx.display());
-        return Some(onnx);
-    }
-
-    // 优先级 2：打包 resource_dir / 开发态仓库 resources
-    let mut roots: Vec<PathBuf> = Vec::new();
-    if let Ok(resource_dir) = app.path().resource_dir() {
-        roots.push(resource_dir);
-    }
-    if let Ok(cwd) = std::env::current_dir() {
-        roots.push(cwd.join("src-tauri").join("resources"));
-        roots.push(cwd.join("resources"));
-        roots.push(cwd.join("resources").join("models").join("embedding"));
-        roots.push(cwd.join("models").join("embedding"));
-    }
-
-    for root in roots {
-        let flat = root.join(ONNX_FILE_NAME);
-        if flat.is_file() {
-            let tok = root.join(TOKENIZER_FILE_NAME);
-            if tok.is_file() {
-                log::info!("[embed] found model at {}", flat.display());
-                return Some(flat);
-            }
-        }
-        for rel in model_relative_candidates() {
-            let candidate = root.join(rel);
-            if candidate.is_file() {
-                let parent = candidate.parent()?;
-                if parent.join(TOKENIZER_FILE_NAME).is_file() {
-                    log::info!("[embed] found model at {}", candidate.display());
-                    return Some(candidate);
-                }
-            }
-        }
-    }
-    None
-}
-
-/// 模型是否存在于标准下载目录（~/.ccgui/...）。
-fn model_exists_in_data_dir(app: &tauri::AppHandle) -> bool {
-    data_dir_model_pair(app).is_some()
-}
-
-fn tokenizer_path(model_dir: &Path) -> PathBuf {
-    model_dir.join("tokenizer.json")
-}
-
-// ── 加载 ──
-
-fn try_load_runtime(model_path: &Path) -> Option<EmbeddingRuntime> {
-    let model_dir = model_path.parent()?;
-    let tok_path = tokenizer_path(model_dir);
-
-    if !tok_path.is_file() {
-        log::warn!("[embed] tokenizer.json not found at {}", tok_path.display());
-        return None;
-    }
-
-    let mut tokenizer = match Tokenizer::from_file(&tok_path) {
-        Ok(t) => t,
-        Err(e) => {
-            log::warn!("[embed] failed to load tokenizer: {}", e);
-            return None;
-        }
-    };
-
-    // 防御：截断过长文本 + padding，避免 OOM / 推理超时
-    let _ = tokenizer.with_truncation(Some(TruncationParams {
-        max_length: MAX_SEQ_LENGTH,
-        strategy: tokenizers::TruncationStrategy::LongestFirst,
-        direction: tokenizers::TruncationDirection::Right,
-        stride: 0,
-    }));
-    let _ = tokenizer.with_padding(Some(PaddingParams {
-        strategy: tokenizers::PaddingStrategy::BatchLongest,
-        ..Default::default()
-    }));
-
-    let session: Session = match Session::builder() {
-        Ok(mut b) => match b.commit_from_file(model_path) {
-            Ok(s) => s,
-            Err(e) => {
-                log::warn!("[embed] commit_from_file failed: {}", e);
-                return None;
-            }
-        },
-        Err(e) => {
-            log::warn!("[embed] Session::builder failed: {}", e);
-            return None;
-        }
-    };
-
-    log::info!(
-        "[embed] runtime ready: model={} inputs={} outputs={}",
-        model_path.display(),
-        session.inputs().len(),
-        session.outputs().len(),
-    );
-
-    Some(EmbeddingRuntime { session, tokenizer })
-}
-
-fn ensure_runtime(app: &tauri::AppHandle) -> Result<(), String> {
-    // 快速路径：已加载直接返回（不持锁做 I/O）
-    {
-        let guard = lock_runtime();
-        if guard.is_some() {
-            return Ok(());
-        }
-    } // 释放锁
-
-    let model_path =
-        resolve_model_path(app).ok_or_else(|| "model_resource_missing".to_string())?;
-
-    // 在锁外完成 I/O 重量级加载
-    let loaded = try_load_runtime(&model_path);
-
-    // 写入缓存：只有 None → Some 才更新；已经是 Some 则保留（先到先得）
-    let mut guard = lock_runtime();
-    if guard.is_none() {
-        *guard = loaded;
-    }
-
-    match guard.as_ref() {
-        Some(_) => Ok(()),
-        None => Err("runtime_load_failed".to_string()),
-    }
-}
-
-// ── 推理 ──
-
-/// mean pooling + L2 normalize（对标 sentence-transformers）
-fn mean_pool(
-    token_embeddings: &[f32],
-    attention_mask: &[i64],
-    seq_len: usize,
-    hidden_size: usize,
-) -> Vec<f32> {
-    let mut result = vec![0.0f32; hidden_size];
-    let mut mask_sum = 0.0f32;
-
-    for i in 0..seq_len {
-        let mask = attention_mask[i] as f32;
-        if mask == 0.0 {
-            continue;
-        }
-        mask_sum += mask;
-        let offset = i * hidden_size;
-        for j in 0..hidden_size {
-            result[j] += token_embeddings[offset + j] * mask;
-        }
-    }
-
-    if mask_sum > 0.0 {
-        for v in result.iter_mut() {
-            *v /= mask_sum;
-        }
-    }
-
-    // L2 normalize
-    let norm: f32 = result.iter().map(|v| v * v).sum::<f32>().sqrt();
-    if norm > 0.0 {
-        for v in result.iter_mut() {
-            *v /= norm;
-        }
-    }
-
-    result
-}
-
-fn run_embed(text: &str, rt: &mut EmbeddingRuntime) -> Result<Vec<f32>, String> {
-    let input: EncodeInput = EncodeInput::Single(text.into());
-    let encoding = rt
-        .tokenizer
-        .encode(input, true)
-        .map_err(|e| format!("tokenize error: {}", e))?;
-
-    let seq_len = encoding.len();
-    if seq_len == 0 {
-        return Err("empty tokenization".to_string());
-    }
-
-    let token_ids: Vec<i64> = encoding.get_ids().iter().map(|&id| id as i64).collect();
-    let attention_mask: Vec<i64> = encoding
-        .get_attention_mask()
-        .iter()
-        .map(|&m| m as i64)
-        .collect();
-
-    let input_count = rt.session.inputs().len();
-    let shape = [1i64, seq_len as i64];
-
-    let id_tensor = Tensor::from_array((shape.to_vec(), token_ids.into_boxed_slice()))
-        .map_err(|e| format!("input_ids tensor: {}", e))?;
-
-    let mask_tensor =
-        Tensor::from_array((shape.to_vec(), attention_mask.clone().into_boxed_slice()))
-            .map_err(|e| format!("attention_mask tensor: {}", e))?;
-
-    let outputs = if input_count >= 3 {
-        let type_ids: Vec<i64> = vec![0i64; seq_len];
-        let type_tensor = Tensor::from_array((shape.to_vec(), type_ids.into_boxed_slice()))
-            .map_err(|e| format!("type_ids tensor: {}", e))?;
-
-        rt.session
-            .run(ort::inputs![id_tensor, mask_tensor, type_tensor])
-            .map_err(|e| format!("inference error (3 inputs): {}", e))?
-    } else if input_count == 2 {
-        rt.session
-            .run(ort::inputs![id_tensor, mask_tensor])
-            .map_err(|e| format!("inference error (2 inputs): {}", e))?
-    } else {
-        return Err(format!(
-            "unexpected input count {} (expected 2 or 3)",
-            input_count
-        ));
-    };
-
-    // 取第一个输出（通常是 last_hidden_state）
-    let output = outputs.values().next().ok_or("no output tensor")?;
-
-    let output_array = output
-        .try_extract_array::<f32>()
-        .map_err(|e| format!("extract output: {}", e))?;
-
-    let output_data = output_array
-        .as_slice()
-        .ok_or("tensor memory not contiguous")?;
-
-    let hidden_size = DEFAULT_DIMENSIONS;
-    if output_data.len() != seq_len * hidden_size {
-        return Err(format!(
-            "output size mismatch: got {} expected {}×{}",
-            output_data.len(),
-            seq_len,
-            hidden_size,
-        ));
-    }
-
-    let pooled = mean_pool(output_data, &attention_mask, seq_len, hidden_size);
-    Ok(pooled)
-}
-
-// ── Tauri commands ──
-
-fn health_from_runtime(app: &tauri::AppHandle) -> ProjectMemoryEmbedHealth {
-    let model_dir_str = embed_model_data_dir(app).map(|p| p.display().to_string());
-    let model_path = resolve_model_path(app);
-    let model_path_str = model_path.as_ref().map(|p| p.display().to_string());
-    let model_found = model_path.is_some();
-
-    // health 调用也触发懒加载，避免前端先调 health 看到 unavailable 就永久走 lexical
-    let runtime_ok = if model_found {
-        ensure_runtime(app).is_ok()
-    } else {
-        false
-    };
-
-    // downloadable：标准 ~/.ccgui 目录尚无完整模型 → 可触发下载
-    let on_disk = model_exists_in_data_dir(app);
-    let downloadable = !on_disk && !model_found;
-
-    ProjectMemoryEmbedHealth {
-        status: if runtime_ok {
-            "available"
-        } else if on_disk && !runtime_ok {
-            // 已下载但加载失败（路径/ORT/模型不兼容）
-            "error"
-        } else {
-            "unavailable"
-        }
-        .to_string(),
-        reason: if !model_found && !on_disk {
-            Some("model_resource_missing".to_string())
-        } else if !runtime_ok {
-            Some("runtime_load_failed".to_string())
-        } else {
-            None
-        },
-        downloadable,
-        provider_id: PROVIDER_ID.to_string(),
-        model_id: MODEL_ID.to_string(),
-        embedding_version: EMBEDDING_VERSION.to_string(),
-        dimensions: DEFAULT_DIMENSIONS,
-        model_path: model_path_str,
-        model_dir: model_dir_str,
-    }
-}
-
-#[tauri::command]
-pub(crate) async fn project_memory_embed_health(
-    app: tauri::AppHandle,
-) -> Result<ProjectMemoryEmbedHealth, String> {
-    Ok(health_from_runtime(&app))
-}
-
-#[tauri::command]
-pub(crate) async fn project_memory_embed_text(
-    app: tauri::AppHandle,
-    text: String,
-) -> Result<ProjectMemoryEmbedResult, String> {
-    ensure_runtime(&app)?;
-
-    let mut guard = lock_runtime();
-    let rt = guard
-        .as_mut()
-        .ok_or_else(|| "runtime_not_loaded".to_string())?;
-
-    let vector = run_embed(&text, rt)?;
-
-    Ok(ProjectMemoryEmbedResult {
-        vector,
-        dimensions: DEFAULT_DIMENSIONS,
-        embedding_version: EMBEDDING_VERSION.to_string(),
-        model_id: MODEL_ID.to_string(),
-    })
-}
-
-// ── 自动下载 ──
-
-/// 流式下载文件到目标路径（atomic：先写 .download 临时文件，成功后 rename）。
-/// 临时文件路径（跨平台：不用 with_extension，避免 `file.onnx` → 意外后缀）
 fn download_tmp_path(dest: &Path) -> PathBuf {
     let file_name = dest
         .file_name()
         .and_then(|s| s.to_str())
         .unwrap_or("download.bin");
-    // stem + .download：memory-embed-v1.onnx → memory-embed-v1.onnx.download
     dest.with_file_name(format!("{file_name}.download"))
 }
 
-async fn download_file(
-    url: &str,
-    dest: &Path,
-    phase: &str,
-    app: &tauri::AppHandle,
-) -> Result<(), String> {
-    // 跟随重定向；超时拉长以兼容慢网（约 90MB 模型）
-    let client = reqwest::Client::builder()
-        .redirect(reqwest::redirect::Policy::limited(10))
-        .timeout(std::time::Duration::from_secs(600))
-        .build()
-        .map_err(|e| format!("http client: {}", e))?;
-
-    let response = client
-        .get(url)
-        .send()
-        .await
-        .map_err(|e| format!("download request failed: {}", e))?;
-
-    if !response.status().is_success() {
-        return Err(format!(
-            "download http {}: {}",
-            response.status(),
-            url
-        ));
-    }
-
-    let total = response.content_length().unwrap_or(0);
-    let tmp = download_tmp_path(dest);
-
-    if let Some(parent) = tmp.parent() {
-        std::fs::create_dir_all(parent).map_err(|e| format!("mkdir: {}", e))?;
-    }
-
-    // 清理上次失败残留
-    let _ = std::fs::remove_file(&tmp);
-
-    let mut file = tokio::fs::File::create(&tmp)
-        .await
-        .map_err(|e| format!("create tmp file: {}", e))?;
-
-    let mut stream = response.bytes_stream();
-    let mut downloaded: u64 = 0;
-
-    use futures_util::StreamExt;
-    while let Some(chunk) = stream.next().await {
-        let chunk = chunk.map_err(|e| format!("download chunk: {}", e))?;
-        tokio::io::AsyncWriteExt::write_all(&mut file, &chunk)
-            .await
-            .map_err(|e| format!("write chunk: {}", e))?;
-        downloaded += chunk.len() as u64;
-
-        let _ = app.emit(
-            DOWNLOAD_PROGRESS_EVENT,
-            EmbedDownloadProgress {
-                phase: phase.to_string(),
-                downloaded_bytes: downloaded,
-                total_bytes: total,
-            },
-        );
-    }
-
-    tokio::io::AsyncWriteExt::flush(&mut file)
-        .await
-        .map_err(|e| format!("flush: {}", e))?;
-    // 关闭文件再 rename（Windows 上句柄未关可能导致 rename 失败）
-    drop(file);
-
-    // 目标已存在则先删（Windows replace 更稳）
-    if dest.exists() {
-        let _ = std::fs::remove_file(dest);
-    }
-    std::fs::rename(&tmp, dest).map_err(|e| format!("rename: {}", e))?;
-
-    log::info!(
-        "[embed] downloaded {} ({:.1} MB) to {}",
-        phase,
-        downloaded as f64 / 1_000_000.0,
-        dest.display(),
-    );
-
-    Ok(())
-}
-
-#[tauri::command]
-pub(crate) async fn project_memory_embed_download(
-    app: tauri::AppHandle,
-) -> Result<ProjectMemoryEmbedHealth, String> {
-    let model_dir = embed_model_data_dir(&app)
-        .ok_or_else(|| "app_data_dir_unavailable".to_string())?;
-    std::fs::create_dir_all(&model_dir).map_err(|e| format!("mkdir model dir: {}", e))?;
-
-    let onnx_path = model_dir.join(ONNX_FILE_NAME);
-    let tokenizer_path = model_dir.join(TOKENIZER_FILE_NAME);
-
-    // 已存在则跳过下载，直接加载
-    let need_onnx = !onnx_path.is_file();
-    let need_tokenizer = !tokenizer_path.is_file();
-
-    if !need_onnx && !need_tokenizer {
-        log::info!(
-            "[embed] model already at {}, reloading runtime",
-            model_dir.display()
-        );
-    }
-
-    if need_tokenizer {
-        log::info!("[embed] downloading tokenizer (0.5MB)...");
-        download_file(HF_TOKENIZER_URL, &tokenizer_path, "tokenizer", &app).await?;
-    }
-
-    if need_onnx {
-        log::info!("[embed] downloading ONNX model (~90MB)...");
-        download_file(HF_ONNX_URL, &onnx_path, "model", &app).await?;
-    }
-
-    // 下载完成 → 重置 runtime 缓存，强制用数据目录路径重新加载
-    __reset_embedding_runtime_for_tests();
-
-    // 强制 ensure 一次，避免 health 只看路径不加载
-    if let Err(e) = ensure_runtime(&app) {
-        log::warn!("[embed] post-download ensure_runtime failed: {}", e);
-        return Ok(ProjectMemoryEmbedHealth {
-            status: "error".to_string(),
-            reason: Some(e),
-            downloadable: false,
-            provider_id: PROVIDER_ID.to_string(),
-            model_id: MODEL_ID.to_string(),
-            embedding_version: EMBEDDING_VERSION.to_string(),
-            dimensions: DEFAULT_DIMENSIONS,
-            model_path: Some(onnx_path.display().to_string()),
-            model_dir: Some(model_dir.display().to_string()),
-        });
-    }
-
-    Ok(health_from_runtime(&app))
-}
-
-/// 删除指定目录下的模型文件（onnx / tokenizer / 临时 .download）。
 fn remove_model_files_in_dir(model_dir: &Path) -> Result<(), String> {
     if !model_dir.exists() {
         return Ok(());
@@ -672,45 +96,70 @@ fn remove_model_files_in_dir(model_dir: &Path) -> Result<(), String> {
 
     for path in [&onnx_path, &tokenizer_path, &tmp_onnx, &tmp_tok] {
         if path.exists() {
-            std::fs::remove_file(path).map_err(|e| {
-                format!("remove {}: {}", path.display(), e)
-            })?;
+            std::fs::remove_file(path)
+                .map_err(|e| format!("remove {}: {}", path.display(), e))?;
             log::info!("[embed] removed {}", path.display());
         }
     }
-    // 目录空则尝试删除（非致命；Windows 上目录非空会失败，可忽略）
     let _ = std::fs::remove_dir(model_dir);
     Ok(())
 }
 
-/// 删除本地语义模型（~/.ccgui + 旧 Application Support 副本）并卸载 runtime。
+fn disabled_health(app: &tauri::AppHandle) -> ProjectMemoryEmbedHealth {
+    ProjectMemoryEmbedHealth {
+        status: "unavailable".to_string(),
+        reason: Some(REASON_ONNX_RUNTIME_REMOVED.to_string()),
+        downloadable: false,
+        provider_id: PROVIDER_ID.to_string(),
+        model_id: MODEL_ID.to_string(),
+        embedding_version: EMBEDDING_VERSION.to_string(),
+        dimensions: DEFAULT_DIMENSIONS,
+        model_path: None,
+        model_dir: embed_model_data_dir(app).map(|p| p.display().to_string()),
+    }
+}
+
+#[tauri::command]
+pub(crate) async fn project_memory_embed_health(
+    app: tauri::AppHandle,
+) -> Result<ProjectMemoryEmbedHealth, String> {
+    Ok(disabled_health(&app))
+}
+
+#[tauri::command]
+pub(crate) async fn project_memory_embed_text(
+    _app: tauri::AppHandle,
+    _text: String,
+) -> Result<ProjectMemoryEmbedResult, String> {
+    Err(REASON_ONNX_RUNTIME_REMOVED.to_string())
+}
+
+#[tauri::command]
+pub(crate) async fn project_memory_embed_download(
+    app: tauri::AppHandle,
+) -> Result<ProjectMemoryEmbedHealth, String> {
+    log::info!(
+        "[embed] download rejected: ONNX runtime removed to restore Intel macOS packaging"
+    );
+    Ok(disabled_health(&app))
+}
+
+/// 清理历史模型残留（用户目录 / 旧 app_data），便于磁盘回收。
 #[tauri::command]
 pub(crate) async fn project_memory_embed_remove(
     app: tauri::AppHandle,
 ) -> Result<ProjectMemoryEmbedHealth, String> {
-    __reset_embedding_runtime_for_tests();
-
-    // 1) 标准路径 ~/.ccgui/models/embedding
     if let Some(model_dir) = embed_model_data_dir(&app) {
         remove_model_files_in_dir(&model_dir)?;
     }
-
-    // 2) 旧 Tauri app_data 副本（否则 migrate 会把文件再拷回 ~/.ccgui）
     if let Some(legacy_dir) = embed_model_legacy_app_data_dir(&app) {
         if let Err(e) = remove_model_files_in_dir(&legacy_dir) {
             log::warn!("[embed] remove legacy dir failed: {}", e);
         }
     }
-
-    Ok(health_from_runtime(&app))
+    Ok(disabled_health(&app))
 }
 
-// ── 测试辅助（依赖注入口） ──
-
-/// 仅测试用：清空缓存的 runtime（下次调用会重新加载）。
+/// 兼容测试辅助：当前无 runtime 缓存，no-op。
 #[allow(dead_code)]
-pub(crate) fn __reset_embedding_runtime_for_tests() {
-    if let Ok(mut guard) = EMBEDDING_RUNTIME.lock() {
-        *guard = None;
-    }
-}
+pub(crate) fn __reset_embedding_runtime_for_tests() {}

--- a/src/features/project-memory/hooks/useProjectMemoryEmbedModel.test.ts
+++ b/src/features/project-memory/hooks/useProjectMemoryEmbedModel.test.ts
@@ -1,6 +1,6 @@
 /**
  * useProjectMemoryEmbedModel 状态机测试。
- * 覆盖：health 探测 → missing/ready；下载 → 进度事件 → ready；下载失败 → error。
+ * 覆盖：disabled / missing / ready；下载进度；失败；remove。
  */
 // @vitest-environment jsdom
 import { act, renderHook, waitFor } from "@testing-library/react";
@@ -38,6 +38,23 @@ describe("useProjectMemoryEmbedModel", () => {
     healthMock.mockReset();
     downloadMock.mockReset();
     removeMock.mockReset();
+  });
+
+  it("ONNX runtime 已移除 → status=disabled", async () => {
+    healthMock.mockResolvedValue({
+      status: "unavailable",
+      reason: "onnx_runtime_removed",
+      downloadable: false,
+      modelDir: "/home/u/.ccgui/models/embedding",
+    });
+    const { result } = renderHook(() => useProjectMemoryEmbedModel());
+    await waitFor(() => expect(result.current.status).not.toBeNull());
+    expect(result.current.status).toEqual({
+      state: "disabled",
+      reason: "onnx_runtime_removed",
+      modelDir: "/home/u/.ccgui/models/embedding",
+    });
+    expect(result.current.modelDir).toBe("/home/u/.ccgui/models/embedding");
   });
 
   it("模型缺失且可下载 → status=missing", async () => {
@@ -126,7 +143,7 @@ describe("useProjectMemoryEmbedModel", () => {
     });
   });
 
-  it("remove 成功 → status=missing downloadable", async () => {
+  it("remove 成功 → status=disabled（当前构建无 runtime）", async () => {
     healthMock.mockResolvedValue({
       status: "available",
       downloadable: false,
@@ -135,7 +152,8 @@ describe("useProjectMemoryEmbedModel", () => {
     });
     removeMock.mockResolvedValue({
       status: "unavailable",
-      downloadable: true,
+      reason: "onnx_runtime_removed",
+      downloadable: false,
       modelDir: "/home/u/.ccgui/models/embedding",
     });
 
@@ -148,8 +166,8 @@ describe("useProjectMemoryEmbedModel", () => {
 
     expect(removeMock).toHaveBeenCalledOnce();
     expect(result.current.status).toEqual({
-      state: "missing",
-      downloadable: true,
+      state: "disabled",
+      reason: "onnx_runtime_removed",
       modelDir: "/home/u/.ccgui/models/embedding",
     });
   });

--- a/src/features/project-memory/hooks/useProjectMemoryEmbedModel.ts
+++ b/src/features/project-memory/hooks/useProjectMemoryEmbedModel.ts
@@ -1,6 +1,7 @@
 /**
- * 本地语义模型（ONNX embedding）下载状态控制器。
- * 落盘：`~/.ccgui/models/embedding/`；状态机 missing → downloading → ready / error。
+ * 本地语义模型状态控制器。
+ * 当前构建已移除 ONNX Runtime（Intel macOS 打包兼容）：health 为 disabled。
+ * 状态机：disabled | missing → downloading → ready / error。
  */
 import { useCallback, useEffect, useState } from "react";
 import { projectMemoryEmbedHealth } from "../../../services/tauri/projectMemoryEmbed";
@@ -12,6 +13,11 @@ import {
 } from "../utils/projectMemoryEmbeddingProvider";
 
 export type ProjectMemoryEmbedModelStatus =
+  | {
+      state: "disabled";
+      reason: string;
+      modelDir?: string | null;
+    }
   | { state: "missing"; downloadable: boolean; modelDir?: string | null }
   | {
       state: "downloading";
@@ -40,6 +46,8 @@ type EmbedHealthLike = {
   modelDir?: string | null;
 };
 
+const ONNX_RUNTIME_REMOVED = "onnx_runtime_removed";
+
 function toStatus(health: EmbedHealthLike): ProjectMemoryEmbedModelStatus {
   if (health.status === "available") {
     return {
@@ -54,6 +62,17 @@ function toStatus(health: EmbedHealthLike): ProjectMemoryEmbedModelStatus {
       error: health.reason ?? "unknown_error",
       modelDir: health.modelDir,
       modelPath: health.modelPath,
+    };
+  }
+  // 构建未链接 ONNX：不可下载，诚实展示 disabled
+  if (
+    health.reason === ONNX_RUNTIME_REMOVED ||
+    (health.status === "unavailable" && health.downloadable !== true)
+  ) {
+    return {
+      state: "disabled",
+      reason: health.reason ?? ONNX_RUNTIME_REMOVED,
+      modelDir: health.modelDir,
     };
   }
   return {

--- a/src/features/project-memory/utils/projectMemoryEmbeddingProvider.ts
+++ b/src/features/project-memory/utils/projectMemoryEmbeddingProvider.ts
@@ -1,6 +1,7 @@
 /**
- * 生产侧 ProjectMemoryEmbeddingProvider（方案 A：应用内 ONNX）。
- * health unavailable 时 retrieve 走 lexical；禁止引导用户安装第三方。
+ * 生产侧 ProjectMemoryEmbeddingProvider。
+ * 当前构建未链接 ONNX Runtime（Intel macOS 打包兼容），health 恒为 unavailable → lexical。
+ * 命令面仍保留，便于后续恢复推理而不改前端 contract。
  */
 import {
   projectMemoryEmbedDownload,

--- a/src/features/settings/components/settings-view/sections/EmbedModelSection.tsx
+++ b/src/features/settings/components/settings-view/sections/EmbedModelSection.tsx
@@ -37,10 +37,12 @@ export function EmbedModelSection({ active, t }: EmbedModelSectionProps) {
 
   const downloading = status?.state === "downloading";
   const ready = status?.state === "ready";
+  const disabled = status?.state === "disabled";
   const progress = downloading ? status : null;
   const displayPath = modelPath || modelDir;
   const semanticToggleOn = retrievalPref === "semantic";
-  const semanticToggleDisabled = !ready && !downloading;
+  // 无 ONNX runtime 时禁止开启语义；下载中也不切换
+  const semanticToggleDisabled = disabled || (!ready && !downloading);
 
   const onToggleSemantic = (next: boolean) => {
     const pref: SemanticRetrievalPreference = next ? "semantic" : "lexical";
@@ -101,6 +103,11 @@ export function EmbedModelSection({ active, t }: EmbedModelSectionProps) {
                 </div>
                 <div className="settings-help">
                   {ready && t("settings.modelReady")}
+                  {disabled &&
+                    t("settings.memoryEmbedRuntimeDisabled", {
+                      defaultValue:
+                        "当前版本未包含本地语义推理运行时，记忆参考使用关键词匹配。",
+                    })}
                   {status.state === "missing" && t("settings.modelNotDownloaded")}
                   {downloading && t("settings.modelDownloading")}
                   {status.state === "error" &&
@@ -194,6 +201,14 @@ export function EmbedModelSection({ active, t }: EmbedModelSectionProps) {
                 {t("settings.memoryEmbedNotDownloadable")}
               </div>
             )}
+            {disabled ? (
+              <div className="settings-help">
+                {t("settings.memoryEmbedRuntimeDisabledHint", {
+                  defaultValue:
+                    "已移除 ONNX Runtime 以恢复 Intel macOS 打包；语义向量检索将在后续可跨平台方案中恢复。",
+                })}
+              </div>
+            ) : null}
           </div>
         )}
 

--- a/src/i18n/locales/en/settings.ts
+++ b/src/i18n/locales/en/settings.ts
@@ -1124,18 +1124,23 @@ const settings = {
       "Inject: memories are prior context for the current user message only; the user bubble shows original text; failures never block send.",
     memoryEmbedModelTitle: "Local semantic model",
     memoryEmbedModelDesc:
-      "Download ~90MB semantic model for on-device vector matching. Files live under .ccgui/models/embedding/ in the user home directory (the absolute path for this machine is shown below as Storage location). Never uploaded.",
+      "Memory reference uses keyword matching by default. On-device ONNX semantic vectors were removed from this build to restore Intel macOS packaging; a cross-platform approach will return later.",
     memoryEmbedPhaseTokenizer: "Downloading tokenizer…",
     memoryEmbedPhaseModel: "Downloading semantic model…",
     memoryEmbedNotDownloadable: "Not downloadable in this environment.",
+    memoryEmbedRuntimeDisabled:
+      "This build does not include a local semantic runtime; memory reference uses keyword matching.",
+    memoryEmbedRuntimeDisabledHint:
+      "ONNX Runtime was removed to restore Intel macOS packaging; semantic vector retrieval will return with a cross-platform solution.",
     memoryEmbedModelPath: "Storage location",
     memoryEmbedDeleteModel: "Delete model",
     memoryEmbedDeleteConfirm:
       "Delete the local semantic model? Memory reference will fall back to keyword matching. You can download again anytime.",
     memorySemanticRetrievalToggle: "Use semantic model for retrieval",
     memorySemanticRetrievalToggleDesc:
-      "When off, retrieval uses keyword matching even if the model is installed. You can turn it back on anytime.",
-    memorySemanticRetrievalNeedModel: "Download and ready the model first",
+      "No semantic runtime in this build; the switch stays off until a model is available.",
+    memorySemanticRetrievalNeedModel:
+      "Semantic model is not available in this build",
     memorySemanticRetrievalLexicalHint: "Current: keyword text retrieval",
     memorySemanticRetrievalSemanticHint:
       "Current: semantic model retrieval (hybrid when available)",

--- a/src/i18n/locales/zh/settings.ts
+++ b/src/i18n/locales/zh/settings.ts
@@ -1056,18 +1056,22 @@ const settings = {
       "注入规则：记忆仅作当前用户原文的参考（prior context），用户气泡只显示原文；注入失败不阻塞发送。",
     memoryEmbedModelTitle: "本地语义模型",
     memoryEmbedModelDesc:
-      "下载约 90MB 语义模型后，记忆参考使用设备端向量匹配提升准确度。模型落在本机用户主目录 .ccgui/models/embedding/ 下（下方「存储位置」为当前机器实际绝对路径），不会上传。",
+      "记忆参考默认使用关键词匹配。设备端语义向量（ONNX）已从本版本移除以保障 Intel macOS 打包，后续将以可跨平台方案恢复。",
     memoryEmbedPhaseTokenizer: "下载分词器中…",
     memoryEmbedPhaseModel: "下载语义模型中…",
     memoryEmbedNotDownloadable: "当前环境暂不可下载。",
+    memoryEmbedRuntimeDisabled:
+      "当前版本未包含本地语义推理运行时，记忆参考使用关键词匹配。",
+    memoryEmbedRuntimeDisabledHint:
+      "已移除 ONNX Runtime 以恢复 Intel macOS 打包；语义向量检索将在后续可跨平台方案中恢复。",
     memoryEmbedModelPath: "存储位置",
     memoryEmbedDeleteModel: "删除模型",
     memoryEmbedDeleteConfirm:
       "确定删除本地语义模型？删除后记忆参考将回退为关键词匹配，可随时重新下载。",
     memorySemanticRetrievalToggle: "检索时使用语义模型",
     memorySemanticRetrievalToggleDesc:
-      "关闭后即使已下载模型，也只用默认文本检索。可随时再打开。",
-    memorySemanticRetrievalNeedModel: "请先下载并就绪语义模型",
+      "当前构建无语义运行时；开关在模型可用前保持关闭。",
+    memorySemanticRetrievalNeedModel: "当前版本暂不可用语义模型",
     memorySemanticRetrievalLexicalHint: "当前：默认文本检索（关键词）",
     memorySemanticRetrievalSemanticHint: "当前：语义模型检索（可用时 hybrid）",
     memoryReferencePreviewTitle: "开启后效果示意",


### PR DESCRIPTION
Remove the on-device ONNX embedding stack so Intel macOS builds can ship again. ort-sys does not provide prebuilt binaries for x86_64-apple-darwin, which blocked packaging when ort/tokenizers were linked into the Tauri backend.

What changed:
- Drop ort, tokenizers, and futures-util from src-tauri/Cargo.toml and refresh Cargo.lock (large transitive graph pruned).
- Replace project_memory/embed.rs runtime with a compatible command surface: health returns unavailable / downloadable=false / reason=onnx_runtime_removed; embed_text and download fail closed; remove still cleans residual model files under ~/.ccgui.
- Remove build.rs warn_embedding_model_missing() compile-time checks.
- Frontend: map onnx_runtime_removed to a disabled model state; keep semantic retrieval toggle off; update EmbedModelSection UX and EN/ZH settings copy; extend useProjectMemoryEmbedModel tests.

Why:
- Packaging correctness for Intel macOS outweighs shipping semantic vectors that cannot be linked on that target.
- Preserve the existing Tauri command contract so a future cross-platform embedding runtime can be reintroduced without frontend API churn.

Impact:
- Memory reference uses lexical/keyword retrieval by default on all platforms in this build.
- No model download or local ONNX inference until a portable runtime returns.
- Installer size and native dependency surface shrink by dropping ORT.

## 摘要

<!-- 用 1–3 句说明改了什么、为什么 -->

## 变更类型

- [ ] feature
- [ ] fix
- [ ] refactor / 结构治理
- [ ] docs
- [ ] chore / CI

## AppShell / Domain 状态（若涉及 `src/app-shell/**` 或 shell domain bag）

- [ ] 新状态已写入 **owner domain**（`APP_SHELL_DOMAIN_CONTEXT_OWNED_KEYS` + builder/assembly）
- [ ] 未向 `workspaceNavigation` / 无主 bag 尾塞 key
- [ ] 生产路径使用 `selectAppShellDomainBag`（未新增 full-flatten / Legacy adapt）
- [ ] 已跑：`npm run check:app-shell:governance`

> 规则入口：`AGENTS.md` → AppShell Structure Gate；计划：`docs/plans/2026-08-11-app-shell-cohesion-optimization.md`

## 测试

- [ ] 相关 unit / vitest
- [ ] `npm run check:runtime-contracts`（含 app-shell governance）
- [ ] 其它受影响 gate：

## 风险与回滚

- 风险：
- 回滚：按 commit / PR revert
