### PR TITLE
fix(macos): stabilize nested codesign by deferring sign and gating de…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,12 +174,16 @@ jobs:
 
       - name: Build app bundle
         env:
-          APPLE_SIGNING_IDENTITY: ${{ vars.CODESIGN_IDENTITY }}
+          # Intentionally omit APPLE_SIGNING_IDENTITY so Tauri does not codesign
+          # mid-bundle. Multi-bin nested signing order is flaky on Intel runners
+          # (cc_gui_daemon subcomponent). We re-sign inside-out in the next step.
           NODE_OPTIONS: "--max-old-space-size=8192"
         run: |
           set -euo pipefail
           # TAURI_SIGNING_PRIVATE_KEY expects base64-encoded minisign key
           export TAURI_SIGNING_PRIVATE_KEY="$TAURI_SIGNING_PRIVATE_KEY_B64"
+          # Ensure no Apple identity leaks in from the job env.
+          unset APPLE_SIGNING_IDENTITY || true
           npm run tauri -- build --bundles app
 
       - name: Bundle OpenSSL and re-sign

--- a/package.json
+++ b/package.json
@@ -80,9 +80,9 @@
     "typecheck": "tsc --noEmit",
     "preview": "vite preview",
     "tauri": "tauri",
-    "tauri:dev:hot": "tauri dev --config src-tauri/tauri.dev.conf.json",
+    "tauri:dev:hot": "tauri dev --config src-tauri/tauri.dev.conf.json --features debug-bin",
     "tauri:dev:isolated": "npm run doctor:strict && node scripts/tauri-dev-isolated.mjs",
-    "tauri:dev": "npm run doctor:strict && tauri dev --config src-tauri/tauri.dev.conf.json",
+    "tauri:dev": "npm run doctor:strict && tauri dev --config src-tauri/tauri.dev.conf.json --features debug-bin",
     "tauri:build": "npm run doctor:strict && tauri build",
     "tauri:dev:win": "npm run doctor:win && tauri dev --config src-tauri/tauri.windows.conf.json",
     "tauri:build:win": "npm run doctor:win && tauri build --config src-tauri/tauri.windows.conf.json"

