### PR TITLE
docs(readme): re-add Star History chart (was broken)

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,10 @@ Thanks to all the contributors who help make ccgui better.
 
 ---
 
+## Star History
+
+[![Star History Chart](https://star-history.dera.page/svg?repos=zhukunpenglinyutong/desktop-cc-gui&type=date&legend=top-left)](https://star-history.dera.page/#zhukunpenglinyutong/desktop-cc-gui&type=date&legend=top-left)
+
 <!-- LINK GROUP -->
 
 [github-contributors-shield]: https://img.shields.io/github/contributors/zhukunpenglinyutong/desktop-cc-gui?color=c4f042&labelColor=black&style=flat-square

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -314,6 +314,10 @@ docs(readme): 校准项目文档索引
 
 ---
 
+## Star History
+
+[![Star History Chart](https://star-history.dera.page/svg?repos=zhukunpenglinyutong/desktop-cc-gui&type=date&legend=top-left)](https://star-history.dera.page/#zhukunpenglinyutong/desktop-cc-gui&type=date&legend=top-left)
+
 <!-- LINK GROUP -->
 
 [github-contributors-shield]: https://img.shields.io/github/contributors/zhukunpenglinyutong/desktop-cc-gui?color=c4f042&labelColor=black&style=flat-square


### PR DESCRIPTION
The Star History chart was dropped from the READMEs in 350d7841. The original api.star-history.com endpoint has since broken due to GitHub stargazer API rate limits, so this PR re-adds the chart pointing to a working, token-free mirror on star-history.dera.page.

Restored in both README.md and README.zh-CN.md at their original location, using the /svg endpoint for the image and a hash-based link for the full interactive chart.