--- a/scripts/build-platform.mjs
+++ b/scripts/build-platform.mjs
@@ -208,8 +208,10 @@ async function buildMacOS(arch, options = {}) {
   exec(`rm -f ${TAURI_DIR}/target/${target}/release/cc-gui`, { ignoreError: true });
   exec(`rm -rf ${TAURI_DIR}/target/${target}/release/bundle`, { ignoreError: true });
 
-  // Build the app
-  const buildEnv = arch === "arm64" ? "" : `X86_64_APPLE_DARWIN_OPENSSL_DIR=${CONFIG.openssl.x64} `;
+  // Build the app without Apple codesign mid-bundle (nested helper order is flaky
+  // on Intel). Post-sign via macos-fix-openssl.sh / explicit codesign below.
+  const opensslEnv = arch === "arm64" ? "" : `X86_64_APPLE_DARWIN_OPENSSL_DIR=${CONFIG.openssl.x64} `;
+  const buildEnv = `${opensslEnv}env -u APPLE_SIGNING_IDENTITY `;
   exec(`${buildEnv}npm run tauri -- build --target ${target} --bundles app`);
 
   // For universal builds, merge daemon binary
@@ -256,13 +258,15 @@ async function buildMacOS(arch, options = {}) {
         exec(`install_name_tool -change ${CONFIG.openssl.arm64}/lib/libcrypto.3.dylib @rpath/libcrypto.3.dylib "${binPath}"`, { ignoreError: true });
       }
 
-      // Sign all components
+      // Inside-out: dylibs → helpers → main → .app
       const identity = CONFIG.codesignIdentity;
       const entitlements = CONFIG.entitlements;
-      exec(`codesign --force --options runtime --sign "${identity}" --entitlements "${entitlements}" --timestamp "${frameworksPath}/libcrypto.3.dylib"`);
-      exec(`codesign --force --options runtime --sign "${identity}" --entitlements "${entitlements}" --timestamp "${frameworksPath}/libssl.3.dylib"`);
-      exec(`codesign --force --options runtime --sign "${identity}" --entitlements "${entitlements}" --timestamp "${bundlePath}/Contents/MacOS/cc-gui"`);
+      const debugBin = join(bundlePath, "Contents/MacOS/cc-gui-debug");
+      exec(`rm -f "${debugBin}"`, { ignoreError: true });
+      exec(`codesign --force --options runtime --sign "${identity}" --timestamp "${frameworksPath}/libcrypto.3.dylib"`);
+      exec(`codesign --force --options runtime --sign "${identity}" --timestamp "${frameworksPath}/libssl.3.dylib"`);
       exec(`codesign --force --options runtime --sign "${identity}" --entitlements "${entitlements}" --timestamp "${bundlePath}/Contents/MacOS/cc_gui_daemon"`);
+      exec(`codesign --force --options runtime --sign "${identity}" --entitlements "${entitlements}" --timestamp "${bundlePath}/Contents/MacOS/cc-gui"`);
       exec(`codesign --force --options runtime --sign "${identity}" --entitlements "${entitlements}" --timestamp "${bundlePath}"`);
     } else {
       // Use existing script for single-arch builds

--- a/scripts/macos-fix-openssl.sh
+++ b/scripts/macos-fix-openssl.sh
@@ -44,13 +44,23 @@ fi
 libssl="${openssl_prefix}/lib/libssl.3.dylib"
 libcrypto="${openssl_prefix}/lib/libcrypto.3.dylib"
 frameworks_dir="${app_path}/Contents/Frameworks"
-bin_path="${app_path}/Contents/MacOS/cc-gui"
-daemon_path="${app_path}/Contents/MacOS/cc_gui_daemon"
+macos_dir="${app_path}/Contents/MacOS"
+bin_path="${macos_dir}/cc-gui"
+daemon_path="${macos_dir}/cc_gui_daemon"
 
 if [[ ! -f "${libssl}" || ! -f "${libcrypto}" ]]; then
   echo "OpenSSL dylibs not found at ${openssl_prefix}/lib"
   exit 1
 fi
+
+# Release must not ship the dev-only binary (distinct Dock label for local runs).
+# Leftover copies break nested codesign on some Intel runners.
+for stray in "${macos_dir}/cc-gui-debug" "${macos_dir}/cc-gui-debug-debug"; do
+  if [[ -e "${stray}" ]]; then
+    echo "Removing non-release binary from app bundle: ${stray}"
+    rm -f "${stray}"
+  fi
+done
 
 mkdir -p "${frameworks_dir}"
 cp -f "${libssl}" "${frameworks_dir}/"
@@ -66,17 +76,23 @@ if [[ -n "${crypto_ref}" && "${crypto_ref}" != "@rpath/libcrypto.3.dylib" ]]; th
   install_name_tool -change "${crypto_ref}" "@rpath/libcrypto.3.dylib" "${frameworks_dir}/libssl.3.dylib"
 fi
 
-# Fix binary references dynamically
-for bin in "${bin_path}" "${daemon_path}"; do
-  [[ -f "${bin}" ]] || continue
+# Fix binary references dynamically (helpers first, then main).
+bins_to_fix=()
+if [[ -f "${daemon_path}" ]]; then
+  bins_to_fix+=("${daemon_path}")
+fi
+if [[ -f "${bin_path}" ]]; then
+  bins_to_fix+=("${bin_path}")
+fi
 
-  ssl_ref=$(otool -L "${bin}" | grep 'libssl' | awk '{print $1}')
+for bin in "${bins_to_fix[@]}"; do
+  ssl_ref=$(otool -L "${bin}" | grep 'libssl' | awk '{print $1}' || true)
   if [[ -n "${ssl_ref}" && "${ssl_ref}" != "@rpath/libssl.3.dylib" ]]; then
     echo "Fixing $(basename "${bin}") -> libssl reference: ${ssl_ref}"
     install_name_tool -change "${ssl_ref}" "@rpath/libssl.3.dylib" "${bin}"
   fi
 
-  crypto_ref=$(otool -L "${bin}" | grep 'libcrypto' | awk '{print $1}')
+  crypto_ref=$(otool -L "${bin}" | grep 'libcrypto' | awk '{print $1}' || true)
   if [[ -n "${crypto_ref}" && "${crypto_ref}" != "@rpath/libcrypto.3.dylib" ]]; then
     echo "Fixing $(basename "${bin}") -> libcrypto reference: ${crypto_ref}"
     install_name_tool -change "${crypto_ref}" "@rpath/libcrypto.3.dylib" "${bin}"
@@ -97,8 +113,7 @@ for lib in "${frameworks_dir}/libssl.3.dylib" "${frameworks_dir}/libcrypto.3.dyl
     verify_failed=1
   fi
 done
-for bin in "${bin_path}" "${daemon_path}"; do
-  [[ -f "${bin}" ]] || continue
+for bin in "${bins_to_fix[@]}"; do
   if otool -L "${bin}" | grep -E 'libssl|libcrypto' | grep -v '@rpath' | grep -q '/opt/\|/usr/local/'; then
     echo "ERROR: ${bin} still has absolute references:"
     otool -L "${bin}" | grep -E 'libssl|libcrypto' | grep '/opt/\|/usr/local/'
@@ -111,12 +126,40 @@ if [[ ${verify_failed} -eq 1 ]]; then
 fi
 echo "All library references verified OK."
 
-codesign --force --options runtime --timestamp --sign "${identity}" "${frameworks_dir}/libcrypto.3.dylib"
-codesign --force --options runtime --timestamp --sign "${identity}" "${frameworks_dir}/libssl.3.dylib"
-codesign --force --options runtime --timestamp --sign "${identity}" "${codesign_entitlements[@]}" "${bin_path}"
-if [[ -f "${daemon_path}" ]]; then
-  codesign --force --options runtime --timestamp --sign "${identity}" "${codesign_entitlements[@]}" "${daemon_path}"
-fi
-codesign --force --options runtime --timestamp --sign "${identity}" "${codesign_entitlements[@]}" "${app_path}"
+sign_file() {
+  local target="$1"
+  shift || true
+  echo "codesign: ${target}"
+  codesign --force --options runtime --timestamp --sign "${identity}" "$@" "${target}"
+}
 
+# Inside-out: dylibs → helper executables → main executable → .app
+sign_file "${frameworks_dir}/libcrypto.3.dylib"
+sign_file "${frameworks_dir}/libssl.3.dylib"
+
+# Helpers first (daemon / any non-main executables), then main, then .app.
+# Signing the main binary or .app while nested helpers are unsigned fails on
+# some Intel codesign toolchains ("code object is not signed at all / In subcomponent").
+if [[ -d "${macos_dir}" ]]; then
+  for helper in "${macos_dir}"/*; do
+    [[ -f "${helper}" ]] || continue
+    base="$(basename "${helper}")"
+    if [[ "${base}" == "cc-gui" ]]; then
+      continue
+    fi
+    if [[ -x "${helper}" ]] || file "${helper}" | grep -q 'Mach-O'; then
+      sign_file "${helper}" "${codesign_entitlements[@]}"
+    fi
+  done
+fi
+
+if [[ ! -f "${bin_path}" ]]; then
+  echo "ERROR: main binary not found at ${bin_path}"
+  exit 1
+fi
+sign_file "${bin_path}" "${codesign_entitlements[@]}"
+sign_file "${app_path}" "${codesign_entitlements[@]}"
+
+echo "Verifying signatures..."
+codesign --verify --deep --strict --verbose=2 "${app_path}"
 echo "Bundled OpenSSL dylibs and re-signed ${app_path}"

--- a/scripts/tauri-dev-isolated.mjs
+++ b/scripts/tauri-dev-isolated.mjs
@@ -21,7 +21,15 @@ const isolatedConfig = JSON.stringify({
 
 const child = spawn(
   tauriBin,
-  ["dev", "--config", "src-tauri/tauri.dev.conf.json", "--config", isolatedConfig],
+  [
+    "dev",
+    "--config",
+    "src-tauri/tauri.dev.conf.json",
+    "--config",
+    isolatedConfig,
+    "--features",
+    "debug-bin",
+  ],
   {
     env: {
       ...process.env,

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,13 +4,17 @@ version = "0.3.0"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"
-# Local `tauri dev` / `cargo run` uses this binary name as the macOS Dock tooltip.
+# Local `cargo run --features debug-bin` / `tauri dev --features debug-bin` Dock tooltip.
+# Release builds must NOT enable `debug-bin` (keeps cc-gui-debug out of the app bundle).
 default-run = "cc-gui-debug"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
 custom-protocol = ["tauri/custom-protocol"]
+# Dev-only second binary for distinct Dock label. Never enable on release packaging:
+# shipping it into Contents/MacOS regressed Intel codesign (nested unsigned helpers).
+debug-bin = []
 
 [lib]
 # The `_lib` suffix may seem redundant but it is necessary
@@ -19,7 +23,8 @@ custom-protocol = ["tauri/custom-protocol"]
 name = "cc_gui_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
-# Release packaging keeps `cc-gui`; debug runs as `cc-gui-debug` (distinct Dock label).
+# Release packaging keeps `cc-gui` (+ auto-discovered `cc_gui_daemon`).
+# `cc-gui-debug` is feature-gated so release bundles never include it.
 [[bin]]
 name = "cc-gui"
 path = "src/main.rs"
@@ -27,6 +32,7 @@ path = "src/main.rs"
 [[bin]]
 name = "cc-gui-debug"
 path = "src/main.rs"
+required-features = ["debug-bin"]
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }


### PR DESCRIPTION
…bug-bin

Tauri mid-bundle Apple codesign was flaky on Intel runners when the app contained nested helpers (notably `cc_gui_daemon`). Failures showed up as unsigned subcomponents during bundle signing.

What changed:
- Skip `APPLE_SIGNING_IDENTITY` during the Tauri app-bundle build in CI and local macOS packaging (`env -u` / unset), then re-sign after OpenSSL bundling.
- Re-sign strictly inside-out: Frameworks dylibs → helper executables (daemon and other MacOS helpers) → main `cc-gui` → `.app`, then deep-verify.
- Introduce a Cargo feature `debug-bin` for the `cc-gui-debug` binary so release packaging never ships the dev-only Dock-label binary, which could remain unsigned and break nested codesign.
- Wire `--features debug-bin` only into local dev entrypoints (`tauri:dev`, `tauri:dev:hot`, isolated dev script).
- Strip any leftover `cc-gui-debug*` from the bundle before re-signing; harden OpenSSL rpath fix-ups for missing bins.

Why:
- Nested multi-bin signing order is unreliable when Tauri signs during bundle creation on some Intel toolchains.
- A release-shipped debug helper is both unwanted product surface and a codesign footgun.

Impact:
- Release and platform macOS builds should produce a fully signed deep- verified `.app` without Intel nested-signing flakes.
- Local `tauri dev` still gets a distinct Dock label via `cc-gui-debug`.
- Release artifacts no longer include the debug binary under Contents/MacOS.

## 摘要

<!-- 用 1–3 句说明改了什么、为什么 -->

## 变更类型

- [ ] feature
- [ ] fix
- [ ] refactor / 结构治理
- [ ] docs
- [ ] chore / CI

## AppShell / Domain 状态（若涉及 `src/app-shell/**` 或 shell domain bag）

- [ ] 新状态已写入 **owner domain**（`APP_SHELL_DOMAIN_CONTEXT_OWNED_KEYS` + builder/assembly）
- [ ] 未向 `workspaceNavigation` / 无主 bag 尾塞 key
- [ ] 生产路径使用 `selectAppShellDomainBag`（未新增 full-flatten / Legacy adapt）
- [ ] 已跑：`npm run check:app-shell:governance`

> 规则入口：`AGENTS.md` → AppShell Structure Gate；计划：`docs/plans/2026-08-11-app-shell-cohesion-optimization.md`

## 测试

- [ ] 相关 unit / vitest
- [ ] `npm run check:runtime-contracts`（含 app-shell governance）
- [ ] 其它受影响 gate：

## 风险与回滚

- 风险：
- 回滚：按 commit / PR revert
